### PR TITLE
fix: start Storybook from root of monorepo for mdx support

### DIFF
--- a/components/blockquote/html.stories.mdx
+++ b/components/blockquote/html.stories.mdx
@@ -4,7 +4,7 @@ Copyright (c) 2021 Robbert Broersma
 Copyright (c) 2021 Gemeente Utrecht
 -->
 
-import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
+import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs/blocks";
 
 <!-- Import component and component styles -->
 

--- a/components/blockquote/stories.mdx
+++ b/components/blockquote/stories.mdx
@@ -3,7 +3,7 @@
 Copyright (c) 2021 Robbert Broersma
 -->
 
-import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
+import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs/blocks";
 import clsx from "clsx";
 
 <!-- Import component and component styles -->

--- a/components/button/button-html.stories.mdx
+++ b/components/button/button-html.stories.mdx
@@ -3,7 +3,7 @@
 Copyright (c) 2021 Robbert Broersma
 -->
 
-import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
+import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs/blocks";
 
 <!-- Import component and component styles -->
 

--- a/components/button/button.stories.mdx
+++ b/components/button/button.stories.mdx
@@ -4,7 +4,7 @@ Copyright (c) 2021 Gemeente Utrecht
 Copyright (c) 2021 Robbert Broersma
 -->
 
-import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
+import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs/blocks";
 import clsx from "clsx";
 
 import "./style.css";

--- a/components/favicon/stories.mdx
+++ b/components/favicon/stories.mdx
@@ -3,7 +3,7 @@
 Copyright (c) 2021 Robbert Broersma
 -->
 
-import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
+import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs/blocks";
 import README from "./README.md";
 
 export const Template = ({ href }) => `<link rel="icon" href="${href}">`;

--- a/components/form-field-checkbox/stories.mdx
+++ b/components/form-field-checkbox/stories.mdx
@@ -3,7 +3,7 @@
 Copyright (c) 2021 Robbert Broersma
 -->
 
-import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
+import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs/blocks";
 
 <!-- Import component and component styles -->
 

--- a/components/form-field-radio-group/stories.mdx
+++ b/components/form-field-radio-group/stories.mdx
@@ -3,7 +3,7 @@
 Copyright (c) 2021 Robbert Broersma
 -->
 
-import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
+import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs/blocks";
 
 <!-- Import component and component styles -->
 

--- a/components/form-field-radio/stories.mdx
+++ b/components/form-field-radio/stories.mdx
@@ -3,7 +3,7 @@
 Copyright (c) 2021 Robbert Broersma
 -->
 
-import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
+import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs/blocks";
 
 <!-- Import component and component styles -->
 

--- a/components/form-label/html.stories.mdx
+++ b/components/form-label/html.stories.mdx
@@ -3,7 +3,7 @@
 Copyright (c) 2021 Robbert Broersma
 -->
 
-import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
+import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs/blocks";
 
 <!-- Import component and component styles -->
 

--- a/components/form-label/stories.mdx
+++ b/components/form-label/stories.mdx
@@ -3,7 +3,7 @@
 Copyright (c) 2021 Robbert Broersma
 -->
 
-import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
+import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs/blocks";
 
 <!-- Import component and component styles -->
 

--- a/components/heading/html.stories.mdx
+++ b/components/heading/html.stories.mdx
@@ -3,7 +3,7 @@
 Copyright (c) 2021 Robbert Broersma
 -->
 
-import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
+import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs/blocks";
 
 <!-- Import component and component styles -->
 

--- a/components/heading/stories.mdx
+++ b/components/heading/stories.mdx
@@ -3,7 +3,7 @@
 Copyright (c) 2021 Robbert Broersma
 -->
 
-import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
+import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs/blocks";
 import clsx from "clsx";
 
 <!-- Import component and component styles -->

--- a/components/link/link-html.stories.mdx
+++ b/components/link/link-html.stories.mdx
@@ -3,7 +3,7 @@
 Copyright (c) 2021 Robbert Broersma
 -->
 
-import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
+import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs/blocks";
 
 <!-- Import component and component styles -->
 

--- a/components/link/link.stories.mdx
+++ b/components/link/link.stories.mdx
@@ -4,7 +4,7 @@ Copyright (c) 2021 Gemeente Utrecht
 Copyright (c) 2021 Robbert Broersma
 -->
 
-import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
+import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs/blocks";
 import clsx from "clsx";
 
 import "./style.css";

