### PR TITLE
feat: paragraph component

### DIFF
--- a/src/paragraph/README.md
+++ b/src/paragraph/README.md
@@ -1,0 +1,6 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Gemeente Utrecht
+-->
+
+# Paragraph

--- a/src/paragraph/html.scss
+++ b/src/paragraph/html.scss
@@ -9,8 +9,8 @@
   @extend .utrecht-paragraph;
 }
 
-.utrecht-html p.intro {
-  @extend .utrecht-paragraph--intro;
+.utrecht-html p.lead {
+  @extend .utrecht-paragraph--lead;
 }
 
 .utrecht-html * ~ p {

--- a/src/paragraph/html.scss
+++ b/src/paragraph/html.scss
@@ -1,0 +1,18 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+@import "index";
+
+.utrecht-html p {
+  @extend .utrecht-paragraph;
+}
+
+.utrecht-html p.intro {
+  @extend .utrecht-paragraph--intro;
+}
+
+.utrecht-html * ~ p {
+  margin-block-start: var(--utrecht-paragraph-margin-block);
+}

--- a/src/paragraph/html.stories.mdx
+++ b/src/paragraph/html.stories.mdx
@@ -22,7 +22,7 @@ export const Template = ({ content }) =>
 
 export const TemplateMulti = ({ content }) =>
   `<section class="utrecht-html">
-  <p class="intro">${content}</p>
+  <p class="lead">${content}</p>
   <p>${content}</p>
   <p>${content}</p>
 </section>`;
@@ -36,8 +36,8 @@ export const TemplateMulti = ({ content }) =>
       defaultValue:
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
     },
-    intro: {
-      description: "Intro paragraph",
+    lead: {
+      description: "Lead paragraph",
       control: "boolean",
       defaultValue: false,
     },
@@ -61,12 +61,12 @@ Styling via the `<p>` element:
   <Story name="Paragraph">{Template.bind({})}</Story>
 </Canvas>
 
-## Intro paragraph
+## Lead paragraph
 
-Styling via the `<p>` element with the `intro` class name:
+Styling via the `<p>` element with the `lead` class name:
 
 <Canvas>
-  <Story name="Intro paragraph" args={{ intro: true }}>
+  <Story name="Lead paragraph" args={{ lead: true }}>
     {Template.bind({})}
   </Story>
 </Canvas>

--- a/src/paragraph/html.stories.mdx
+++ b/src/paragraph/html.stories.mdx
@@ -1,0 +1,86 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Robbert Broersma
+-->
+
+import { Meta, Story, Canvas, ArgsTable, Description, Source } from "@storybook/addon-docs/blocks";
+import { sanitize } from "dompurify"; // Helps with preventing injections via argstable
+import { MDXEmbedProvider } from "mdx-embed";
+
+<!-- Import component and component styles -->
+
+import "./html.scss";
+
+<!-- Import Docs -->
+
+import README from "./README.md";
+
+export const Template = ({ content }) =>
+  `<section class="utrecht-html">
+  <p>${content}</p>
+</section>`;
+
+export const TemplateMulti = ({ content }) =>
+  `<section class="utrecht-html">
+  <p class="intro">${content}</p>
+  <p>${content}</p>
+  <p>${content}</p>
+</section>`;
+
+<Meta
+  title="Semantic HTML/Paragraph"
+  argTypes={{
+    content: {
+      description: "Paragraph text",
+      control: "text",
+      defaultValue:
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+    },
+    intro: {
+      description: "Intro paragraph",
+      control: "boolean",
+      defaultValue: false,
+    },
+  }}
+  parameters={{
+    docs: {
+      transformSource: (_src, { args }) => Template(args),
+    },
+    status: "IN DEVELOPMENT",
+    notes: {
+      UX: README,
+    },
+  }}
+/>
+
+# Paragraph
+
+Styling via the `<p>` element:
+
+<Canvas>
+  <Story name="Paragraph">{Template.bind({})}</Story>
+</Canvas>
+
+## Intro paragraph
+
+Styling via the `<p>` element with the `intro` class name:
+
+<Canvas>
+  <Story name="Intro paragraph" args={{ intro: true }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Multiple paragraphs with whitespace
+
+<Canvas>
+  <Story name="Multiple paragraphs">{TemplateMulti.bind({})}</Story>
+</Canvas>
+
+<ArgsTable story="Paragraph" />
+
+## Design Kit
+
+<MDXEmbedProvider>
+  <Figma title="Paragraph" url="file/x" />
+</MDXEmbedProvider>

--- a/src/paragraph/index.css
+++ b/src/paragraph/index.css
@@ -10,8 +10,8 @@
   line-height: var(--utrecht-paragraph-line-height, inherit);
 }
 
-.utrecht-paragraph--intro {
-  font-size: var(--utrecht-paragraph-intro-font-size, inherit);
-  font-weight: var(--utrecht-paragraph-intro-font-weight, inherit);
-  line-height: var(--utrecht-paragraph-intro-line-height, inherit);
+.utrecht-paragraph--lead {
+  font-size: var(--utrecht-paragraph-lead-font-size, inherit);
+  font-weight: var(--utrecht-paragraph-lead-font-weight, inherit);
+  line-height: var(--utrecht-paragraph-lead-line-height, inherit);
 }

--- a/src/paragraph/index.css
+++ b/src/paragraph/index.css
@@ -1,0 +1,17 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 The Knights Who Say NIH! B.V.
+ */
+
+.utrecht-paragraph {
+  font-family: var(--utrecht-document-font-family, inherit);
+  font-size: var(--utrecht-paragraph-font-size, inherit);
+  font-weight: var(--utrecht-paragraph-font-weight, inherit);
+  line-height: var(--utrecht-paragraph-line-height, inherit);
+}
+
+.utrecht-paragraph--intro {
+  font-size: var(--utrecht-paragraph-intro-font-size, inherit);
+  font-weight: var(--utrecht-paragraph-intro-font-weight, inherit);
+  line-height: var(--utrecht-paragraph-intro-line-height, inherit);
+}

--- a/src/paragraph/stories.mdx
+++ b/src/paragraph/stories.mdx
@@ -15,11 +15,11 @@ import "./index.css";
 
 import README from "./README.md";
 
-export const Template = ({ content, intro }) =>
-  `<p class="utrecht-paragraph${intro ? " utrecht-paragraph--intro" : ""}">${content}</p>`;
+export const Template = ({ content, lead }) =>
+  `<p class="utrecht-paragraph${lead ? " utrecht-paragraph--lead" : ""}">${content}</p>`;
 
 export const TemplateMulti = ({ content }) =>
-  `<p class="utrecht-paragraph utrecht-paragraph--intro">${content}</p>
+  `<p class="utrecht-paragraph utrecht-paragraph--lead">${content}</p>
 <p class="utrecht-paragraph">${content}</p>
 <p class="utrecht-paragraph">${content}</p>`;
 
@@ -32,8 +32,8 @@ export const TemplateMulti = ({ content }) =>
       defaultValue:
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
     },
-    intro: {
-      description: "Intro paragraph",
+    lead: {
+      description: "Lead paragraph",
       control: "boolean",
       defaultValue: false,
     },
@@ -57,12 +57,12 @@ Styling via the `.utrecht-paragraph` class name:
   <Story name="Paragraph">{Template.bind({})}</Story>
 </Canvas>
 
-## Intro paragraph
+## Lead paragraph
 
-Styling via the `.utrecht-paragraph--intro` class name:
+Styling via the `.utrecht-paragraph--lead` class name:
 
 <Canvas>
-  <Story name="Intro paragraph" args={{ intro: true }}>
+  <Story name="Lead paragraph" args={{ lead: true }}>
     {Template.bind({})}
   </Story>
 </Canvas>

--- a/src/paragraph/stories.mdx
+++ b/src/paragraph/stories.mdx
@@ -1,0 +1,82 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Robbert Broersma
+-->
+
+import { Meta, Story, Canvas, ArgsTable, Description, Source } from "@storybook/addon-docs/blocks";
+import { sanitize } from "dompurify"; // Helps with preventing injections via argstable
+import { MDXEmbedProvider } from "mdx-embed";
+
+<!-- Import component and component styles -->
+
+import "./index.css";
+
+<!-- Import Docs -->
+
+import README from "./README.md";
+
+export const Template = ({ content, intro }) =>
+  `<p class="utrecht-paragraph${intro ? " utrecht-paragraph--intro" : ""}">${content}</p>`;
+
+export const TemplateMulti = ({ content }) =>
+  `<p class="utrecht-paragraph utrecht-paragraph--intro">${content}</p>
+<p class="utrecht-paragraph">${content}</p>
+<p class="utrecht-paragraph">${content}</p>`;
+
+<Meta
+  title="Components/Paragraph"
+  argTypes={{
+    content: {
+      description: "Paragraph text",
+      control: "text",
+      defaultValue:
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+    },
+    intro: {
+      description: "Intro paragraph",
+      control: "boolean",
+      defaultValue: false,
+    },
+  }}
+  parameters={{
+    docs: {
+      transformSource: (_src, { args }) => Template(args),
+    },
+    status: "IN DEVELOPMENT",
+    notes: {
+      UX: README,
+    },
+  }}
+/>
+
+# Paragraph
+
+Styling via the `.utrecht-paragraph` class name:
+
+<Canvas>
+  <Story name="Paragraph">{Template.bind({})}</Story>
+</Canvas>
+
+## Intro paragraph
+
+Styling via the `.utrecht-paragraph--intro` class name:
+
+<Canvas>
+  <Story name="Intro paragraph" args={{ intro: true }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Multiple paragraphs with whitespace
+
+<Canvas>
+  <Story name="Multiple paragraphs">{TemplateMulti.bind({})}</Story>
+</Canvas>
+
+<ArgsTable story="Paragraph" />
+
+## Design Kit
+
+<MDXEmbedProvider>
+  <Figma title="Paragraph" url="file/x" />
+</MDXEmbedProvider>


### PR DESCRIPTION
Voorzet voor de Paragraaf component #25

## Terminologie

- **paragraph** omdat het de onafgekorte versie van het `<p>` element in HTML
- **lead** paragraph omdat het een [eigen lemma heeft op Wikipedia](https://en.wikipedia.org/wiki/Lead_paragraph). Eerst had ik "Intro paragraph" gekozen, omdat ik in code vaak `<p class="intro">` ben tegengekomen, maar het blijkt niet de gebruikelijke term te zijn.

## Class names

- `utrecht-paragraph`
- `utrecht-paragraph--lead`

## Design tokens

We gebruiken de volgende CSS variabelen:

Document (abstract component)
- `utrecht-document-font-family`

Paragraph:
- `utrecht-paragraph-font-size`
- `utrecht-paragraph-font-family`
- `utrecht-paragraph-font-size`
- `utrecht-paragraph-font-weight`
- `utrecht-paragraph-line-height`
- `utrecht-paragraph-margin-block`

Lead paragraph:
- `utrecht-paragraph-lead-font-size`
- `utrecht-paragraph-lead-font-weight`
- `utrecht-paragraph-lead-line-height`

## States

Niet van toepassing.