### PR TITLE
fix: make `npm run storybook` work on windows

### DIFF
--- a/packages/web-component-library-stencil/package.json
+++ b/packages/web-component-library-stencil/package.json
@@ -44,7 +44,7 @@
     "clean": "rimraf dist/",
     "start": "stencil build --dev --watch --serve",
     "watch": "npm-run-all --parallel watch:**",
-    "watch:stencil": "chokidar --follow-symlinks --initial --command 'npm run build:stencil' '../../components/**/*.(js|jsx|ts|tsx)'",
+    "watch:stencil": "chokidar --follow-symlinks --initial --command \"npm run build:stencil\" \"../../components/**/*.(js|jsx|ts|tsx)\"",
     "generate": "stencil generate"
   }
 }


### PR DESCRIPTION
there was a problem in my system because it is windows and that problem is now solved