### PR TITLE
feat: link component

### DIFF
--- a/src/link/README.md
+++ b/src/link/README.md
@@ -1,59 +1,27 @@
-<!-- \*Status: **In development\*** -->
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Gemeente Utrecht
+-->
 
 # Link
 
-## UX guidelines
+## Tekstlinks
 
-### Introduction
+Tekstlinks zijn standaard donkerblauw (#2A5587) en onderstreept. In sommige gevallen zijn tekstlinks zwart of wit. Dit geldt bij teksten op een gekleurde achtergrond, waar blauw niet voldoende contrast biedt. Kijk voor meer informatie over de contrastrichtlijnen bij kleuren (link naar kleuren).
 
-Some information on the Demo component. Where can it be used, what types of information can it contain?
+### Voorbeeld
 
-### Variations
+U kunt tegelijk een paspoort en een ID-kaart hebben. Met een paspoort kunt u naar alle landen reizen. Een ID-kaart is goedkoper, maar u kunt hiermee niet naar alle landen reizen.
 
-List of Variations
+## Links met pijl
 
-- Variation 1
-- Variation 2
+Links met een pijl als voorloopteken worden gebruikt aan het einde van een tekst. Ze verwijzen naar gerelateerde informatie over het onderwerp wat er in de voorafgaande tekst is besproken. De links zijn donkerblauw (#2A5587), bold en hebben een pijl (>) als voorloopteken. Dit type link wordt ook gebruikt in de linklijst en de subnavigatie.
 
-### Alternatives and related components
+### Variant
 
-- Example component can be used instead of the demo component
+Een variant van de link met pijl is zwart (#000) in plaats van donkerblauw. Deze link wordt gebruikt in de linklijsten ‘related’ die verwijzen naar gerelateerde content onderaan een contentpagina.
 
-### Anatomy
+## Ankerlinks
 
-Describe the atanomy of a component, for example:
-
-- A container
-- With a content block
-- And a header
-
-### Design tokens
-
-#### Global/default
-
-Describe which global brand tokens should be used by this component. Semantic colors, Borders, Border-radius, typography, etc
-
--
-
--
-
-#### Interactive states
-
-Describe which interactive states this component can have and which design tokens should then be used
-
-### Best practices
-
-#### Do
-
--
--
-
-#### Don't
-
--
--
-
-### References
-
--
--
+Ankerlinks worden gebruikt om te navigeren naar specifieke content op de pagina. Ankerlinks staan boven de content waar ze naar verwijzen, komen alleen voor op contentpagina’s en worden gebruikt als opsomming. Ankerlinks zijn worden veel gebruikt als een soort inhoudsopgave van de pagina.
+Ankerlinks zijn blauw, onderstreept en hebben een rood bolletje als voorloopteken.

--- a/src/link/docs/accessibility-guidelines.md
+++ b/src/link/docs/accessibility-guidelines.md
@@ -1,11 +1,17 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Gemeente Utrecht
+-->
+
 <!-- markdownlint-disable MD033 -->
+
 # Toegangkelijkheidseisen
 
 ## Focus
 
 ### WCAG 2.4.11
 
-Bij het Link component hebben we te maken met [WCAG eis 2.4.1](https://www.w3.org/TR/WCAG22/#focus-appearance-minimum). Deze eis beschrijft dat als een link de focus door het te selecteren met het toetsenbord het uiterlijk van de link moet veranderen.  De [bedoeling van dit punt](https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance-minimum.html#intent) is dat de keyboard focus indicator altijd duidelijk zichtbaar is.
+Bij het Link component hebben we te maken met [WCAG eis 2.4.1](https://www.w3.org/TR/WCAG22/#focus-appearance-minimum). Deze eis beschrijft dat als een link de focus door het te selecteren met het toetsenbord het uiterlijk van de link moet veranderen. De [bedoeling van dit punt](https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance-minimum.html#intent) is dat de keyboard focus indicator altijd duidelijk zichtbaar is.
 
 ### Design keuzes
 

--- a/src/link/html.scss
+++ b/src/link/html.scss
@@ -1,0 +1,26 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+@import "./style";
+
+.utrecht-html a:link {
+  @extend .utrecht-link;
+}
+
+.utrecht-html a:visited {
+  @extend .utrecht-link--visited;
+}
+
+.utrecht-html a:hover {
+  @extend .utrecht-link--hover;
+}
+
+.utrecht-html a:active {
+  @extend .utrecht-link--active;
+}
+
+.utrecht-html a:focus {
+  @extend .utrecht-link--focus;
+}

--- a/src/link/link-html.stories.mdx
+++ b/src/link/link-html.stories.mdx
@@ -1,0 +1,60 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Robbert Broersma
+-->
+
+import { Meta, Story, Canvas, ArgsTable, Description, Source } from "@storybook/addon-docs/blocks";
+import { sanitize } from "dompurify"; // Helps with preventing injections via argstable
+import { MDXEmbedProvider } from "mdx-embed";
+import dedent from "ts-dedent";
+
+<!-- Import component and component styles -->
+
+import "./html.scss";
+
+<!-- Import Docs -->
+
+import README from "./README.md";
+import accessibilityGuidelines from "./docs/accessibility-guidelines.md";
+
+export const Template = ({ content }) =>
+  `<section class="utrecht-html">
+  <a href="#">${content}</a>
+</section>`;
+
+<Meta
+  title="Semantic HTML/Link"
+  argTypes={{
+    content: {
+      description: "Content of the link",
+      control: "text",
+      defaultValue: "The Quick Brown Fox Jumps Over The Lazy Dog",
+    },
+  }}
+  parameters={{
+    docs: {
+      transformSource: (_src, { args }) => Template(args),
+    },
+    status: "IN DEVELOPMENT",
+    notes: {
+      UX: README,
+      Accessibility: accessibilityGuidelines,
+    },
+  }}
+/>
+
+# Link
+
+Styling via the `<a>` element:
+
+<Canvas>
+  <Story name="Link">{Template.bind({})}</Story>
+</Canvas>
+
+<ArgsTable story="Link" />
+
+## Design Kit
+
+<MDXEmbedProvider>
+  <Figma title="Link" url="file/x" />
+</MDXEmbedProvider>

--- a/src/link/link.stories.mdx
+++ b/src/link/link.stories.mdx
@@ -1,24 +1,53 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Gemeente Utrecht
+Copyright (c) 2021 Robbert Broersma
+-->
+
 import { Meta, Story, Canvas, ArgsTable, Description, Source } from "@storybook/addon-docs/blocks";
 import { sanitize } from "dompurify"; // Helps with preventing injections via argstable
 import { MDXEmbedProvider } from "mdx-embed";
 import dedent from "ts-dedent";
 
-<!-- Import component and component styles -->
-
 import "./style.css";
 
-<!-- Import Docs -->
-
 import README from "./README.md";
-import contentGuidelines from "./docs/content-guidelines.md";
 import accessibilityGuidelines from "./docs/accessibility-guidelines.md";
 
-export const Template = ({ href, content }) =>
-  `<a class="link" href="${href}"><span class="link__text">${sanitize(content)}</span></a>`;
+export const Template = ({ content, active, focus, hover, visited }) =>
+  `<a href="#" class="utrecht-link ${hover ? " utrecht-link--hover" : ""}${focus ? " utrecht-link--focus" : ""}${
+    active ? " utrecht-link--active" : ""
+  }${visited ? " utrecht-link--visited" : ""}">${content}</a>`;
 
 <Meta
   title="Components/Link"
-  argTypes={{}}
+  argTypes={{
+    content: {
+      description: "Link text",
+      control: "text",
+      defaultValue: "Read more...",
+    },
+    visited: {
+      description: "Visited",
+      control: "text",
+      defaultValue: false,
+    },
+    active: {
+      description: "Visited",
+      control: "text",
+      defaultValue: false,
+    },
+    focus: {
+      description: "Visited",
+      control: "text",
+      defaultValue: false,
+    },
+    hover: {
+      description: "Visited",
+      control: "text",
+      defaultValue: false,
+    },
+  }}
   parameters={{
     docs: {
       transformSource: (_src, { args }) => Template(args),
@@ -26,18 +55,47 @@ export const Template = ({ href, content }) =>
     status: "IN DEVELOPMENT",
     notes: {
       UX: README,
-      Content: contentGuidelines,
-      Accessibility: accessibilityGuidelines
+      Accessibility: accessibilityGuidelines,
     },
   }}
 />
 
-# Demo Implemented Link Component
+# Link
 
-To use the component as a web component, make sure the component is defined by including the components `element.js` file
+Styling via the `.utrecht-link` class name:
 
 <Canvas>
-  <Story name="Link" args={{ href: "#", content: "Link" }}>
+  <Story name="Link">{Template.bind({})}</Story>
+</Canvas>
+
+Styling via the `.utrecht-link--hover` class name:
+
+<Canvas>
+  <Story name="Link hover" args={{ hover: true }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+Styling via the `.utrecht-link--focus` class name:
+
+<Canvas>
+  <Story name="Link focus" args={{ focus: true }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+Styling via the `.utrecht-link--active` class name:
+
+<Canvas>
+  <Story name="Link active" args={{ active: true }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+Styling via the `.utrecht-link--visited` class name:
+
+<Canvas>
+  <Story name="Link visited" args={{ visited: true }}>
     {Template.bind({})}
   </Story>
 </Canvas>

--- a/src/link/style.css
+++ b/src/link/style.css
@@ -1,12 +1,32 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 The Knights Who Say NIH! B.V.
+ * Copyright (c) 2021 Gemeente Utrecht
+ */
+
 .utrecht-link {
-  color: var(--demo-link-color, blue);
-  text-decoration: none;
+  text-decoration: var(--utrecht-link-text-decoration, underline);
+  color: var(--utrecht-link-color, blue);
 }
 
-.utrecht-link__text {
-  margin-inline-start: 1ch;
+.utrecht-link:visited,
+.utrecht-link--visited {
+  color: var(--utrecht-link-visited-color, var(--utrecht-link-color));
 }
 
-.utrecht-link:hover .utrecht-link__text {
-  border-bottom: 1px solid currentColor;
+.utrecht-link:hover,
+.utrecht-link--hover {
+  color: var(--utrecht-link-hover-color, var(--utrecht-link-color));
+  text-decoration: var(--utrecht-link-hover-text-decoration, var(--utrecht-link-text-decoration, underline));
+}
+
+.utrecht-link:active,
+.utrecht-link--active {
+  color: var(--utrecht-link-active-color, var(--utrecht-link-color));
+}
+
+.utrecht-link:focus,
+.utrecht-link--focus {
+  color: var(--utrecht-link-focus-color, var(--utrecht-link-color));
+  text-decoration: var(--utrecht-link-focus-text-decoration, var(--utrecht-link-text-decoration, underline));
 }


### PR DESCRIPTION
Meer varianten en meer design tokens voor de Link component #26 nl-design-system/backlog#118 

## Terminologie

De termen de we gebruiken komen uit HTML en CSS.

- link (`:link` in CSS, "hyperlink" in de HTML specificatie)
- active (`:active` in CSS)
- focus (`:focus` in CSS)
- hover (`:hover` in CSS)
- visited (`:visited` in CSS)

Voor de component naam hebben we voor "`link`" gekozen, en niet voor "`a`" zoals de [`<a>`](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element) in HTML. Buiten de context van HTML-code (bijvoorbeeld in Figma) is `a`niet duidelijk genoeg, en we verwachten niet dat er grote verwarring ontstaat met het [`<link>`](https://html.spec.whatwg.org/multipage/semantics.html#the-link-element) element van HTML.

## States

We hebben de volgende states:

- normal
- hover
- focus
- active

## Class names

De volgende class names zijn gebruikt:

- `utrecht-link`
- `utrecht-link--focus` (voor testen en toepassen op andere CSS selectors)
- `utrecht-link--hover` (voor testen en toepassen op andere CSS selectors)
- `utrecht-link--active` (voor testen en toepassen op andere CSS selectors)
- `utrecht-link--visited` (voor testen en toepassen op andere CSS selectors)

## Variant

- alleen tekst
- TODO: icon voor de tekst

## Design tokens

We hebben de volgende CSS variabelen:

- `utrecht-link-color`
  - `utrecht-link-active-color`
  - `utrecht-link-focus-color`
  - `utrecht-link-hover-color`
  - `utrecht-link-visited-color`
- `utrecht-link-text-decoration`
  - `utrecht-link-focus-text-decoration`
  - `utrecht-link-hover-text-decoration`

## Visueel design Utrecht

- Link tekst is blauw
- Link tekst is niet onderstreept
- Link tekst is andere kleur blauw in hover state
- Link tekst is onderstreept in hover en focus state, een eventueel icon is niet onderstreept