### PR TITLE
feat: form components

### DIFF
--- a/proprietary/design-tokens/component/button.css
+++ b/proprietary/design-tokens/component/button.css
@@ -5,26 +5,29 @@
  */
 
 :root {
-  --utrecht-button-border-radius: 0.1875rem;
-  --utrecht-button-focus-border-width: 0.125rem;
-  --utrecht-button-font-family: "TheMix", sans-serif;
+  --utrecht-button-border-width: 0;
 
   --utrecht-button-font-family: var(--utrecht-font-family-sans-serif);
-  --utrecht-button-padding-inline: 1.25rem;
-  --utrecht-button-padding-block: 0.6875rem;
+  --utrecht-button-font-size: var(--utrecht-font-size-md);
+  --utrecht-button-padding-inline: var(--utrecht-space-inline-lg);
+  --utrecht-button-padding-block: var(--utrecht-space-block-md);
+
+  --utrecht-button-margin-inline: 0;
+  --utrecht-button-margin-block: var(--utrecht-space-block-sm);
+
   --utrecht-button-border-radius: 0.1875rem;
   --utrecht-button-focus-border-color: var(--utrecht-blue-40);
   --utrecht-button-focus-border-width: 0.125rem;
-  --utrecht-button-margin: 0 0.5rem 0.5rem 0;
-  --utrecht-button-padding: 0.75rem 2.5rem 0.75rem 1rem;
+  --utrecht-button-focus-transform-scale: 1.02;
 
   --utrecht-button-primary-action-background-color: var(--utrecht-blue-35);
-  --utrecht-button-primary-action-color: var(--utrecht-blue-35);
+  --utrecht-button-primary-action-color: var(--utrecht-white);
   --utrecht-button-primary-action-hover-background-color: var(--utrecht-blue-40);
   --utrecht-button-primary-action-hover-color: var(--utrecht-white);
+
   --utrecht-button-primary-action-disabled-background-color: var(--utrecht-grey-90);
   --utrecht-button-primary-action-disabled-color: var(--utrecht-white);
-  --utrecht-button-primary-action-disabled-color: var(--utrecht-white);
+  --utrecht-button-primary-action-disabled-border-color: var(--utrecht-white);
 
   --utrecht-button-secondary-action-background-color: var(--utrecht-white);
   --utrecht-button-secondary-action-color: var(--utrecht-blue-35);

--- a/proprietary/design-tokens/component/form.css
+++ b/proprietary/design-tokens/component/form.css
@@ -28,3 +28,34 @@
   --utrecht-form-textarea: normal;
   --utrecht-form-select: normal;
 }
+
+/**
+ * @tokens Component / Form input
+ */
+:root {
+  /* @presenter Sizing */
+  --utrecht-form-input-max-width: 28em;
+  --utrecht-form-input-border-width: 1px;
+  --utrecht-form-input-border-bottom-width: 3px;
+  --utrecht-form-input-border-radius: 0;
+  --utrecht-form-padding-inline-start: 12px;
+  --utrecht-form-padding-inline-end: 12px;
+  --utrecht-form-padding-block-start: 8px;
+  --utrecht-form-padding-block-end: 8px;
+
+  /* @presenter Color */
+  --utrecht-form-input-border-color: var(--utrecht-grey-50);
+  --utrecht-form-input-invalid-border-color: var(--utrecht-feedback-invalid-color);
+
+  /* @presenter FontFamily */
+  --utrecht-form-input-font-family: var(--utrecht-font-family-sans-serif);
+}
+
+/**
+ * @tokens Component / Form field
+ */
+:root {
+  /* @presenter Sizing */
+  --utrecht-form-field-margin-block-start: var(--utrecht-space-block-xs);
+  --utrecht-form-field-margin-block-end: var(--utrecht-space-block-xs);
+}

--- a/proprietary/design-tokens/component/index.css
+++ b/proprietary/design-tokens/component/index.css
@@ -12,4 +12,5 @@
 @import url("./menulijst.css");
 @import url("./paragraph.css");
 @import url("./separator.css");
+@import url("./textarea.css");
 @import url("./unordered-list.css");

--- a/proprietary/design-tokens/component/index.css
+++ b/proprietary/design-tokens/component/index.css
@@ -13,4 +13,5 @@
 @import url("./paragraph.css");
 @import url("./separator.css");
 @import url("./textarea.css");
+@import url("./textbox.css");
 @import url("./unordered-list.css");

--- a/proprietary/design-tokens/component/textarea.css
+++ b/proprietary/design-tokens/component/textarea.css
@@ -1,0 +1,27 @@
+/**
+ * @license SEE LICENSE.md
+ * Copyright (c) 2021 Gemeente Utrecht
+ * All rights reserved
+ */
+
+/**
+ * @tokens Component / Textarea
+ */
+:root {
+  /* @presenter Sizing */
+  --utrecht-textarea-max-width: var(--utrecht-textbox-max-width);
+  --utrecht-textarea-border-width: var(--utrecht-textbox-border-width);
+  --utrecht-textarea-border-bottom-width: var(--utrecht-textbox-border-bottom-width);
+  --utrecht-textarea-border-radius: var(--utrecht-textbox-border-radius);
+  --utrecht-textarea-padding-inline-start: var(--utrecht-textbox-padding-inline-start);
+  --utrecht-textarea-padding-inline-end: var(--utrecht-textbox-padding-inline-end);
+  --utrecht-textarea-padding-block-start: var(--utrecht-textbox-padding-block-start);
+  --utrecht-textarea-padding-block-end: var(--utrecht-textbox-padding-block-end);
+
+  /* @presenter Color */
+  --utrecht-textarea-border-color: var(--utrecht-textbox-border-color);
+  --utrecht-textarea-invalid-border-color: var(--utrecht-textbox-invalid-border-color);
+
+  /* @presenter FontFamily */
+  --utrecht-textarea-font-family: var(--utrecht-textbox-font-family);
+}

