### PR TITLE
fix: add .idea to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ tmp/
 .vscode/
 *.sublime-workspace
 .vs/
+.idea/
 
 # Ignore OS files
 .DS_Store


### PR DESCRIPTION
Files generated by JetBrains IDEs were are not yet present in the gitignore. This PR adds the `.idea/` folder to the gitignore.