### PR TITLE
feat: add `text-transform` design tokens for headings

### DIFF
--- a/components/heading/README.md
+++ b/components/heading/README.md
@@ -40,6 +40,7 @@ Om gemakkelijk alle headings in één keer te stylen, is er ook sprake van een s
   - `utrecht-heading-1-line-height`
   - `utrecht-heading-1-margin-block-end`
   - `utrecht-heading-1-margin-block-start`
+  - `utrecht-heading-1-text-transform`
 - Heading 2
   - `utrecht-heading-2-color`
   - `utrecht-heading-2-font-family`
@@ -48,6 +49,7 @@ Om gemakkelijk alle headings in één keer te stylen, is er ook sprake van een s
   - `utrecht-heading-2-line-height`
   - `utrecht-heading-2-margin-block-end`
   - `utrecht-heading-2-margin-block-start`
+  - `utrecht-heading-2-text-transform`
 - Heading 3
   - `utrecht-heading-3-color`
   - `utrecht-heading-3-font-family`
@@ -56,6 +58,7 @@ Om gemakkelijk alle headings in één keer te stylen, is er ook sprake van een s
   - `utrecht-heading-3-line-height`
   - `utrecht-heading-3-margin-block-end`
   - `utrecht-heading-3-margin-block-start`
+  - `utrecht-heading-3-text-transform`
 - Heading 4
   - `utrecht-heading-4-color`
   - `utrecht-heading-4-font-family`
@@ -64,6 +67,7 @@ Om gemakkelijk alle headings in één keer te stylen, is er ook sprake van een s
   - `utrecht-heading-4-line-height`
   - `utrecht-heading-4-margin-block-end`
   - `utrecht-heading-4-margin-block-start`
+  - `utrecht-heading-4-text-transform`
 - Heading 5
   - `utrecht-heading-5-color`
   - `utrecht-heading-5-font-family`
@@ -72,6 +76,7 @@ Om gemakkelijk alle headings in één keer te stylen, is er ook sprake van een s
   - `utrecht-heading-5-line-height`
   - `utrecht-heading-5-margin-block-end`
   - `utrecht-heading-5-margin-block-start`
+  - `utrecht-heading-5-text-transform`
 - Heading 6
   - `utrecht-heading-6-color`
   - `utrecht-heading-6-font-family`
@@ -80,6 +85,7 @@ Om gemakkelijk alle headings in één keer te stylen, is er ook sprake van een s
   - `utrecht-heading-6-line-height`
   - `utrecht-heading-6-margin-block-end`
   - `utrecht-heading-6-margin-block-start`
+  - `utrecht-heading-6-text-transform`
 
 Of de `*-margin-block-start` en `*-margin-block-end` design tokens effect moeten hebben op de Heading components in elke context is nog de vraag: mogelijk willen we alleen marges toepassen in een bepaalde context, zoals binnen de Rich text component.
 

--- a/components/heading/index.css
+++ b/components/heading/index.css
@@ -14,6 +14,7 @@
   font-weight: var(--utrecht-heading-1-font-weight, var(--utrecht-heading-font-weight, bold));
   line-height: var(--utrecht-heading-1-line-height);
   color: var(--utrecht-heading-1-color, var(--utrecht-heading-color, inherit));
+  text-transform: var(--utrecht-heading-1-text-transform, inherit);
 }
 
 .utrecht-heading-1--distanced {
@@ -30,6 +31,7 @@
   font-weight: var(--utrecht-heading-2-font-weight, var(--utrecht-heading-font-weight, bold));
   line-height: var(--utrecht-heading-2-line-height);
   color: var(--utrecht-heading-2-color, var(--utrecht-heading-color, inherit));
+  text-transform: var(--utrecht-heading-2-text-transform, inherit);
 }
 
 .utrecht-heading-2--distanced {
@@ -46,6 +48,7 @@
   font-weight: var(--utrecht-heading-3-font-weight, var(--utrecht-heading-font-weight, bold));
   line-height: var(--utrecht-heading-3-line-height);
   color: var(--utrecht-heading-3-color, var(--utrecht-heading-color, inherit));
+  text-transform: var(--utrecht-heading-3-text-transform, inherit);
 }
 
 .utrecht-heading-3--distanced {
@@ -62,6 +65,7 @@
   font-weight: var(--utrecht-heading-4-font-weight, var(--utrecht-heading-font-weight, bold));
   line-height: var(--utrecht-heading-4-line-height);
   color: var(--utrecht-heading-4-color, var(--utrecht-heading-color, inherit));
+  text-transform: var(--utrecht-heading-4-text-transform, inherit);
 }
 
 .utrecht-heading-4--distanced {
@@ -78,6 +82,7 @@
   font-weight: var(--utrecht-heading-5-font-weight, var(--utrecht-heading-font-weight, bold));
   line-height: var(--utrecht-heading-5-line-height);
   color: var(--utrecht-heading-5-color, var(--utrecht-heading-color, inherit));
+  text-transform: var(--utrecht-heading-5-text-transform, inherit);
 }
 
 .utrecht-heading-5--distanced {
@@ -94,6 +99,7 @@
   font-weight: var(--utrecht-heading-6-font-weight, var(--utrecht-heading-font-weight, bold));
   line-height: var(--utrecht-heading-6-line-height);
   color: var(--utrecht-heading-6-color, var(--utrecht-heading-color, inherit));
+  text-transform: var(--utrecht-heading-6-text-transform, inherit);
 }
 
 .utrecht-heading-6--distanced {

--- a/proprietary/design-tokens/src/component/_heading.scss
+++ b/proprietary/design-tokens/src/component/_heading.scss
@@ -22,11 +22,11 @@
  * @presenter FontWeight
  */
 :root {
-  --utrecht-heading-font-weight: var(--utrecht-font-bold);
-  --utrecht-heading-3-font-weight: var(--utrecht-font-normal);
-  --utrecht-heading-4-font-weight: var(--utrecht-font-normal);
-  --utrecht-heading-5-font-weight: var(--utrecht-font-normal);
-  --utrecht-heading-6-font-weight: var(--utrecht-font-normal);
+  --utrecht-heading-font-weight: bold;
+  --utrecht-heading-3-font-weight: normal;
+  --utrecht-heading-4-font-weight: normal;
+  --utrecht-heading-5-font-weight: normal;
+  --utrecht-heading-6-font-weight: normal;
 }
 
 /**


### PR DESCRIPTION
The heading in the page footer component needs a custom `text-transform`:

<img width="295" alt="Screenshot 2021-06-25 at 18 18 52" src="https://user-images.githubusercontent.com/30694/123455327-daca9700-d5e1-11eb-8841-2e1e49c35578.png">

This PR includes the `text-transform` design token for every heading level (1-6).

Aditionally the Heading 5 and Heading 6 in the regular body text also need text-transform. For this the design token was already defined in the theme even though the component didn't support it yet.

Investigating this I also noticed the font-weight was incorrectly bold for h3-h6.