### PR TITLE
feat: blockquote component

### DIFF
--- a/proprietary/design-tokens/component/blockquote.css
+++ b/proprietary/design-tokens/component/blockquote.css
@@ -1,0 +1,20 @@
+/**
+ * @license SEE LICENSE.md
+ * Copyright (c) 2021 Gemeente Utrecht
+ * All rights reserved
+ */
+
+/**
+ * @tokens Components / Blockquote
+ */
+:root {
+  /* @presenter Sizing */
+  --utrecht-blockquote-margin-inline-start: 1.6em;
+  --utrecht-blockquote-margin-inline-end: 1.6em;
+  --utrecht-blockquote-margin-block-start: 1.6em;
+  --utrecht-blockquote-margin-block-end: 1.6em;
+  --utrecht-blockquote-font-color: 1.125em;
+
+  /* @presenter Color */
+  --utrecht-blockquote-content-color: var(--utrecht-red-40);
+}

--- a/proprietary/design-tokens/component/index.css
+++ b/proprietary/design-tokens/component/index.css
@@ -4,6 +4,7 @@
  * All rights reserved
  */
 
+@import url("./blockquote.css");
 @import url("./button.css");
 @import url("./form.css");
 @import url("./heading.css");

--- a/src/blockquote/README.md
+++ b/src/blockquote/README.md
@@ -1,0 +1,8 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Gemeente Utrecht
+-->
+
+# Quote
+
+Quotes worden gebruikt om uitspraken te accentueren. De quote bestaat uit een uitspraak en een bronvermelding. De tekstkleur van de uitspraak is rood en de tekst is iets groter (font-size: 1.125em) dan de standaard broodtekst. De tekstgrootte van de bronvermelding is iets kleiner dan de standaard broodtekst (font-size:.75em) en start met een (lang) streepje. De quote is links uitgelijnd en springt iets in naar het midden in 1.6em vanaf de linkerkantlijn.

--- a/src/blockquote/html.scss
+++ b/src/blockquote/html.scss
@@ -1,0 +1,12 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+@import "./index";
+
+.utrecht-html blockquote {
+  @extend .utrecht-blockquote;
+  @extend .utrecht-blockquote__content;
+  @extend .utrecht-blockquote--distanced;
+}

--- a/src/blockquote/html.stories.mdx
+++ b/src/blockquote/html.stories.mdx
@@ -1,0 +1,52 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Robbert Broersma
+Copyright (c) 2021 Gemeente Utrecht
+-->
+
+import { Meta, Story, Canvas, ArgsTable, Description, Source } from "@storybook/addon-docs/blocks";
+
+<!-- Import component and component styles -->
+
+import "./html.scss";
+
+<!-- Import Docs -->
+
+import README from "./README.md";
+
+export const Template = ({ content }) =>
+  `<section class="utrecht-html">
+  <blockquote>
+    <p>${content}</p>
+  </blockquote>
+</section>`;
+
+<Meta
+  title="Semantic HTML/Blockquote"
+  argTypes={{
+    content: {
+      description: "Content of the quote",
+      control: "text",
+      defaultValue: "The Quick Brown Fox Jumps Over The Lazy Dog",
+    },
+  }}
+  parameters={{
+    docs: {
+      transformSource: (_src, { args }) => Template(args),
+    },
+    status: "IN DEVELOPMENT",
+    notes: {
+      UX: README,
+    },
+  }}
+/>
+
+# Blockquote
+
+Styling via the `<blockquote>` element:
+
+<Canvas>
+  <Story name="Blockquote in HTML">{Template.bind({})}</Story>
+</Canvas>
+
+<ArgsTable story="Blockquote in HTML" />

--- a/src/blockquote/index.css
+++ b/src/blockquote/index.css
@@ -1,0 +1,20 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+.utrecht-blockquote {
+  font-family: var(--utrecht-document-font-family);
+  font-size: var(--utrecht-blockquote-font-size);
+}
+
+.utrecht-blockquote__content {
+  color: var(--utrecht-blockquote-content-color, inherit);
+}
+
+.utrecht-blockquote--distanced {
+  margin-inline-start: var(--utrecht-blockquote-margin-inline-start);
+  margin-inline-end: var(--utrecht-blockquote-margin-inline-end);
+  margin-block-start: var(--utrecht-blockquote-margin-block);
+  margin-block-end: var(--utrecht-blockquote-margin-block);
+}

--- a/src/blockquote/stories.mdx
+++ b/src/blockquote/stories.mdx
@@ -1,0 +1,71 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Robbert Broersma
+-->
+
+import { Meta, Story, Canvas, ArgsTable, Description, Source } from "@storybook/addon-docs/blocks";
+
+<!-- Import component and component styles -->
+
+import "./index.css";
+
+<!-- Import Docs -->
+
+import README from "./README.md";
+
+export const Template = ({ content, attribution }) =>
+  `<blockquote class="utrecht-blockquote">
+    <div class="utrecht-blockquote__content">
+      <p>${content}</p>${
+    attribution
+      ? `
+    </div>
+    <div class="utrecht-blockquote__attribution"><cite>${attribution}</cite></div>`
+      : ""
+  }
+</blockquote>`;
+
+<Meta
+  title="Components/Blockquote"
+  argTypes={{
+    content: {
+      description: "Content of the quote",
+      control: "text",
+      defaultValue: "The Quick Brown Fox Jumps Over The Lazy Dog",
+    },
+    attribution: {
+      description: "Attribution of the quote",
+      control: "text",
+      defaultValue: "",
+    },
+  }}
+  parameters={{
+    docs: {
+      transformSource: (_src, { args }) => Template(args),
+    },
+    status: "IN DEVELOPMENT",
+    notes: {
+      UX: README,
+    },
+  }}
+/>
+
+# Blockquote
+
+Styling via the `.utrecht-blockquote` and `.utrecht-blockquote__content` class names:
+
+<Canvas>
+  <Story name="Blockquote">{Template.bind({})}</Story>
+</Canvas>
+
+<ArgsTable story="Blockquote" />
+
+## Blockquote with attribution
+
+Styling with an additional `.utrecht-blockquote__attribution` class name:
+
+<Canvas>
+  <Story name="Blockquote with attribution" args={{ attribution: "L. Ipsum" }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>


### PR DESCRIPTION
# Blockquote

Voorzetje voor de Blockquote component (backlog: #28 en nl-design-system/backlog#73).

## Terminologie

- **blockquote**: van het [HTML element `<blockquote>`](https://html.spec.whatwg.org/multipage/grouping-content.html#the-blockquote-element). MDN noemt het ["Block Quotation element"](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blockquote), misschien zou dat nog wel beter zijn dan "Blockquote".
- **content**: ik sta open voor suggesties.
- **attribution**: verwijzing naar de bron van het citaat. Alternatieven welkom.

## Class names

- `utrecht-blockquote`: container element
- `utrecht-blockquote__content`: gedeelte waar het citaat word genoemd
- `utrecht-blockquote__attribution`: gedeelte waar de bron van het citaat word genoemd
- `utrecht-blockquote--distanced`: modifier om afstand te creëren tot omliggende tekst

## Design tokens

- Document (parent):
  - `--utrecht-document-font-family`
- Blockquote:
  - `--utrecht-blockquote-margin-inline-start`
  - `--utrecht-blockquote-margin-inline-end`
  - `--utrecht-blockquote-margin-block`
  - `--utrecht-blockquote-margin-block`
  - `--utrecht-blockquote-font-size`
  - `--utrecht-blockquote-font-family`
  - Blockquote content:
    - `--utrecht-blockquote-content-color`
