### PR TITLE
config: avoid pre-commit error for files in ignore list

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,6 +1,6 @@
 {
-  "package.json": "npmPkgJsonLint",
+  "package.json": "npmPkgJsonLint --allowEmptyTargets",
   "*.md": "markdownlint",
-  "*.{js,jsx,ts,tsx}": "eslint",
-  "*.css": "stylelint"
+  "*.{js,jsx,ts,tsx}": "eslint --no-error-on-unmatched-pattern",
+  "*.css": "stylelint --allow-empty-input"
 }


### PR DESCRIPTION
Couple of days ago I added `.css` file that in a directory listed in `.stylelintignore`, which caused the pre-commit hook to fail because the lint tool errored with "no files matched the specified pattern". Allowing no matching files for the lint-staged commands will prevent that.