--- a/components/logo/logo.stories.mdx
+++ b/components/logo/logo.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
+import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs/blocks";
 
 <!-- Import component and component styles -->
 

--- a/components/menulijst/menulijst.stories.mdx
+++ b/components/menulijst/menulijst.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
+import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs/blocks";
 
 <!-- Import component and component styles -->
 

--- a/components/paragraph/html.stories.mdx
+++ b/components/paragraph/html.stories.mdx
@@ -3,7 +3,7 @@
 Copyright (c) 2021 Robbert Broersma
 -->
 
-import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
+import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs/blocks";
 
 <!-- Import component and component styles -->
 

--- a/components/paragraph/stories.mdx
+++ b/components/paragraph/stories.mdx
@@ -3,7 +3,7 @@
 Copyright (c) 2021 Robbert Broersma
 -->
 
-import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
+import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs/blocks";
 import clsx from "clsx";
 
 <!-- Import component and component styles -->

--- a/components/separator/html.stories.mdx
+++ b/components/separator/html.stories.mdx
@@ -3,7 +3,7 @@
 Copyright (c) 2021 Robbert Broersma
 -->
 
-import { Meta, Story, Canvas } from "@storybook/addon-docs";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 
 <!-- Import component and component styles -->
 

--- a/components/separator/stories.mdx
+++ b/components/separator/stories.mdx
@@ -3,7 +3,7 @@
 Copyright (c) 2021 Robbert Broersma
 -->
 
-import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
+import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs/blocks";
 
 <!-- Import component and component styles -->
 

--- a/components/textarea/html.stories.mdx
+++ b/components/textarea/html.stories.mdx
@@ -3,7 +3,7 @@
 Copyright (c) 2021 Robbert Broersma
 -->
 
-import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
+import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs/blocks";
 
 <!-- Import component and component styles -->
 

--- a/components/textbox/html.stories.mdx
+++ b/components/textbox/html.stories.mdx
@@ -3,7 +3,7 @@
 Copyright (c) 2021 Robbert Broersma
 -->
 
-import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
+import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs/blocks";
 
 <!-- Import component and component styles -->
 

--- a/components/unordered-list/html.stories.mdx
+++ b/components/unordered-list/html.stories.mdx
@@ -3,7 +3,7 @@
 Copyright (c) 2021 Robbert Broersma
 -->
 
-import { Meta, Story, Canvas } from "@storybook/addon-docs";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 
 <!-- Import component and component styles -->
 

--- a/components/unordered-list/stories.mdx
+++ b/components/unordered-list/stories.mdx
@@ -3,7 +3,7 @@
 Copyright (c) 2021 Robbert Broersma
 -->
 
-import { Meta, Story, Canvas } from "@storybook/addon-docs";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 
 <!-- Import component and component styles -->
 

--- a/documentation/colours.stories.mdx
+++ b/documentation/colours.stories.mdx
@@ -1,5 +1,5 @@
 import { getParams } from "./utils.js";
-import { Description, Meta } from "@storybook/addon-docs";
+import { Description, Meta } from "@storybook/addon-docs/blocks";
 import document from "./colours.md";
 
 <Meta title="Utrecht/Kleuren huisstijl" parameters={getParams()} />

--- a/documentation/content.stories.mdx
+++ b/documentation/content.stories.mdx
@@ -1,5 +1,5 @@
 import { getParams } from "./utils.js";
-import { Description, Meta } from "@storybook/addon-docs";
+import { Description, Meta } from "@storybook/addon-docs/blocks";
 import document from "./content-richtlijnen.md";
 
 <Meta title="Utrecht/Content Richtlijnen" parameters={getParams()} />

--- a/documentation/introduction.stories.mdx
+++ b/documentation/introduction.stories.mdx
@@ -1,5 +1,5 @@
 import { getParams } from "./utils.js";
-import { Meta, Description } from "@storybook/addon-docs";
+import { Meta, Description } from "@storybook/addon-docs/blocks";
 import document from "./introductie.md";
 
 <Meta title="Utrecht/Wat is het Utrecht Design System?" parameters={getParams()} />

--- a/documentation/permission.stories.mdx
+++ b/documentation/permission.stories.mdx
@@ -1,5 +1,5 @@
 import { getParams } from "./utils.js";
-import { Meta, Description } from "@storybook/addon-docs";
+import { Meta, Description } from "@storybook/addon-docs/blocks";
 import document from "../NOTICE.md";
 
 <Meta title="Utrecht/Toestemming voor gebruik" parameters={getParams()} />

