### PR TITLE
build: include proprietary CSS in Storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "scripts": {
     "bootstrap": "lerna bootstrap",
-    "build:storybook": "build-storybook --output-dir dist/storybook -s src/brand.css",
+    "build:storybook": "build-storybook --output-dir dist/storybook -s src/static/,src/proprietary/static/",
     "build": "npm-run-all 'build:*'",
     "deploy": "npm-run-all 'deploy:*'",
     "deploy:storybook": "storybook-to-ghpages",


### PR DESCRIPTION
This configuration change fixes the color demo's in the Storybooks color page:

<img width="1038" alt="Screenshot 2021-03-17 at 17 19 11" src="https://user-images.githubusercontent.com/30694/111501042-e980f280-8744-11eb-8ad3-f651aa03c906.png">

Typical case of "worked in dev"... `npm run storybook` was okay, `npm run build && npm run start` was not.