### PR TITLE
feat: unordered list

### DIFF
--- a/proprietary/design-tokens/common/document.css
+++ b/proprietary/design-tokens/common/document.css
@@ -6,4 +6,5 @@
 
 :root {
   --utrecht-document-font-family: var(--utrecht-font-family-sans-serif);
+  --utrecht-document-line-height: 1.4;
 }

--- a/proprietary/design-tokens/component/index.css
+++ b/proprietary/design-tokens/component/index.css
@@ -11,3 +11,4 @@
 @import url("./menulijst.css");
 @import url("./paragraph.css");
 @import url("./separator.css");
+@import url("./unordered-list.css");

--- a/proprietary/design-tokens/component/unordered-list.css
+++ b/proprietary/design-tokens/component/unordered-list.css
@@ -1,0 +1,19 @@
+/**
+ * @license SEE LICENSE.md
+ * Copyright (c) 2021 Gemeente Utrecht
+ * All rights reserved
+ */
+
+/**
+ * @tokens Components / Unordered List
+ */
+:root {
+  /** @presenter Sizing */
+  --utrecht-unordered-list-margin-block-start: 0;
+  --utrecht-unordered-list-margin-block-end: 1rem;
+  --utrecht-unordered-list-item-margin-block-start: 0.5rem;
+  --utrecht-unordered-list-item-margin-block-end: 0.5rem;
+
+  /** @presenter Color */
+  --utrecht-unordered-list-marker-color: var(--utrecht-red-40);
+}

--- a/src/unordered-list/README.md
+++ b/src/unordered-list/README.md
@@ -1,0 +1,8 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Gemeente Utrecht
+-->
+
+# Lijsten
+
+Lijsten worden gebruikt voor opsommingen op een contentpagina. Hier gaan opsommingen vooraf met een bullet of een cijfer. De marge tussen twee list items (li) is 0.5em (8px).

--- a/src/unordered-list/html.scss
+++ b/src/unordered-list/html.scss
@@ -1,0 +1,19 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+@import "./index";
+
+.utrecht-html ul {
+  @extend .utrecht-unordered-list;
+  @extend .utrecht-unordered-list--distanced;
+}
+
+.utrecht-html ul > li {
+  @extend .utrecht-unordered-list__item;
+}
+
+.utrecht-html ul > li::marker {
+  @extend .utrecht-unordered-list__marker;
+}

--- a/src/unordered-list/html.stories.mdx
+++ b/src/unordered-list/html.stories.mdx
@@ -1,0 +1,70 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Robbert Broersma
+-->
+
+import { Meta, Story, Canvas, ArgsTable, Description, Source } from "@storybook/addon-docs/blocks";
+import { sanitize } from "dompurify"; // Helps with preventing injections via argstable
+import { MDXEmbedProvider } from "mdx-embed";
+import dedent from "ts-dedent";
+
+<!-- Import component and component styles -->
+
+import "./html.scss";
+
+<!-- Import Docs -->
+
+import README from "./README.md";
+
+export const Template = () =>
+  `<section class="utrecht-html">
+  <ul>
+    <li>Lorem</li>
+    <li>Ipsum</li>
+    <li>Dolor</li>
+  </ul>
+</section>`;
+
+export const TemplateNestedUL = () =>
+  `<section class="utrecht-html">
+  <ul>
+    <li>Lorem</li>
+    <li>Ipsum
+      <ul>
+        <li>Lorem</li>
+        <li>Ipsum</li>
+      </ul>
+    </li>
+    <li>Dolor</li>
+  </ul>
+</section>`;
+
+<Meta
+  title="Semantic HTML/Unordered List"
+  argTypes={{}}
+  parameters={{
+    docs: {
+      transformSource: (_src, { args }) => Template(args),
+    },
+    status: "IN DEVELOPMENT",
+    notes: {
+      UX: README,
+    },
+  }}
+/>
+
+<Canvas>
+  <Story name="Bulleted list">{Template.bind({})}</Story>
+</Canvas>
+
+## Nested
+
+<Canvas>
+  <Story name="Nested bulleted list">{TemplateNestedUL.bind({})}</Story>
+</Canvas>
+
+## Design Kit
+
+<MDXEmbedProvider>
+  <Figma title="List" url="file/x" />
+</MDXEmbedProvider>

