### PR TITLE
feat: separator component

### DIFF
--- a/src/separator/README.md
+++ b/src/separator/README.md
@@ -1,0 +1,8 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Gemeente Utrecht
+-->
+
+# Separator
+
+Scheidingslijnen worden gebruikt om de scanbaarheid van een lange contentpagina te vergroten. Een scheidingslijn is lichtgrijs en heeft een dikte van `8px`.

--- a/src/separator/html.scss
+++ b/src/separator/html.scss
@@ -1,0 +1,10 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+@import "index";
+
+.utrecht-html hr {
+  @extend .utrecht-separator;
+}

--- a/src/separator/html.stories.mdx
+++ b/src/separator/html.stories.mdx
@@ -1,0 +1,42 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Robbert Broersma
+-->
+
+import { Meta, Story, Canvas, ArgsTable, Description, Source } from "@storybook/addon-docs/blocks";
+import { MDXEmbedProvider } from "mdx-embed";
+
+<!-- Import component and component styles -->
+
+import "./html.scss";
+
+<!-- Import Docs -->
+
+import README from "./README.md";
+
+export const Template = ({ level, content }) =>
+  `<section class="utrecht-html">
+  <hr>
+</section>`;
+
+<Meta
+  title="Semantic HTML/Separator"
+  argTypes={{}}
+  parameters={{
+    docs: {
+      transformSource: (_src, { args }) => Template(args),
+    },
+    status: "IN DEVELOPMENT",
+    notes: {
+      UX: README,
+    },
+  }}
+/>
+
+# Separator
+
+Styling via the `<hr>` element:
+
+<Canvas>
+  <Story name="Separator">{Template.bind({})}</Story>
+</Canvas>

--- a/src/separator/index.css
+++ b/src/separator/index.css
@@ -1,0 +1,14 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2021 The Knights Who Say NIH! B.V.
+ */
+
+.utrecht-separator {
+  border-style: solid;
+  border-color: var(--utrecht-separator-color);
+  border-width: 0 0 var(--utrecht-separator-width) 0;
+  margin-block-start: var(--utrecht-separator-margin-block);
+  margin-block-end: var(--utrecht-separator-margin-block);
+}

--- a/src/separator/stories.mdx
+++ b/src/separator/stories.mdx
@@ -1,0 +1,49 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Robbert Broersma
+-->
+
+import { Meta, Story, Canvas, ArgsTable, Description, Source } from "@storybook/addon-docs/blocks";
+import { MDXEmbedProvider } from "mdx-embed";
+
+<!-- Import component and component styles -->
+
+import "./index.css";
+
+<!-- Import Docs -->
+
+import README from "./README.md";
+
+export const Template = ({ level, content }) =>
+  `<div role="separator" aria-orientation="horizontal" class="utrecht-separator"></div>`;
+
+<Meta
+  title="Components/Separator"
+  parameters={{
+    docs: {
+      transformSource: (_src, { args }) => Template(args),
+    },
+    status: "IN DEVELOPMENT",
+    notes: {
+      UX: README,
+      //Content: contentGuidelines,
+      // Accessibility: accessibilityGuidelines
+    },
+  }}
+/>
+
+# Separator
+
+Styling via `utrecht-separator` class name:
+
+<Canvas>
+  <Story name="Separator">{Template.bind({})}</Story>
+</Canvas>
+
+<ArgsTable story="Separator" />
+
+## Design Kit
+
+<MDXEmbedProvider>
+  <Figma title="Separator" url="file/x" />
+</MDXEmbedProvider>


### PR DESCRIPTION
Voorzet voor de Separator component (backlog: #23, nl-design-system/backlog#119).

## Terminologie

- **separator**, van de ARIA `role="separator"`. "hr" van `<hr>` uit HTML is te onduidelijk buiten de context van code, "horizontal rule" te specifieke beschrijving van de originele rendering in HTML. De "separator" zou er ook heel anders uit kunnen zien dan een "rule" (lijn), en bovendien kan er voor andere tekstrichtingen wel eens een verticale variant komen.

"Divider" is ook een vaak gehoorde term hiervoor, misschien moet deze voor vindbaarheid ook genoemd worden in de documentatie.

## States

Niet van toepassing.

## Class names

- `utrecht-separator`

## Variant

- horizontaal

## Design tokens

We hebben de volgende CSS variabelen:

- `utrecht-separator-color`
- `utrecht-separator-width` - "width" is misschien verwarrend, voor de horizontale variant is "height" logischer. Wat zou een schrijf-richting-agnostische term hiervoor kunnen zijn?
- `utrecht-separator-margin-block`

## Visueel design Utrecht

8px dikke grijze lijn.