### PR TITLE
feat: heading components

### DIFF
--- a/src/heading/README.md
+++ b/src/heading/README.md
@@ -1,0 +1,6 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Gemeente Utrecht
+-->
+
+# Heading

--- a/src/heading/html.scss
+++ b/src/heading/html.scss
@@ -1,0 +1,29 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+@import "./index";
+
+.utrecht-html h1 {
+  @extend .utrecht-heading-1;
+}
+
+.utrecht-html h2 {
+  @extend .utrecht-heading-2;
+}
+
+.utrecht-html h3 {
+  @extend .utrecht-heading-3;
+}
+.utrecht-html h4 {
+  @extend .utrecht-heading-4;
+}
+
+.utrecht-html h5 {
+  @extend .utrecht-heading-5;
+}
+
+.utrecht-html h6 {
+  @extend .utrecht-heading-6;
+}

--- a/src/heading/html.stories.mdx
+++ b/src/heading/html.stories.mdx
@@ -1,0 +1,111 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Robbert Broersma
+-->
+
+import { Meta, Story, Canvas, ArgsTable, Description, Source } from "@storybook/addon-docs/blocks";
+import { sanitize } from "dompurify"; // Helps with preventing injections via argstable
+import { MDXEmbedProvider } from "mdx-embed";
+import dedent from "ts-dedent";
+
+<!-- Import component and component styles -->
+
+import "./html.scss";
+
+<!-- Import Docs -->
+
+import README from "./README.md";
+
+export const Template = ({ level, content }) =>
+  `<section class="utrecht-html">
+  <h${level}>${content}</h${level}>
+</section>`;
+
+<Meta
+  title="Semantic HTML/Heading"
+  argTypes={{
+    level: {
+      description: "Heading level",
+      type: "number",
+      defaultValue: "1",
+    },
+    content: {
+      description: "Set the content of the heading",
+      control: "text",
+      defaultValue: "The Quick Brown Fox Jumps Over The Lazy Dog",
+    },
+  }}
+  parameters={{
+    docs: {
+      transformSource: (_src, { args }) => Template(args),
+    },
+    status: "IN DEVELOPMENT",
+    notes: {
+      UX: README,
+    },
+  }}
+/>
+
+# Heading components
+
+## Heading 1
+
+Styling via the `<h1>` element:
+
+<Canvas>
+  <Story name="Heading 1" args={{ level: 1 }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Heading 2
+
+Styling via the `<h2>` element:
+
+<Canvas>
+  <Story name="Heading 2" args={{ level: 2 }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Heading 3
+
+Styling via the `<h3>` element:
+
+<Canvas>
+  <Story name="Heading 3" args={{ level: 3 }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Heading 4
+
+Styling via the `<h4>` element:
+
+<Canvas>
+  <Story name="Heading 4" args={{ level: 4 }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Heading 5
+
+Styling via the `<h5>` element:
+
+<Canvas>
+  <Story name="Heading 5" args={{ level: 5 }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Heading 6
+
+Styling via the `<h6>` element:
+
+<Canvas>
+  <Story name="Heading 6" args={{ level: 6 }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+<ArgsTable story="Heading" />

--- a/src/heading/index.css
+++ b/src/heading/index.css
@@ -1,0 +1,84 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2021 The Knights Who Say NIH! B.V.
+ */
+
+.utrecht-heading-1 {
+  font-family: var(
+    --utrecht-heading-1-font-family,
+    var(--utrecht-heading-font-family, var(--utrecht-document-font-family))
+  );
+  font-size: var(--utrecht-heading-1-font-size);
+  font-weight: var(--utrecht-heading-1-font-weight, var(--utrecht-heading-font-weight, bold));
+  line-height: var(--utrecht-heading-1-line-height);
+  color: var(--utrecht-heading-1-color, var(--utrecht-heading-color, inherit));
+  margin-block-start: var(--utrecht-heading-1-margin-block-start);
+  margin-block-end: var(--utrecht-heading-1-margin-block-end);
+}
+
+.utrecht-heading-2 {
+  font-family: var(
+    --utrecht-heading-2-font-family,
+    var(--utrecht-heading-font-family, var(--utrecht-document-font-family))
+  );
+  font-size: var(--utrecht-heading-2-font-size);
+  font-weight: var(--utrecht-heading-2-font-weight, var(--utrecht-heading-font-weight, bold));
+  line-height: var(--utrecht-heading-2-line-height);
+  color: var(--utrecht-heading-2-color, var(--utrecht-heading-color, inherit));
+  margin-block-start: var(--utrecht-heading-2-margin-block-start);
+  margin-block-end: var(--utrecht-heading-2-margin-block-end);
+}
+
+.utrecht-heading-3 {
+  font-family: var(
+    --utrecht-heading-3-font-family,
+    var(--utrecht-heading-font-family, var(--utrecht-document-font-family))
+  );
+  font-size: var(--utrecht-heading-3-font-size);
+  font-weight: var(--utrecht-heading-3-font-weight, var(--utrecht-heading-font-weight, bold));
+  line-height: var(--utrecht-heading-3-line-height);
+  color: var(--utrecht-heading-3-color, var(--utrecht-heading-color, inherit));
+  margin-block-start: var(--utrecht-heading-3-margin-block-start);
+  margin-block-end: var(--utrecht-heading-3-margin-block-end);
+}
+
+.utrecht-heading-4 {
+  font-family: var(
+    --utrecht-heading-4-font-family,
+    var(--utrecht-heading-font-family, var(--utrecht-document-font-family))
+  );
+  font-size: var(--utrecht-heading-4-font-size);
+  font-weight: var(--utrecht-heading-4-font-weight, var(--utrecht-heading-font-weight, bold));
+  line-height: var(--utrecht-heading-4-line-height);
+  color: var(--utrecht-heading-4-color, var(--utrecht-heading-color, inherit));
+  margin-block-start: var(--utrecht-heading-4-margin-block-start);
+  margin-block-end: var(--utrecht-heading-4-margin-block-end);
+}
+
+.utrecht-heading-5 {
+  font-family: var(
+    --utrecht-heading-5-font-family,
+    var(--utrecht-heading-font-family, var(--utrecht-document-font-family))
+  );
+  font-size: var(--utrecht-heading-5-font-size);
+  font-weight: var(--utrecht-heading-5-font-weight, var(--utrecht-heading-font-weight, bold));
+  line-height: var(--utrecht-heading-5-line-height);
+  color: var(--utrecht-heading-5-color, var(--utrecht-heading-color, inherit));
+  margin-block-start: var(--utrecht-heading-5-margin-block-start);
+  margin-block-end: var(--utrecht-heading-5-margin-block-end);
+}
+
+.utrecht-heading-6 {
+  font-family: var(
+    --utrecht-heading-6-font-family,
+    var(--utrecht-heading-font-family, var(--utrecht-document-font-family))
+  );
+  font-size: var(--utrecht-heading-6-font-size);
+  font-weight: var(--utrecht-heading-6-font-weight, var(--utrecht-heading-font-weight, bold));
+  line-height: var(--utrecht-heading-6-line-height);
+  color: var(--utrecht-heading-6-color, var(--utrecht-heading-color, inherit));
+  margin-block-start: var(--utrecht-heading-6-margin-block-start);
+  margin-block-end: var(--utrecht-heading-6-margin-block-end);
+}

--- a/src/heading/stories.mdx
+++ b/src/heading/stories.mdx
@@ -1,0 +1,116 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Robbert Broersma
+-->
+
+import { Meta, Story, Canvas, ArgsTable, Description, Source } from "@storybook/addon-docs/blocks";
+import { sanitize } from "dompurify"; // Helps with preventing injections via argstable
+import { MDXEmbedProvider } from "mdx-embed";
+
+<!-- Import component and component styles -->
+
+import "./index.css";
+
+<!-- Import Docs -->
+
+import README from "./README.md";
+
+export const Template = ({ level, content }) =>
+  `<div role="heading" aria-level="${level}" class="utrecht-heading-${level}">${content}</div>`;
+
+<Meta
+  title="Components/Heading"
+  argTypes={{
+    level: {
+      description: "Heading level",
+      type: "number",
+      defaultValue: "1",
+    },
+    content: {
+      description: "Set the content of the heading",
+      control: "text",
+      defaultValue: "The Quick Brown Fox Jumps Over The Lazy Dog",
+    },
+  }}
+  parameters={{
+    docs: {
+      transformSource: (_src, { args }) => Template(args),
+    },
+    status: "IN DEVELOPMENT",
+    notes: {
+      UX: README,
+    },
+  }}
+/>
+
+# Heading components
+
+To use the component as a web component, make sure the component is defined by including the components `element.js` file
+
+## Heading 1
+
+Styling via `utrecht-heading-1` class name:
+
+<Canvas>
+  <Story name="Heading 1" args={{ level: 1 }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Heading 2
+
+Styling via `utrecht-heading-2` class name:
+
+<Canvas>
+  <Story name="Heading 2" args={{ level: 2 }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Heading 3
+
+Styling via `utrecht-heading-3` class name:
+
+<Canvas>
+  <Story name="Heading 3" args={{ level: 3 }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Heading 4
+
+Styling via `utrecht-heading-4` class name:
+
+<Canvas>
+  <Story name="Heading 4" args={{ level: 4 }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Heading 5
+
+Styling via `utrecht-heading-5` class name:
+
+<Canvas>
+  <Story name="Heading 5" args={{ level: 5 }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Heading 6
+
+Styling via `utrecht-heading-6` class name:
+
+<Canvas>
+  <Story name="Heading 6" args={{ level: 6 }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+<ArgsTable story="Heading" />
+
+## Design Kit
+
+<MDXEmbedProvider>
+  <Figma title="Heading" url="file/x" />
+</MDXEmbedProvider>


### PR DESCRIPTION
Voorzetje voor de Heading 1 - Heading 6 components (backlog: #22 en nl-design-system/backlog#114)

De documentatie voor de verschillende heading levels kan verschillen, het kan zijn dat wordt aangeraden de teksthierarchie te beperken tot en met niveau van h4. Veel design systeems raden af om heading-5 en heading-6 te gebruiken.

## Terminologie

- "heading" uit [de HTML specificatie van `h1`/`h2`/`h3`/`h4`/`h5`/`h6`](https://html.spec.whatwg.org/multipage/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements). "h1" is nogal kortaf, daarom schrijven we "heading-1".

In HTML wordt de term "heading" gebruikt, niet "header" (dat is ook iets anders). Let dus op om niet per ongeluk "header" te schrijven in plaats van "heading".

## Class names

- `utrecht-heading-1`
- `utrecht-heading-2`
- `utrecht-heading-3`
- `utrecht-heading-4`
- `utrecht-heading-5`
- `utrecht-heading-6`

## Design Tokens

Om gemakkelijk alle headings in één keer te stylen, is er ook sprake van een soort "abstracte" heading component zonder niveau-aanduiding: `utrecht-heading`. Die component kun je niet in de praktijk gebruiken, maar de design tokens voor `utrecht-heading` worden overgenomen door de `utrecht-heading-[n]` components.

- Document (abstract component)
  - `utrecht-document-font-family`
- Heading (abstract component)
  - `utrecht-heading-color`
  - `utrecht-heading-font-family`
  - `utrecht-heading-font-weight`
- Heading 1
  - `utrecht-heading-1-color`
  - `utrecht-heading-1-font-family`
  - `utrecht-heading-1-font-size`
  - `utrecht-heading-1-font-weight`
  - `utrecht-heading-1-line-height`
  - `utrecht-heading-1-margin-block-end`
  - `utrecht-heading-1-margin-block-start`
- Heading 2
  - `utrecht-heading-2-color`
  - `utrecht-heading-2-font-family`
  - `utrecht-heading-2-font-size`
  - `utrecht-heading-2-font-weight`
  - `utrecht-heading-2-line-height`
  - `utrecht-heading-2-margin-block-end`
  - `utrecht-heading-2-margin-block-start`
- Heading 3
  - `utrecht-heading-3-color`
  - `utrecht-heading-3-font-family`
  - `utrecht-heading-3-font-size`
  - `utrecht-heading-3-font-weight`
  - `utrecht-heading-3-line-height`
  - `utrecht-heading-3-margin-block-end`
  - `utrecht-heading-3-margin-block-start`
- Heading 4
  - `utrecht-heading-4-color`
  - `utrecht-heading-4-font-family`
  - `utrecht-heading-4-font-size`
  - `utrecht-heading-4-font-weight`
  - `utrecht-heading-4-line-height`
  - `utrecht-heading-4-margin-block-end`
  - `utrecht-heading-4-margin-block-start`
- Heading 5
  - `utrecht-heading-5-color`
  - `utrecht-heading-5-font-family`
  - `utrecht-heading-5-font-size`
  - `utrecht-heading-5-font-weight`
  - `utrecht-heading-5-line-height`
  - `utrecht-heading-5-margin-block-end`
  - `utrecht-heading-5-margin-block-start`
- Heading 6
  - `utrecht-heading-6-color`
  - `utrecht-heading-6-font-family`
  - `utrecht-heading-6-font-size`
  - `utrecht-heading-6-font-weight`
  - `utrecht-heading-6-line-height`
  - `utrecht-heading-6-margin-block-end`
  - `utrecht-heading-6-margin-block-start`

Of de `*-margin-block-start` en `*-margin-block-end` design tokens effect moeten hebben op de Heading components in elke context is nog de vraag: mogelijk willen we alleen marges toepassen in een bepaalde context, zoals binnen de Rich text component.

Voor sommige huisstijlen is ook nog `letter-spacing` nodig als Design Token, die is nu nog niet geïmplementeerd.