--- a/documentation/research.stories.mdx
+++ b/documentation/research.stories.mdx
@@ -1,5 +1,5 @@
 import { getParams } from "./utils.js";
-import { Meta, Description } from "@storybook/addon-docs";
+import { Meta, Description } from "@storybook/addon-docs/blocks";
 import document from "./research.md";
 
 <Meta title="Utrecht/Gebruikersonderzoek" parameters={getParams()} />

--- a/documentation/research_0001.stories.mdx
+++ b/documentation/research_0001.stories.mdx
@@ -1,5 +1,5 @@
 import { getParams } from "./utils.js";
-import { Meta, Description } from "@storybook/addon-docs";
+import { Meta, Description } from "@storybook/addon-docs/blocks";
 import document from "./research_0001.md";
 
 <Meta title="Onderzoek/Online meldingen" parameters={getParams()} />

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "./proprietary/*"
       ],
       "devDependencies": {
+        "@storybook/html": "6.2.9",
         "clsx": "^1.1.1",
         "eslint": "7.13.0",
         "eslint-config-prettier": "8.3.0",
@@ -20197,18 +20198,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/listr2/node_modules/p-map": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-      "dev": true,
-      "dependencies": {
-        "aggregate-error": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/listr2/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -22266,12 +22255,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/npm-package-json-lint/node_modules/hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
-      "dev": true
-    },
     "node_modules/npm-package-json-lint/node_modules/ignore": {
       "version": "5.1.8",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
@@ -22317,27 +22300,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
-    },
-    "node_modules/npm-package-json-lint/node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "dev": true,
-      "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "node_modules/npm-package-json-lint/node_modules/normalize-package-data/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
     },
     "node_modules/npm-package-json-lint/node_modules/semver": {
       "version": "7.3.4",
@@ -22475,12 +22437,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/npm-run-all/node_modules/hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
-      "dev": true
-    },
     "node_modules/npm-run-all/node_modules/load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -22494,18 +22450,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/npm-run-all/node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "dev": true,
-      "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
       }
     },
     "node_modules/npm-run-all/node_modules/parse-json": {
@@ -25074,33 +25018,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/read-pkg/node_modules/hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
-      "dev": true
-    },
-    "node_modules/read-pkg/node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "dev": true,
-      "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "node_modules/read-pkg/node_modules/type-fest": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -27208,26 +27125,6 @@
         "lodash": "^4.17.20",
         "memoizerific": "^1.11.3",
         "qs": "^6.10.0",
-        "ts-dedent": "^2.0.0"
-      }
-    },
-    "node_modules/storybook-design-token/node_modules/@storybook/theming": {
-      "version": "6.2.9",
-      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.2.9.tgz",
-      "integrity": "sha512-183oJW7AD7Fhqg5NT4ct3GJntwteAb9jZnQ6yhf9JSdY+fk8OhxRbPf7ov0au2gYACcGrWDd9K5pYQsvWlP5gA==",
-      "dev": true,
-      "dependencies": {
-        "@emotion/core": "^10.1.1",
-        "@emotion/is-prop-valid": "^0.8.6",
-        "@emotion/styled": "^10.0.27",
-        "@storybook/client-logger": "6.2.9",
-        "core-js": "^3.8.2",
-        "deep-object-diff": "^1.1.0",
-        "emotion-theming": "^10.0.27",
-        "global": "^4.4.0",
-        "memoizerific": "^1.11.3",
-        "polished": "^4.0.5",
-        "resolve-from": "^5.0.0",
         "ts-dedent": "^2.0.0"
       }
     },