--- a/proprietary/design-tokens/component/textbox.css
+++ b/proprietary/design-tokens/component/textbox.css
@@ -1,0 +1,27 @@
+/**
+ * @license SEE LICENSE.md
+ * Copyright (c) 2021 Gemeente Utrecht
+ * All rights reserved
+ */
+
+/**
+ * @tokens Component / Form input
+ */
+:root {
+  /* @presenter Sizing */
+  --utrecht-textbox-max-width: 28em;
+  --utrecht-textbox-border-width: 1px;
+  --utrecht-textbox-border-bottom-width: 3px;
+  --utrecht-textbox-border-radius: 0;
+  --utrecht-textbox-padding-inline-start: 12px;
+  --utrecht-textbox-padding-inline-end: 12px;
+  --utrecht-textbox-padding-block-start: 8px;
+  --utrecht-textbox-padding-block-end: 8px;
+
+  /* @presenter Color */
+  --utrecht-textbox-border-color: var(--utrecht-grey-50);
+  --utrecht-textbox-invalid-border-color: var(--utrecht-feedback-invalid-color);
+
+  /* @presenter FontFamily */
+  --utrecht-textbox-font-family: var(--utrecht-font-family-sans-serif);
+}

--- a/src/button/README.md
+++ b/src/button/README.md
@@ -1,0 +1,49 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Gemeente Utrecht
+Copyright (c) 2021 Robbert Broersma
+-->
+
+# Button
+
+## Tekstbutton
+
+Tekstlinks zijn standaard donkerblauw (#2A5587) en onderstreept. In sommige gevallen zijn tekstlinks zwart of wit. Dit geldt bij teksten op een gekleurde achtergrond, waar blauw niet voldoende contrast biedt. Kijk voor meer informatie over de contrastrichtlijnen bij kleuren (link naar kleuren).
+
+### Voorbeeld
+
+U kunt tegelijk een paspoort en een ID-kaart hebben. Met een paspoort kunt u naar alle landen reizen. Een ID-kaart is goedkoper, maar u kunt hiermee niet naar alle landen reizen.
+
+## Button met pijl
+
+Links met een pijl als voorloopteken worden gebruikt aan het einde van een tekst. Ze verwijzen naar gerelateerde informatie over het onderwerp wat er in de voorafgaande tekst is besproken. De links zijn donkerblauw (#2A5587), bold en hebben een pijl (>) als voorloopteken. Dit type link wordt ook gebruikt in de linklijst en de subnavigatie.
+
+## Terminologie
+
+- **button**: van het `<button>` HTML element, `role="button"` in ARIA.
+
+## States
+
+- `hover`
+- `focus`
+
+## Class names
+
+- `.utrecht-button`
+- `.utrecht-button--focus`
+- `.utrecht-button--hover`
+
+## Design tokens
+
+- Button
+  - `--utrecht-button-border-width`
+  - `--utrecht-button-focus-transform-scale`
+  - `--utrecht-button-font-size`
+  - `--utrecht-button-margin-block`
+  - `--utrecht-button-margin-inline`
+  - `--utrecht-button-padding-block`
+  - `--utrecht-button-padding-inline`
+  - Modifier: primary action
+    - `--utrecht-button-primary-action-background-color`
+    - `--utrecht-button-primary-action-color`
+    - `--utrecht-button-primary-action-hover-background-color`

--- a/src/button/button-html.stories.mdx
+++ b/src/button/button-html.stories.mdx
@@ -1,0 +1,60 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Robbert Broersma
+-->
+
+import { Meta, Story, Canvas, ArgsTable, Description, Source } from "@storybook/addon-docs/blocks";
+import { sanitize } from "dompurify"; // Helps with preventing injections via argstable
+import { MDXEmbedProvider } from "mdx-embed";
+import dedent from "ts-dedent";
+
+<!-- Import component and component styles -->
+
+import "./html.scss";
+
+<!-- Import Docs -->
+
+import README from "./README.md";
+import accessibilityGuidelines from "./docs/accessibility-guidelines.md";
+
+export const Template = ({ content }) =>
+  `<section class="utrecht-html">
+  <button type="button">${content}</button>
+</section>`;
+
+<Meta
+  title="Semantic HTML/Button"
+  argTypes={{
+    content: {
+      description: "Content of the button",
+      control: "text",
+      defaultValue: "The Quick Brown Fox Jumps Over The Lazy Dog",
+    },
+  }}
+  parameters={{
+    docs: {
+      transformSource: (_src, { args }) => Template(args),
+    },
+    status: "IN DEVELOPMENT",
+    notes: {
+      UX: README,
+      Accessibility: accessibilityGuidelines,
+    },
+  }}
+/>
+
+# Button
+
+Styling via the `<button>` element:
+
+<Canvas>
+  <Story name="Button">{Template.bind({})}</Story>
+</Canvas>
+
+<ArgsTable story="Button" />
+
+## Design Kit
+
+<MDXEmbedProvider>
+  <Figma title="Button" url="file/x" />
+</MDXEmbedProvider>

--- a/src/button/button.stories.mdx
+++ b/src/button/button.stories.mdx
@@ -1,0 +1,83 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Gemeente Utrecht
+Copyright (c) 2021 Robbert Broersma
+-->
+
+import { Meta, Story, Canvas, ArgsTable, Description, Source } from "@storybook/addon-docs/blocks";
+import { sanitize } from "dompurify"; // Helps with preventing injections via argstable
+import { MDXEmbedProvider } from "mdx-embed";
+import dedent from "ts-dedent";
+
+import "./style.css";
+
+import README from "./README.md";
+import accessibilityGuidelines from "./docs/accessibility-guidelines.md";
+
+export const Template = ({ content, focus, hover }) =>
+  `<button class="utrecht-button ${hover ? " utrecht-button--hover" : ""}${
+    focus ? " utrecht-button--focus" : ""
+  }">${content}</button>`;
+
+<Meta
+  title="Components/Button"
+  argTypes={{
+    content: {
+      description: "Button text",
+      control: "text",
+      defaultValue: "Read more...",
+    },
+    focus: {
+      description: "Visited",
+      control: "text",
+      defaultValue: false,
+    },
+    hover: {
+      description: "Visited",
+      control: "text",
+      defaultValue: false,
+    },
+  }}
+  parameters={{
+    docs: {
+      transformSource: (_src, { args }) => Template(args),
+    },
+    status: "IN DEVELOPMENT",
+    notes: {
+      UX: README,
+      Accessibility: accessibilityGuidelines,
+    },
+  }}
+/>
+
+# Button
+
+Styling via the `.utrecht-button` class name:
+
+<Canvas>
+  <Story name="Button">{Template.bind({})}</Story>
+</Canvas>
+
+Styling via the `.utrecht-button--hover` class name:
+
+<Canvas>
+  <Story name="Button hover" args={{ hover: true }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+Styling via the `.utrecht-button--focus` class name:
+
+<Canvas>
+  <Story name="Button focus" args={{ focus: true }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+<ArgsTable story="Button" />
+
+## Design Kit
+
+<MDXEmbedProvider>
+  <Figma title="Button" url="file/x" />
+</MDXEmbedProvider>

--- a/src/button/docs/accessibility-guidelines.md
+++ b/src/button/docs/accessibility-guidelines.md
@@ -1,0 +1,32 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Gemeente Utrecht
+-->
+
+<!-- markdownlint-disable MD033 -->
+
+# Toegangkelijkheidseisen
+
+## Focus
+
+### WCAG 2.4.11
+
+Bij het Link component hebben we te maken met [WCAG eis 2.4.1](https://www.w3.org/TR/WCAG22/#focus-appearance-minimum). Deze eis beschrijft dat als een link de focus door het te selecteren met het toetsenbord het uiterlijk van de link moet veranderen. De [bedoeling van dit punt](https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance-minimum.html#intent) is dat de keyboard focus indicator altijd duidelijk zichtbaar is.
+
+### Design keuzes
+
+We maken daarom de volgende design keuzes bij een hover state:
+
+- Een link in focus state krijgt een gele achtergrondkleur (`var(--utrecht-yellow-60)`).
+- Een link in focus state krijgt een donkerblauwe outline (`var(--utrecht-blue-35)`).
+- We kiezen voor outline in plaats van border omdat dit beter opgepakt wordt door de verschillende browsers.
+
+Als een link de focus krijgt is deze een stuk zichtbaarder dan zonder deze achtergrond. Het verschil tussen de normale achtergrond (zonder focus) en de nieuwe achtergrond (met focus) moet voldoen aan een contrast ration van 3:1. Met de bovenstaande keuzes hebben we een contrastwaarde van ??:??
+Het verschil tussen de achtergrond met focus en de omgeving moet voldoen aan een contrast van 3:1 of de afscheiding heeft ten minste een waarde van 2 pixels. Met de bovenstaande keuzes hebben we een contrastwaarde van ??:?? en de dikte van de outline is ??:??.
+
+### Toegevoegde waarde
+
+De toegevoegde waarde van deze beslissingen is:
+
+- Bij het gebruik van het toetsenbord om door de links te navigeren is het visueel duidelijker welke link geselecteerd is.
+- We voldoen aan [WCAG eis 2.4.1](https://www.w3.org/TR/WCAG22/#focus-appearance-minimum), zodat we de voldoen aan de [wettelijke bepaling voor een gemeente](https://wcag.nl/wat-is-wcag/wet--en-regelgeving).

--- a/src/button/docs/content-guidelines.md
+++ b/src/button/docs/content-guidelines.md
@@ -1,0 +1,5 @@
+# Demo
+
+## Content guidelines
+
+Besides the general content guidelines there are no component specific guidelines available

--- a/src/button/html.scss
+++ b/src/button/html.scss
@@ -1,0 +1,19 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+@import "./style";
+
+.utrecht-html button {
+  @extend .utrecht-button;
+  @extend .utrecht-button--distanced;
+}
+
+.utrecht-html button:hover {
+  @extend .utrecht-button--hover;
+}
+
+.utrecht-html button:focus {
+  @extend .utrecht-button--focus;
+}

--- a/src/button/style.css
+++ b/src/button/style.css
@@ -1,0 +1,37 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 The Knights Who Say NIH! B.V.
+ * Copyright (c) 2021 Gemeente Utrecht
+ */
+
+.utrecht-button {
+  color: var(--utrecht-button-primary-action-color);
+  font-size: var(--utrecht-button-font-size);
+  background-color: var(--utrecht-button-primary-action-background-color);
+  border-width: var(--utrecht-button-border-width);
+  padding-inline-start: var(--utrecht-button-padding-inline);
+  padding-inline-end: var(--utrecht-button-padding-inline);
+  padding-block-start: var(--utrecht-button-padding-block);
+  padding-block-end: var(--utrecht-button-padding-block);
+}
+
+.utrecht-button--distanced {
+  margin-inline-start: var(--utrecht-button-margin-inline);
+  margin-inline-end: var(--utrecht-button-margin-inline);
+  margin-block-start: var(--utrecht-button-margin-block);
+  margin-block-end: var(--utrecht-button-margin-block);
+}
+
+.utrecht-button:hover,
+.utrecht-button--hover {
+  color: var(--utrecht-button-primary-action-color);
+  background-color: var(--utrecht-button-primary-action-hover-background-color);
+  transform: scale(var(--utrecht-button-focus-transform-scale, 1));
+}
+
+.utrecht-button:focus,
+.utrecht-button--focus {
+  color: var(--utrecht-button-primary-action-color);
+  background-color: var(--utrecht-button-primary-action-background-color);
+  border-width: var(--utrecht-button-border-width);
+}

--- a/src/checkbox/README.md
+++ b/src/checkbox/README.md
@@ -1,0 +1,19 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Robbert Broersma
+-->
+
+# Checkbox
+
+## Terminologie
+
+- **checkbox**: `type="checkbox"` in HTML, [`role="checkbox"`](https://www.w3.org/TR/wai-aria-1.2/#checkbox) in WAI-ARIA 1.2, "checkbox" in [WAI-ARIA Authoring Practices](https://www.w3.org/TR/wai-aria-practices-1.2/#checkbox).
+- **checked**: `checked` attribuut in HTML, `aria-checked="true"` in [WAI-ARIA](https://www.w3.org/TR/wai-aria-1.2/#aria-checked), `:checked` pseudo-class in CSS.
+
+## Class names
+
+- `utrecht-checkbox`
+
+## Design tokens
+
+Nog geen.

--- a/src/checkbox/html.scss
+++ b/src/checkbox/html.scss
@@ -1,0 +1,10 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+@import "./index";
+
+.utrecht-html input[type="checkbox"] {
+  @extend .utrecht-checkbox;
+}

--- a/src/checkbox/index.css
+++ b/src/checkbox/index.css
@@ -1,0 +1,12 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+.utrecht-checkbox {
+  /* reset native margin for input[type="checkbox"] */
+  margin-block-start: 0;
+  margin-block-end: 0;
+  margin-inline-start: 0;
+  margin-inline-end: 0;
+}

--- a/src/form-field-checkbox/README.md
+++ b/src/form-field-checkbox/README.md
@@ -1,0 +1,1 @@
+# Form field with checkbox

--- a/src/form-field-checkbox/index.css
+++ b/src/form-field-checkbox/index.css
@@ -1,0 +1,17 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+.utrecht-form-field-checkbox {
+  font-family: var(--utrecht-document-font-family, inherit);
+}
+
+.utrecht-form-field-checkbox--distanced {
+  margin-block-start: var(--utrecht-form-field-margin-block-start, var(--utrecht-paragraph-margin-block-start));
+  margin-block-end: var(--utrecht-form-field-margin-block-end, var(--utrecht-paragraph-margin-block-end));
+}
+
+.utrecht-form-field-checkbox__label {
+  margin-inline-start: 1ch;
+}

--- a/src/form-field-checkbox/stories.mdx
+++ b/src/form-field-checkbox/stories.mdx
@@ -1,0 +1,53 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Robbert Broersma
+-->
+
+import { Meta, Story, Canvas, ArgsTable, Description, Source } from "@storybook/addon-docs/blocks";
+import { sanitize } from "dompurify"; // Helps with preventing injections via argstable
+import { MDXEmbedProvider } from "mdx-embed";
+import dedent from "ts-dedent";
+
+<!-- Import component and component styles -->
+
+import "./index.css";
+import "../checkbox/index.css";
+import "../form-label/index.css";
+
+<!-- Import Docs -->
+
+import README from "./README.md";
+
+export const Template = ({ label }) =>
+  `<div class="utrecht-form-field-checkbox utrecht-form-field-checkbox--distanced">
+    <input type="checkbox" class="utrecht-form-field-checkbox__input utrecht-checkbox" id="id-ce0239e2">
+  <label class="utrecht-form-field-checkbox__label" for="id-ce0239e2">${label}</label>
+</div>`;
+
+<Meta
+  title="Molecules/Form field"
+  argTypes={{
+    label: {
+      description: "Set the content of the label",
+      control: "text",
+      defaultValue: "I agree",
+    },
+  }}
+  parameters={{
+    docs: {
+      transformSource: (_src, { args }) => Template(args),
+    },
+    status: "IN DEVELOPMENT",
+    notes: {
+      UX: README,
+    },
+  }}
+/>
+
+# Form field with checkbox
+
+<Canvas>
+  <Story name="Form field with checkbox">{Template.bind({})}</Story>
+</Canvas>
+
+<ArgsTable story="Form field with checkbox" />

--- a/src/form-field-radio-group/README.md
+++ b/src/form-field-radio-group/README.md
@@ -1,0 +1,1 @@
+# Form field with radio group

--- a/src/form-field-radio-group/index.css
+++ b/src/form-field-radio-group/index.css
@@ -1,0 +1,19 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+.utrecht-form-field-radio-group {
+  font-size: var(--utrecht-paragraph-font-size);
+  font-family: var(--utrecht-document-font-family, inherit);
+}
+
+.utrecht-form-field-radio-group--distanced {
+  margin-block-start: var(--utrecht-form-field-margin-block-start, var(--utrecht-paragraph-margin-block-start));
+  margin-block-end: var(--utrecht-form-field-margin-block-end, var(--utrecht-paragraph-margin-block-end));
+}
+
+.utrecht-form-field-radio-group__label {
+  margin-block-start: var(--utrecht-paragraph-margin-block-start);
+  margin-block-end: var(--utrecht-paragraph-margin-block-end);
+}

--- a/src/form-field-radio-group/stories.mdx
+++ b/src/form-field-radio-group/stories.mdx
@@ -1,0 +1,69 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Robbert Broersma
+-->
+
+import { Meta, Story, Canvas, ArgsTable, Description, Source } from "@storybook/addon-docs/blocks";
+import { sanitize } from "dompurify"; // Helps with preventing injections via argstable
+import { MDXEmbedProvider } from "mdx-embed";
+import dedent from "ts-dedent";
+
+<!-- Import component and component styles -->
+
+import "./index.css";
+import "../radio-button/index.css";
+import "../form-label/index.css";
+
+<!-- Import Docs -->
+
+import README from "./README.md";
+
+export const Template = ({ label, name }) =>
+  `<div class="utrecht-form-field-radio-group utrecht-form-field-radio-group--distanced" role="radiogroup" aria-labelledby="id-9e42cd3e">
+  <div class="utrecht-form-field-radio-group__label" id="id-9e42cd3e">${label}</div>
+  <div class="utrecht-form-field-radio class="utrecht-form-field-radio--distanced">
+    <input type="radio" name="${name}" class="utrecht-form-field-radio__input utrecht-radio-button" id="option-1">
+    <label class="utrecht-form-field-radio__label" for="option-1">Option 1</label>
+  </div>
+  <div class="utrecht-form-field-radio class="utrecht-form-field-radio--distanced">
+    <input type="radio" name="${name}" class="utrecht-form-field-radio__input utrecht-radio-button" id="option-2">
+    <label class="utrecht-form-field-radio__label" for="option-2">Option 2</label>
+  </div>
+  <div class="utrecht-form-field-radio class="utrecht-form-field-radio--distanced">
+    <input type="radio" name="${name}" class="utrecht-form-field-radio__input utrecht-radio-button" id="option-3">
+    <label class="utrecht-form-field-radio__label" for="option-3">Option 3</label>
+  </div>
+</div>`;
+
+<Meta
+  title="Molecules/Form field"
+  argTypes={{
+    label: {
+      description: "Set the content of the label",
+      control: "text",
+      defaultValue: "Which option do you like best?",
+    },
+    name: {
+      description: "Set the name of the radio button",
+      control: "text",
+      defaultValue: "radiobutton",
+    },
+  }}
+  parameters={{
+    docs: {
+      transformSource: (_src, { args }) => Template(args),
+    },
+    status: "IN DEVELOPMENT",
+    notes: {
+      UX: README,
+    },
+  }}
+/>
+
+# Form field with radio
+
+<Canvas>
+  <Story name="Form field with radio group">{Template.bind({})}</Story>
+</Canvas>
+
+<ArgsTable story="Form field with radio group" />

--- a/src/form-field-radio/README.md
+++ b/src/form-field-radio/README.md
@@ -1,0 +1,1 @@
+# Form field with radio

--- a/src/form-field-radio/index.css
+++ b/src/form-field-radio/index.css
@@ -1,0 +1,18 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+.utrecht-form-field-radio {
+  font-size: var(--utrecht-paragraph-font-size);
+  font-family: var(--utrecht-document-font-family, inherit);
+}
+
+.utrecht-form-field-radio--distanced {
+  margin-block-start: var(--utrecht-form-field-margin-block-start, var(--utrecht-paragraph-margin-block-start));
+  margin-block-end: var(--utrecht-form-field-margin-block-end, var(--utrecht-paragraph-margin-block-end));
+}
+
+.utrecht-form-field-radio__label {
+  margin-inline-start: 1ch;
+}

--- a/src/form-field-radio/stories.mdx
+++ b/src/form-field-radio/stories.mdx
@@ -1,0 +1,53 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Robbert Broersma
+-->
+
+import { Meta, Story, Canvas, ArgsTable, Description, Source } from "@storybook/addon-docs/blocks";
+import { sanitize } from "dompurify"; // Helps with preventing injections via argstable
+import { MDXEmbedProvider } from "mdx-embed";
+import dedent from "ts-dedent";
+
+<!-- Import component and component styles -->
+
+import "./index.css";
+import "../radio-button/index.css";
+import "../form-label/index.css";
+
+<!-- Import Docs -->
+
+import README from "./README.md";
+
+export const Template = ({ label }) =>
+  `<div class="utrecht-form-field-radio utrecht-form-field-radio--distanced">
+    <input type="radio" class="utrecht-form-field-radio__input utrecht-radio-button" id="id-ce0239e2">
+  <label class="utrecht-form-field-radio__label" for="id-ce0239e2">${label}</label>
+</div>`;
+
+<Meta
+  title="Molecules/Form field"
+  argTypes={{
+    label: {
+      description: "Set the content of the label",
+      control: "text",
+      defaultValue: "I agree",
+    },
+  }}
+  parameters={{
+    docs: {
+      transformSource: (_src, { args }) => Template(args),
+    },
+    status: "IN DEVELOPMENT",
+    notes: {
+      UX: README,
+    },
+  }}
+/>
+
+# Form field with radio
+
+<Canvas>
+  <Story name="Form field with radio">{Template.bind({})}</Story>
+</Canvas>
+
+<ArgsTable story="Form field with radio" />

--- a/src/form-label/README.md
+++ b/src/form-label/README.md
@@ -1,0 +1,1 @@
+# Form label

--- a/src/form-label/html.scss
+++ b/src/form-label/html.scss
@@ -1,0 +1,10 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+@import "./index";
+
+.utrecht-html label {
+  @extend .utrecht-form-label;
+}

--- a/src/form-label/html.stories.mdx
+++ b/src/form-label/html.stories.mdx
@@ -1,0 +1,52 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Robbert Broersma
+-->
+
+import { Meta, Story, Canvas, ArgsTable, Description, Source } from "@storybook/addon-docs/blocks";
+import { sanitize } from "dompurify"; // Helps with preventing injections via argstable
+import { MDXEmbedProvider } from "mdx-embed";
+import dedent from "ts-dedent";
+
+<!-- Import component and component styles -->
+
+import "./html.scss";
+
+<!-- Import Docs -->
+
+import README from "./README.md";
+
+export const Template = ({ content }) =>
+  `<div class="utrecht-html">
+  <label>${content}</label>
+</div>`;
+
+<Meta
+  title="Semantic HTML/Form label"
+  argTypes={{
+    content: {
+      description: "Set the content of the label",
+      control: "text",
+      defaultValue: "Username",
+    },
+  }}
+  parameters={{
+    docs: {
+      transformSource: (_src, { args }) => Template(args),
+    },
+    status: "IN DEVELOPMENT",
+    notes: {
+      UX: README,
+    },
+  }}
+/>
+
+# Label component
+
+Styling via the `<label>` element:
+
+<Canvas>
+  <Story name="Label">{Template.bind({})}</Story>
+</Canvas>
+
+<ArgsTable story="Label" />

--- a/src/form-label/index.css
+++ b/src/form-label/index.css
@@ -1,0 +1,9 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+.utrecht-form-label {
+  font-weight: var(--utrecht-form-label-font-weight);
+  font-size: var(--utrecht-form-label-font-size);
+}

--- a/src/form-label/stories.mdx
+++ b/src/form-label/stories.mdx
@@ -1,0 +1,49 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Robbert Broersma
+-->
+
+import { Meta, Story, Canvas, ArgsTable, Description, Source } from "@storybook/addon-docs/blocks";
+import { sanitize } from "dompurify"; // Helps with preventing injections via argstable
+import { MDXEmbedProvider } from "mdx-embed";
+import dedent from "ts-dedent";
+
+<!-- Import component and component styles -->
+
+import "./html.scss";
+
+<!-- Import Docs -->
+
+import README from "./README.md";
+
+export const Template = ({ content }) => `<span class="utrecht-form-label">${content}</span>`;
+
+<Meta
+  title="Components/Form label"
+  argTypes={{
+    content: {
+      description: "Set the content of the label",
+      control: "text",
+      defaultValue: "Username",
+    },
+  }}
+  parameters={{
+    docs: {
+      transformSource: (_src, { args }) => Template(args),
+    },
+    status: "IN DEVELOPMENT",
+    notes: {
+      UX: README,
+    },
+  }}
+/>
+
+# Label component
+
+Styling via the `.utrecht-form-label` class name:
+
+<Canvas>
+  <Story name="Label">{Template.bind({})}</Story>
+</Canvas>
+
+<ArgsTable story="Label" />

--- a/src/radio-button/README.md
+++ b/src/radio-button/README.md
@@ -1,0 +1,19 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Robbert Broersma
+-->
+
+# Radio button
+
+## Terminologie
+
+- **radio button**: "Radio button" heeft [een Wikipedia-lemma](https://en.wikipedia.org/wiki/Radio_button), [WAI-ARIA Authoring Practices 1.2](https://www.w3.org/TR/wai-aria-practices-1.2/#radiobutton) noemt het ook "radio button" en "radio group".
+- **checked**: [WAI-ARIA Authoring Practices 1.2](https://www.w3.org/TR/wai-aria-practices-1.2/#radiobutton) en HTML noemen de staat van de radio button "checked", CSS heeft de `:checked` pseudo-class.
+
+## Class names
+
+- `.utrecht-radio-button`
+
+## Design tokens
+
+Nog geen design tokens.

--- a/src/radio-button/html.scss
+++ b/src/radio-button/html.scss
@@ -1,0 +1,10 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Gemeente Utrecht
+ */
+
+@import "./index";
+
+.utrecht-html input[type="radio"] {
+  @extend .utrecht-radio;
+}

--- a/src/radio-button/index.css
+++ b/src/radio-button/index.css
@@ -1,0 +1,12 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Gemeente Utrecht
+ */
+
+.utrecht-radio-button {
+  /* reset native margin for input[type="radio"] */
+  margin-block-start: 0;
+  margin-block-end: 0;
+  margin-inline-start: 0;
+  margin-inline-end: 0;
+}

--- a/src/textarea/README.md
+++ b/src/textarea/README.md
@@ -1,0 +1,42 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Robbert Broersma
+-->
+
+# Textarea
+
+## Terminologie
+
+- **textarea**: van het `<textarea>` element in HTML.
+
+## Class names
+
+- `.utrecht-textarea`
+- `.utrecht-textarea--invalid`
+- `.utrecht-textarea--disabled`
+- `.utrecht-textarea--read-only`
+
+## Design tokens
+
+- Textarea:
+  - `--utrecht-textarea-border-bottom-width`
+  - `--utrecht-textarea-border-color`
+  - `--utrecht-textarea-border-radius`
+  - `--utrecht-textarea-border-width`
+  - `--utrecht-textarea-color`
+  - `--utrecht-textarea-font-family`
+  - `--utrecht-textarea-font-size`
+  - `--utrecht-textarea-max-width`
+  - `--utrecht-textarea-padding-block-end`
+  - `--utrecht-textarea-padding-block-start`
+  - `--utrecht-textarea-padding-inline-end`
+  - `--utrecht-textarea-padding-inline-start`
+  - Modifier: `disabled`
+    - `--utrecht-textarea-disabled-border-color`
+    - `--utrecht-textarea-disabled-color`
+  - Modifier: `invalid`
+    - `--utrecht-textarea-invalid-border-color`
+    - `--utrecht-textarea-invalid-border-width`
+  - Modifier: `read-only`:
+    - `--utrecht-textarea-read-only-border-color`
+    - `--utrecht-textarea-read-only-color`

--- a/src/textarea/html.scss
+++ b/src/textarea/html.scss
@@ -1,0 +1,23 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+@import "./index";
+
+.utrecht-html textarea {
+  @extend .utrecht-textarea;
+}
+
+.utrecht-html textarea:disabled {
+  @extend .utrecht-textarea--disabled;
+}
+
+.utrecht-html textarea:invalid,
+.utrecht-html textarea[aria-invalid="true"] {
+  @extend .utrecht-textarea--invalid;
+}
+
+.utrecht-html textarea:read-only {
+  @extend .utrecht-textarea--read-only;
+}

--- a/src/textarea/html.stories.mdx
+++ b/src/textarea/html.stories.mdx
@@ -1,0 +1,106 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Robbert Broersma
+-->
+
+import { Meta, Story, Canvas, ArgsTable, Description, Source } from "@storybook/addon-docs/blocks";
+import { sanitize } from "dompurify"; // Helps with preventing injections via argstable
+import { MDXEmbedProvider } from "mdx-embed";
+import dedent from "ts-dedent";
+
+<!-- Import component and component styles -->
+
+import "./html.scss";
+
+<!-- Import Docs -->
+
+import README from "./README.md";
+
+export const Template = ({ content, invalid, readOnly, disabled, required }) =>
+  `<section class="utrecht-html">
+  <textarea${invalid ? ' aria-invalid="true"' : ""}${disabled ? " disabled" : ""}${required ? " required" : ""}${
+    readOnly ? " readonly" : ""
+  }>${content}</textarea>
+</section>`;
+
+<Meta
+  title="Semantic HTML/Textarea"
+  argTypes={{
+    content: {
+      description: "Set the content of the textarea",
+      control: "text",
+      defaultValue: "The Quick Brown Fox Jumps Over The Lazy Dog",
+    },
+    invalid: {
+      description: "Invalid",
+      control: "boolean",
+      defaultValue: false,
+    },
+    readOnly: {
+      description: "Read-only",
+      control: "boolean",
+      defaultValue: false,
+    },
+    disabled: {
+      description: "Disabled",
+      control: "boolean",
+      defaultValue: false,
+    },
+    required: {
+      description: "Required",
+      control: "boolean",
+      defaultValue: false,
+    },
+  }}
+  parameters={{
+    docs: {
+      transformSource: (_src, { args }) => Template(args),
+    },
+    status: "IN DEVELOPMENT",
+    notes: {
+      UX: README,
+    },
+  }}
+/>
+
+# Textarea component
+
+Styling via the `<textarea>` element:
+
+<Canvas>
+  <Story name="Textarea">{Template.bind({})}</Story>
+</Canvas>
+
+<ArgsTable story="Textarea" />
+
+## Invalid
+
+<Canvas>
+  <Story name="Invalid textarea" args={{ invalid: true }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Disabled
+
+<Canvas>
+  <Story name="Disabled textarea" args={{ disabled: true }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Read-only
+
+<Canvas>
+  <Story name="Read-only textarea" args={{ readOnly: true }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Required
+
+<Canvas>
+  <Story name="Required textarea" args={{ required: true }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>

--- a/src/textarea/index.css
+++ b/src/textarea/index.css
@@ -1,0 +1,36 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+.utrecht-textarea {
+  border-width: var(--utrecht-textarea-border-width);
+  border-bottom-width: var(--utrecht-textarea-border-bottom-width, var(--utrecht-textarea-border-width));
+  border-color: var(--utrecht-textarea-border-color);
+  border-radius: var(--utrecht-textarea-border-radius, 0);
+  border-style: solid;
+  color: var(--utrecht-textarea-color);
+  font-family: var(--utrecht-textarea-font-family);
+  font-size: var(--utrecht-textarea-font-size, 1em);
+  max-width: var(--utrecht-textarea-max-width);
+  padding-block-end: var(--utrecht-textarea-padding-block-end);
+  padding-block-start: var(--utrecht-textarea-padding-block-start);
+  padding-inline-end: var(--utrecht-textarea-padding-inline-end);
+  padding-inline-start: var(--utrecht-textarea-padding-inline-start);
+  width: 100%;
+}
+
+.utrecht-textarea--invalid {
+  border-color: var(--utrecht-textarea-invalid-border-color);
+  border-width: var(--utrecht-textarea-invalid-border-width);
+}
+
+.utrecht-textarea--disabled {
+  border-color: var(--utrecht-textarea-disabled-border-color);
+  color: var(--utrecht-textarea-disabled-color);
+}
+
+.utrecht-textarea--read-only {
+  border-color: var(--utrecht-textarea-read-only-border-color);
+  color: var(--utrecht-textarea-read-only-color);
+}

--- a/src/textbox/README.md
+++ b/src/textbox/README.md
@@ -1,0 +1,45 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Robbert Broersma
+-->
+
+# Text box
+
+## Terminologie
+
+- **textbox**: [`role="textbox"` in WAI-ARIA](https://www.w3.org/TR/wai-aria-1.2/#textbox), [Text box lemma op Wikipedia](https://en.wikipedia.org/wiki/Text_box). HTML noemt het "text control" en text edit control". [MDN noemt het](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/text) "text field" en "text input".
+- **invalid**: ...
+- **disabled**: ...
+- **read-only**: ...
+
+## Class names
+
+- `.utrecht-textbox`
+- `.utrecht-textbox--invalid`
+- `.utrecht-textbox--disabled`
+- `.utrecht-textbox--read-only`
+
+## Design Tokens
+
+- Textbox:
+  - `--utrecht-textbox-border-bottom-width`
+  - `--utrecht-textbox-border-color`
+  - `--utrecht-textbox-border-radius`
+  - `--utrecht-textbox-border-width`
+  - `--utrecht-textbox-color`
+  - `--utrecht-textbox-font-family`
+  - `--utrecht-textbox-font-size`
+  - `--utrecht-textbox-max-width`
+  - `--utrecht-textbox-padding-block-end`
+  - `--utrecht-textbox-padding-block-start`
+  - `--utrecht-textbox-padding-inline-end`
+  - `--utrecht-textbox-padding-inline-start`
+  - Modifier: `disabled`
+    - `--utrecht-textbox-disabled-border-color`
+    - `--utrecht-textbox-disabled-color`
+  - Modifier: `invalid`
+    - `--utrecht-textbox-invalid-border-color`
+    - `--utrecht-textbox-invalid-border-width`
+  - Modifier: `read-only`:
+    - `--utrecht-textbox-read-only-border-color`
+    - `--utrecht-textbox-read-only-color`

--- a/src/textbox/html.scss
+++ b/src/textbox/html.scss
@@ -1,0 +1,31 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+@import "./index";
+
+.utrecht-html {
+  input[type="text"],
+  input[type="email"],
+  input[type="search"],
+  input[type="tel"],
+  input[type="url"] {
+    & {
+      @extend .utrecht-textbox;
+    }
+
+    &:disabled {
+      @extend .utrecht-textbox--disabled;
+    }
+
+    &:invalid,
+    &[aria-invalid="true"] {
+      @extend .utrecht-textbox--invalid;
+    }
+
+    &:read-only {
+      @extend .utrecht-textbox--read-only;
+    }
+  }
+}

--- a/src/textbox/html.stories.mdx
+++ b/src/textbox/html.stories.mdx
@@ -1,0 +1,112 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Robbert Broersma
+-->
+
+import { Meta, Story, Canvas, ArgsTable, Description, Source } from "@storybook/addon-docs/blocks";
+import { sanitize } from "dompurify"; // Helps with preventing injections via argstable
+import { MDXEmbedProvider } from "mdx-embed";
+import dedent from "ts-dedent";
+
+<!-- Import component and component styles -->
+
+import "./html.scss";
+
+<!-- Import Docs -->
+
+import README from "./README.md";
+
+export const Template = ({ type, value, invalid, readOnly, disabled, required }) =>
+  `<div class="utrecht-html">
+  <input type="${type}" ${invalid ? ' aria-invalid="true"' : ""}${disabled ? " disabled" : ""}${
+    required ? " required" : ""
+  }${readOnly ? "readonly" : ""} value="${value}">
+</div>`;
+
+<Meta
+  title="Semantic HTML/Text Box"
+  argTypes={{
+    value: {
+      description: "Set the value of the text box",
+      control: "text",
+      defaultValue: "The Quick Brown Fox Jumps Over The Lazy Dog",
+    },
+    invalid: {
+      description: "Invalid",
+      control: "boolean",
+      defaultValue: false,
+    },
+    readOnly: {
+      description: "Read-only",
+      control: "boolean",
+      defaultValue: false,
+    },
+    disabled: {
+      description: "Disabled",
+      control: "boolean",
+      defaultValue: false,
+    },
+    required: {
+      description: "Required",
+      control: "boolean",
+      defaultValue: false,
+    },
+    type: {
+      description: "Type",
+      control: "select",
+      defaultValue: "text",
+      options: ["email", "search", "tel", "text", "url"],
+    },
+  }}
+  parameters={{
+    docs: {
+      transformSource: (_src, { args }) => Template(args),
+    },
+    status: "IN DEVELOPMENT",
+    notes: {
+      UX: README,
+    },
+  }}
+/>
+
+# Text box component
+
+Styling via the `<input>` element:
+
+<Canvas>
+  <Story name="Text box">{Template.bind({})}</Story>
+</Canvas>
+
+<ArgsTable story="Text box" />
+
+## Invalid
+
+<Canvas>
+  <Story name="Invalid text box" args={{ invalid: true }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Disabled
+
+<Canvas>
+  <Story name="Disabled text box" args={{ disabled: true }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Read-only
+
+<Canvas>
+  <Story name="Read-only text box" args={{ readOnly: true }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+## Required
+
+<Canvas>
+  <Story name="Required text box" args={{ required: true }}>
+    {Template.bind({})}
+  </Story>
+</Canvas>

--- a/src/textbox/index.css
+++ b/src/textbox/index.css
@@ -1,0 +1,37 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+.utrecht-textbox {
+  border-width: var(--utrecht-textbox-border-width);
+  border-bottom-width: var(--utrecht-textbox-border-bottom-width, var(--utrecht-textbox-border-width));
+  border-color: var(--utrecht-textbox-border-color);
+  border-radius: var(--utrecht-textbox-border-radius, 0);
+  border-style: solid;
+  color: var(--utrecht-textbox-color);
+  font-family: var(--utrecht-textbox-font-family);
+  font-size: var(--utrecht-textbox-font-size, 1em);
+  max-width: var(--utrecht-textbox-max-width);
+  padding-block-end: var(--utrecht-textbox-padding-block-end);
+  padding-block-start: var(--utrecht-textbox-padding-block-start);
+  padding-inline-end: var(--utrecht-textbox-padding-inline-end);
+  padding-inline-start: var(--utrecht-textbox-padding-inline-start);
+  box-sizing: border-box;
+  width: 100%;
+}
+
+.utrecht-textbox--invalid {
+  border-color: var(--utrecht-textbox-invalid-border-color);
+  border-width: var(--utrecht-textbox-invalid-border-width);
+}
+
+.utrecht-textbox--disabled {
+  border-color: var(--utrecht-textbox-disabled-border-color);
+  color: var(--utrecht-textbox-disabled-color);
+}
+
+.utrecht-textbox--read-only {
+  border-color: var(--utrecht-textbox-read-only-border-color);
+  color: var(--utrecht-textbox-read-only-color);
+}


### PR DESCRIPTION
# Radio button

Voorzetje voor de Radio button component (backlog: #33 en nl-design-system/backlog#65)

## Terminologie

- **radio button**: "Radio button" heeft [een Wikipedia-lemma](https://en.wikipedia.org/wiki/Radio_button), [WAI-ARIA Authoring Practices 1.2](https://www.w3.org/TR/wai-aria-practices-1.2/#radiobutton) noemt het ook "radio button" en "radio group".
- **checked**: [WAI-ARIA Authoring Practices 1.2](https://www.w3.org/TR/wai-aria-practices-1.2/#radiobutton) en HTML noemen de staat van de radio button "checked", CSS heeft de `:checked` pseudo-class.

## Class names

- `.utrecht-radio-button`

## Design tokens

Nog geen design tokens.

---

# Button

Voorzetje voor Button component (backlog: #10 en nl-design-system/backlog#38).

## Terminologie

- **button**: van het `<button>` HTML element, `role="button"` in ARIA.

## States

- `hover`
- `focus`
- `disabled` (TODO)

## Class names

- `.utrecht-button`
- `.utrecht-button--focus`
- `.utrecht-button--hover`

## Design tokens

- Button
  - `--utrecht-button-border-width`
  - `--utrecht-button-focus-transform-scale`
  - `--utrecht-button-font-size`
  - `--utrecht-button-margin-block`
  - `--utrecht-button-margin-inline`
  - `--utrecht-button-padding-block`
  - `--utrecht-button-padding-inline`
  - Modifier: primary action
    - `--utrecht-button-primary-action-background-color`
    - `--utrecht-button-primary-action-color`
    - `--utrecht-button-primary-action-hover-background-color`

---

# Checkbox

Voorzetje voor Checkbox component (backlog: #32 en nl-design-system/backlog#64)

## Terminologie

- **checkbox**: `type="checkbox"` in HTML, [`role="checkbox"`](https://www.w3.org/TR/wai-aria-1.2/#checkbox) in WAI-ARIA 1.2, "checkbox" in [WAI-ARIA Authoring Practices](https://www.w3.org/TR/wai-aria-practices-1.2/#checkbox).
- **checked**: `checked` attribuut in HTML, `aria-checked="true"` in [WAI-ARIA](https://www.w3.org/TR/wai-aria-1.2/#aria-checked), `:checked` pseudo-class in CSS.

## States

- checked

## Class names

- `utrecht-checkbox`

## Design tokens

Nog geen.

---

# Text box

Voorzetje voor Text Box component (backlog: #30 en nl-design-system/backlog#5)

## Terminologie

- **textbox**: [`role="textbox"` in WAI-ARIA](https://www.w3.org/TR/wai-aria-1.2/#textbox), [Text box lemma op Wikipedia](https://en.wikipedia.org/wiki/Text_box). HTML noemt het "text control" en text edit control". [MDN noemt het](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/text) "text field" en "text input".
- **invalid**: ...
- **disabled**: ...
- **read-only**: ...

## States

- invalid
- disabled
- read-only

## Class names

- `.utrecht-textbox`
- `.utrecht-textbox--invalid`
- `.utrecht-textbox--disabled`
- `.utrecht-textbox--read-only`

## Design Tokens

- Textbox:
  - `--utrecht-textbox-border-bottom-width`
  - `--utrecht-textbox-border-color`
  - `--utrecht-textbox-border-radius`
  - `--utrecht-textbox-border-width`
  - `--utrecht-textbox-color`
  - `--utrecht-textbox-font-family`
  - `--utrecht-textbox-font-size`
  - `--utrecht-textbox-max-width`
  - `--utrecht-textbox-padding-block-end`
  - `--utrecht-textbox-padding-block-start`
  - `--utrecht-textbox-padding-inline-end`
  - `--utrecht-textbox-padding-inline-start`
  - Modifier: `disabled`
    - `--utrecht-textbox-disabled-border-color`
    - `--utrecht-textbox-disabled-color`
  - Modifier: `invalid`
    - `--utrecht-textbox-invalid-border-color`
    - `--utrecht-textbox-invalid-border-width`
  - Modifier: `read-only`:
    - `--utrecht-textbox-read-only-border-color`
    - `--utrecht-textbox-read-only-color`

---

# Textarea

Voorzetje voor Textarea component (backlog: #36 en nl-design-system/backlog#40)

## Terminologie

- **textarea**: van het `<textarea>` element in HTML.

## States

- invalid
- disabled
- read-only

## Class names

- `.utrecht-textarea`
- `.utrecht-textarea--invalid`
- `.utrecht-textarea--disabled`
- `.utrecht-textarea--read-only`

## Design tokens

- Textarea:
  - `--utrecht-textarea-border-bottom-width`
  - `--utrecht-textarea-border-color`
  - `--utrecht-textarea-border-radius`
  - `--utrecht-textarea-border-width`
  - `--utrecht-textarea-color`
  - `--utrecht-textarea-font-family`
  - `--utrecht-textarea-font-size`
  - `--utrecht-textarea-max-width`
  - `--utrecht-textarea-padding-block-end`
  - `--utrecht-textarea-padding-block-start`
  - `--utrecht-textarea-padding-inline-end`
  - `--utrecht-textarea-padding-inline-start`
  - Modifier: `disabled`
    - `--utrecht-textarea-disabled-border-color`
    - `--utrecht-textarea-disabled-color`
  - Modifier: `invalid`
    - `--utrecht-textarea-invalid-border-color`
    - `--utrecht-textarea-invalid-border-width`
  - Modifier: `read-only`:
    - `--utrecht-textarea-read-only-border-color`
    - `--utrecht-textarea-read-only-color`

---

# Radio button group

Voorzetje voor de Radio button group (backlog: #51)

---

# Checkbox group

Voorzetje voor de Checkbox group (backlog: #50)