--- a/src/unordered-list/index.css
+++ b/src/unordered-list/index.css
@@ -1,0 +1,34 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2021 Gemeente Utrecht
+ */
+
+.utrecht-unordered-list {
+  font-family: var(--utrecht-document-font-family, inherit);
+  font-size: var(--utrecht-document-font-size, inherit);
+  line-height: var(--utrecht-document-line-height, inherit);
+  padding-inline-start: 2ch;
+}
+
+.utrecht-unordered-list--distanced {
+  margin-block-start: var(--utrecht-unordered-list-margin-block-start, var(--utrecht-paragraph-margin-block-start));
+  margin-block-end: var(--utrecht-unordered-list-margin-block-end, var(--utrecht-paragraph-margin-block-end));
+}
+
+.utrecht-unordered-list--nested {
+  margin-inline-start: 2ch;
+  margin-block-end: 0;
+}
+
+.utrecht-unordered-list__item {
+  padding-inline-start: 1ch;
+  margin-block-start: var(--utrecht-unordered-list-item-margin-block-start);
+  margin-block-end: var(--utrecht-unordered-list-item-margin-block-end);
+}
+
+.utrecht-unordered-list__item::marker,
+.utrecht-unordered-list__marker {
+  color: var(--utrecht-unordered-list-marker-color);
+  content: "●";
+}

--- a/src/unordered-list/stories.mdx
+++ b/src/unordered-list/stories.mdx
@@ -1,0 +1,66 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Robbert Broersma
+-->
+
+import { Meta, Story, Canvas, ArgsTable, Description, Source } from "@storybook/addon-docs/blocks";
+import { sanitize } from "dompurify"; // Helps with preventing injections via argstable
+import { MDXEmbedProvider } from "mdx-embed";
+import dedent from "ts-dedent";
+
+<!-- Import component and component styles -->
+
+import "./index.css";
+
+<!-- Import Docs -->
+
+import README from "./README.md";
+
+export const Template = () =>
+  `<ul class="utrecht-unordered-list">
+  <li class="utrecht-unordered-list__item">Lorem</li>
+  <li class="utrecht-unordered-list__item">Ipsum</li>
+  <li class="utrecht-unordered-list__item">Dolor</li>
+</ul>`;
+
+export const TemplateNested = () =>
+  `<ul class="utrecht-unordered-list">
+  <li class="utrecht-unordered-list__item">Lorem</li>
+  <li class="utrecht-unordered-list__item">Ipsum
+    <ul class="utrecht-unordered-list utrecht-unordered-list--nested">
+      <li class="utrecht-unordered-list__item">Lorem</li>
+      <li class="utrecht-unordered-list__item">Ipsum</li>
+    </ul>
+  </li>
+  <li class="utrecht-unordered-list__item">Dolor</li>
+</ul>`;
+
+<Meta
+  title="Components/Unordered List"
+  argTypes={{}}
+  parameters={{
+    docs: {
+      transformSource: (_src, { args }) => Template(args),
+    },
+    status: "IN DEVELOPMENT",
+    notes: {
+      UX: README,
+    },
+  }}
+/>
+
+<Canvas>
+  <Story name="Bulleted list">{Template.bind({})}</Story>
+</Canvas>
+
+## Nested list
+
+<Canvas>
+  <Story name="Nested Ordered list">{TemplateNested.bind({})}</Story>
+</Canvas>
+
+## Design Kit
+
+<MDXEmbedProvider>
+  <Figma title="List" url="file/x" />
+</MDXEmbedProvider>


### PR DESCRIPTION
Voorzet voor de Unordered list component #24

## Terminologie

- **unordered list**: uitgeschreven versie van de HTML afkorting `<ul>`
- **list item**: uitgeschreven van van [HTML `<li>`](https://html.spec.whatwg.org/multipage/grouping-content.html#the-li-element). Ook [in ARIA is het `role="listitem"`](https://www.w3.org/TR/wai-aria-1.2/#listitem)
- **marker**: zoals in de [CSS pseudo-selector `::marker`](https://drafts.csswg.org/css-pseudo-4/#marker-pseudo)

## Class names

- `utrecht-unordered-list`
- `utrecht-unordered-list--distanced`: standaard heeft een component geen marge, gebruik deze class name om in een bepaalde context de standaard-marge toe te passen
- `utrecht-unordered-list--nested`
- `utrecht-unordered-list__item`: misschien moet nog aangepast worden naar `utrecht-unordered-list__listitem` of - `utrecht-unordered-list__list-item`
- `utrecht-unordered-list__marker`
## Design tokens

* Document
  * `--utrecht-document-font-family`
  * `--utrecht-document-font-size`
  * `--utrecht-document-line-height`
* Paragraph
  * `--utrecht-paragraph-margin-block-start`
  * `--utrecht-paragraph-margin-block-end`
* List
  * `--utrecht-unordered-list-margin-block-start`
  * `--utrecht-unordered-list-margin-block-end`
  * List item
    * `--utrecht-unordered-list-item-margin-block-start`
    * `--utrecht-unordered-list-item-margin-block-end`
  * Marker
    * `--utrecht-unordered-list-marker-color`