### PR TITLE
docs: use correct orientation terms for spacing

### DIFF
--- a/documentation/space.stories.mdx
+++ b/documentation/space.stories.mdx
@@ -38,7 +38,7 @@ Space inside components, use between text and other types of text or icons.
 
 ## Distance between components: columns
 
-To create distance vertically between components, you can use the following tokens for the following properties:
+To create distance horizontally between components, you can use the following tokens for the following properties:
 
 - `margin-inline-start`
 - `margin-inline-end`
@@ -49,7 +49,7 @@ To create distance vertically between components, you can use the following toke
 
 ## Distance between components: rows
 
-To create distance horizontally between components, you can use the following tokens for the following properties:
+To create distance vertically between components, you can use the following tokens for the following properties:
 
 - `margin-block-start`
 - `margin-block-end`


### PR DESCRIPTION
Stumbled across a very confusing mixup of these two words while reading the docs for spacing tokens