@@ -48792,15 +48689,6 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
-        "p-map": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-          "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-          "dev": true,
-          "requires": {
-            "aggregate-error": "^3.0.0"
-          }
-        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -50547,12 +50435,6 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
-        "hosted-git-info": {
-          "version": "2.8.8",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-          "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
-          "dev": true
-        },
         "ignore": {
           "version": "5.1.8",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
@@ -50589,26 +50471,6 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
-        },
-        "normalize-package-data": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-          "dev": true,
-          "requires": {
-            "hosted-git-info": "^2.1.4",
-            "resolve": "^1.10.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "5.7.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-              "dev": true
-            }
-          }
         },
         "semver": {
           "version": "7.3.4",
@@ -50712,12 +50574,6 @@
         "string.prototype.padend": "^3.0.0"
       },
       "dependencies": {
-        "hosted-git-info": {
-          "version": "2.8.8",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-          "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
-          "dev": true
-        },
         "load-json-file": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -50728,18 +50584,6 @@
             "parse-json": "^4.0.0",
             "pify": "^3.0.0",
             "strip-bom": "^3.0.0"
-          }
-        },
-        "normalize-package-data": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-          "dev": true,
-          "requires": {
-            "hosted-git-info": "^2.1.4",
-            "resolve": "^1.10.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
           }
         },
         "parse-json": {
@@ -52845,32 +52689,6 @@
         "normalize-package-data": "^2.5.0",
         "parse-json": "^5.0.0",
         "type-fest": "^0.6.0"
-      },
-      "dependencies": {
-        "hosted-git-info": {
-          "version": "2.8.8",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-          "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
-          "dev": true
-        },
-        "normalize-package-data": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-          "dev": true,
-          "requires": {
-            "hosted-git-info": "^2.1.4",
-            "resolve": "^1.10.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
-          }
-        },
-        "type-fest": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-          "dev": true
-        }
       }
     },
     "read-pkg-up": {
@@ -54733,26 +54551,6 @@
             "lodash": "^4.17.20",
             "memoizerific": "^1.11.3",
             "qs": "^6.10.0",
-            "ts-dedent": "^2.0.0"
-          }
-        },
-        "@storybook/theming": {
-          "version": "6.2.9",
-          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.2.9.tgz",
-          "integrity": "sha512-183oJW7AD7Fhqg5NT4ct3GJntwteAb9jZnQ6yhf9JSdY+fk8OhxRbPf7ov0au2gYACcGrWDd9K5pYQsvWlP5gA==",
-          "dev": true,
-          "requires": {
-            "@emotion/core": "^10.1.1",
-            "@emotion/is-prop-valid": "^0.8.6",
-            "@emotion/styled": "^10.0.27",
-            "@storybook/client-logger": "6.2.9",
-            "core-js": "^3.8.2",
-            "deep-object-diff": "^1.1.0",
-            "emotion-theming": "^10.0.27",
-            "global": "^4.4.0",
-            "memoizerific": "^1.11.3",
-            "polished": "^4.0.5",
-            "resolve-from": "^5.0.0",
             "ts-dedent": "^2.0.0"
           }
         },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "npm": ">=7"
   },
   "devDependencies": {
+    "@storybook/html": "6.2.9",
     "clsx": "^1.1.1",
     "eslint": "7.13.0",
     "eslint-config-prettier": "8.3.0",
@@ -39,6 +40,8 @@
   },
   "scripts": {
     "bootstrap": "lerna exec npm ci",
+    "build": "build-storybook --output-dir packages/storybook/dist/ --config-dir packages/storybook/.storybook --static-dir packages/storybook/src/style/,proprietary/assets/,proprietary/design-tokens/",
+    "clean": "rimraf packages/storybook/dist/",
     "lint": "npm-run-all --continue-on-error 'lint:*'",
     "lint:css": "stylelint '**/*.css'",
     "lint:js": "eslint '**/*.{js,jsx,mdx,ts,tsx}'",
@@ -51,6 +54,6 @@
     "lint-fix:js": "eslint --fix '**/*.{js,jsx,mdx,ts,tsx}'",
     "lint-fix:md": "markdownlint --fix '**/*.md'",
     "prettier": "prettier --write .",
-    "storybook": "lerna run --stream storybook"
+    "storybook": "start-storybook --config-dir packages/storybook/.storybook --static-dir packages/storybook/src/style/,proprietary/assets/,proprietary/design-tokens/"
   }
 }

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -40,10 +40,8 @@
     "http-server": "^0.12.3"
   },
   "scripts": {
-    "build": "build-storybook --output-dir dist/ -s src/style/,../../proprietary/assets/,../../proprietary/design-tokens/",
     "clean": "rimraf dist/",
     "percy-snapshot": "percy-storybook --build_dir dist/ --widths=1280",
-    "start": "node_modules/http-server/bin/http-server dist/",
-    "storybook": "start-storybook -p 6006 -s src/style/,../../proprietary/assets/,../../proprietary/design-tokens/"
+    "start": "node_modules/http-server/bin/http-server dist/"
   }
 }


### PR DESCRIPTION
Storybook does not currently support loading `.mdx` files from outside the package
or from inside node_modules/. This workaround is to start Storybook from the root
package of the monorepo that contains all `.mdx` files, so there is no issue.

Ideally we find a way to tweak the babel config to enable compilation of `.mdx`
files from any directory we fancy.

Also this PR reverts changes that only should have been merged after upgrading to Storybook 6.3.