### PR TITLE
refactor: move BEM template code from `.mdx` to `.js` files

### DIFF
--- a/components/alternate-lang-link/bem.js
+++ b/components/alternate-lang-link/bem.js
@@ -1,0 +1,21 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+import clsx from 'clsx';
+
+export const defaultArgs = {
+  current: false,
+  hreflang: '',
+  lang: '',
+  textContent: '',
+  title: '',
+};
+
+export const AlternateLangLink = ({ textContent = '', title = '', current = false, lang = '', hreflang = '' }) =>
+  `<a href="https://example.com/${lang}/" class="${clsx('utrecht-link', 'utrecht-link--alternate-lang', {
+    'utrecht-link--current-lang': current,
+  })}"${current ? ' aria-current="page"' : ''}${title ? ` title="${title}"` : ''}${
+    hreflang ? ` hreflang="${hreflang}"` : ''
+  }${lang ? ` lang="${lang}"` : ''}${!current ? ' rel="alternate"' : ''}>${textContent}</a>`;

--- a/components/alternate-lang-link/bem.stories.mdx
+++ b/components/alternate-lang-link/bem.stories.mdx
@@ -4,24 +4,9 @@ Copyright (c) 2021 Robbert Broersma
 -->
 
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-import clsx from "clsx";
 import "../link/bem.scss";
 import "./bem.scss";
-
-export const defaultArgs = {
-  current: false,
-  hreflang: "",
-  lang: "",
-  textContent: "",
-  title: "",
-};
-
-export const AlternateLangLink = ({ textContent = "", title = "", current = false, lang = "", hreflang = "" }) =>
-  `<a href="https://example.com/${lang}/" class="${clsx("utrecht-link", "utrecht-link--alternate-lang", {
-    "utrecht-link--current-lang": current,
-  })}"${current ? ' aria-current="page"' : ""}${title ? ` title="${title}"` : ""}${
-    hreflang ? ` hreflang="${hreflang}"` : ""
-  }${lang ? ` lang="${lang}"` : ""}${!current ? ' rel="alternate"' : ""}>${textContent}</a>`;
+import { defaultArgs, AlternateLangLink } from "./bem";
 
 <Meta
   title="CSS Component/Alternate Language Link"

--- a/components/alternate-lang-nav/bem.js
+++ b/components/alternate-lang-nav/bem.js
@@ -1,0 +1,12 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+import { AlternateLangLink } from '../alternate-lang-link/bem';
+
+export const AlternateLangNav = ({ languages }) =>
+  `<div class="utrecht-alternate-lang-nav">
+${languages.map(AlternateLangLink).join('\n<span aria-hidden="true"> | </span>\n')}
+</div>`;

--- a/components/alternate-lang-nav/bem.stories.mdx
+++ b/components/alternate-lang-nav/bem.stories.mdx
@@ -5,13 +5,8 @@ Copyright (c) 2021 Robbert Broersma
 -->
 
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-import { AlternateLangLink } from "../alternate-lang-link/bem.stories.mdx";
+import { AlternateLangNav } from "./bem";
 import "../link/bem.scss";
-
-export const AlternateLangNav = ({ languages }) =>
-  `<div class="utrecht-alternate-lang-nav">
-${languages.map(AlternateLangLink).join('\n<span aria-hidden="true"> | </span>\n')}
-</div>`;
 
 <Meta
   title="CSS Component/Alternate Language Navigation"

--- a/components/article/bem.js
+++ b/components/article/bem.js
@@ -1,0 +1,6 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+export const Article = ({ content }) => `<div class="utrecht-article">${content}</div>`;

--- a/components/article/bem.stories.mdx
+++ b/components/article/bem.stories.mdx
@@ -4,10 +4,8 @@ Copyright (c) 2021 Robbert Broersma
 -->
 
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-
+import { Article } from "./bem";
 import "./bem.scss";
-
-export const Template = ({ content }) => `<div class="utrecht-article">${content}</div>`;
 
 <Meta
   title="CSS Component/Article"
@@ -19,7 +17,7 @@ export const Template = ({ content }) => `<div class="utrecht-article">${content
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => Article(args),
     },
     status: {
       type: "WORK IN PROGRESS",
@@ -43,7 +41,7 @@ pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui offi
 laborum.</p>`,
     }}
   >
-    {Template.bind({})}
+    {Article.bind({})}
   </Story>
 </Canvas>
 

--- a/components/badge-counter/bem.js
+++ b/components/badge-counter/bem.js
@@ -1,0 +1,7 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+export const BadgeCounter = ({ textContent = '' }) =>
+  `<span class="utrecht-badge-counter"><span class="utrecht-badge-counter__text">${textContent}</span></span>`;

--- a/components/badge-counter/bem.stories.mdx
+++ b/components/badge-counter/bem.stories.mdx
@@ -4,11 +4,8 @@ Copyright (c) 2021 Robbert Broersma
 -->
 
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-
+import { BadgeCounter } from "./bem";
 import "./bem.scss";
-
-export const Template = ({ textContent = "" }) =>
-  `<span class="utrecht-badge-counter"><span class="utrecht-badge-counter__text">${textContent}</span></span>`;
 
 <Meta
   title="CSS Component/Badge/Counter Badge"
@@ -28,7 +25,7 @@ export const Template = ({ textContent = "" }) =>
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => BadgeCounter(args),
     },
     status: {
       type: "WORK IN PROGRESS",
@@ -47,7 +44,7 @@ Styling via the `.utrecht-badge-counter` class name:
       textContent: "42",
     }}
   >
-    {Template.bind({})}
+    {BadgeCounter.bind({})}
   </Story>
 </Canvas>
 

--- a/components/badge-data/bem.js
+++ b/components/badge-data/bem.js
@@ -1,0 +1,6 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+export const BadgeData = ({ textContent = '' }) => `<div class="utrecht-badge-data">${textContent}</div>`;

--- a/components/badge-data/bem.stories.mdx
+++ b/components/badge-data/bem.stories.mdx
@@ -4,10 +4,8 @@ Copyright (c) 2021 Robbert Broersma
 -->
 
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-
+import { BadgeData } from "./bem.js";
 import "./bem.scss";
-
-export const Template = ({ textContent = "" }) => `<div class="utrecht-badge-data">${textContent}</div>`;
 
 <Meta
   title="CSS Component/Badge/Data Badge"
@@ -19,7 +17,7 @@ export const Template = ({ textContent = "" }) => `<div class="utrecht-badge-dat
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => BadgeData(args),
     },
     status: {
       type: "WORK IN PROGRESS",
@@ -38,7 +36,7 @@ Styling via the `.utrecht-badge-data` class name:
       textContent: "Festivals",
     }}
   >
-    {Template.bind({})}
+    {BadgeData.bind({})}
   </Story>
 </Canvas>
 

--- a/components/badge-status/bem.js
+++ b/components/badge-status/bem.js
@@ -1,0 +1,7 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+export const BadgeStatus = ({ status = '', textContent = '' }) =>
+  `<div class="utrecht-badge-status utrecht-badge-status--${status ? status : 'neutral'}">${textContent}</div>`;

--- a/components/badge-status/bem.stories.mdx
+++ b/components/badge-status/bem.stories.mdx
@@ -4,11 +4,8 @@ Copyright (c) 2021 Robbert Broersma
 -->
 
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-
+import { BadgeStatus } from "./bem.js";
 import "./bem.scss";
-
-export const Template = ({ status = "", textContent = "" }) =>
-  `<div class="utrecht-badge-status utrecht-badge-status--${status ? status : "neutral"}">${textContent}</div>`;
 
 <Meta
   title="CSS Component/Badge/Status Badge"
@@ -25,7 +22,7 @@ export const Template = ({ status = "", textContent = "" }) =>
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => BadgeStatus(args),
     },
     status: {
       type: "WORK IN PROGRESS",
@@ -45,7 +42,7 @@ export const Template = ({ status = "", textContent = "" }) =>
       textContent: "neutral",
     }}
   >
-    {Template.bind({})}
+    {BadgeStatus.bind({})}
   </Story>
 </Canvas>
 
@@ -61,7 +58,7 @@ export const Template = ({ status = "", textContent = "" }) =>
       textContent: "danger",
     }}
   >
-    {Template.bind({})}
+    {BadgeStatus.bind({})}
   </Story>
 </Canvas>
 
@@ -75,7 +72,7 @@ export const Template = ({ status = "", textContent = "" }) =>
       textContent: "warning",
     }}
   >
-    {Template.bind({})}
+    {BadgeStatus.bind({})}
   </Story>
 </Canvas>
 
@@ -89,7 +86,7 @@ export const Template = ({ status = "", textContent = "" }) =>
       textContent: "safe",
     }}
   >
-    {Template.bind({})}
+    {BadgeStatus.bind({})}
   </Story>
 </Canvas>
 
@@ -103,7 +100,7 @@ export const Template = ({ status = "", textContent = "" }) =>
       textContent: "invalid",
     }}
   >
-    {Template.bind({})}
+    {BadgeStatus.bind({})}
   </Story>
 </Canvas>
 
@@ -117,7 +114,7 @@ export const Template = ({ status = "", textContent = "" }) =>
       textContent: "valid",
     }}
   >
-    {Template.bind({})}
+    {BadgeStatus.bind({})}
   </Story>
 </Canvas>
 
@@ -131,7 +128,7 @@ export const Template = ({ status = "", textContent = "" }) =>
       textContent: "error",
     }}
   >
-    {Template.bind({})}
+    {BadgeStatus.bind({})}
   </Story>
 </Canvas>
 
@@ -145,7 +142,7 @@ export const Template = ({ status = "", textContent = "" }) =>
       textContent: "success",
     }}
   >
-    {Template.bind({})}
+    {BadgeStatus.bind({})}
   </Story>
 </Canvas>
 
@@ -159,7 +156,7 @@ export const Template = ({ status = "", textContent = "" }) =>
       textContent: "inactive",
     }}
   >
-    {Template.bind({})}
+    {BadgeStatus.bind({})}
   </Story>
 </Canvas>
 
@@ -173,6 +170,6 @@ export const Template = ({ status = "", textContent = "" }) =>
       textContent: "active",
     }}
   >
-    {Template.bind({})}
+    {BadgeStatus.bind({})}
   </Story>
 </Canvas>

--- a/components/blockquote/bem.js
+++ b/components/blockquote/bem.js
@@ -1,0 +1,24 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+import clsx from 'clsx';
+
+export const defaultArgs = {
+  textContent: '',
+  attribution: null,
+  distanced: false,
+};
+
+export const Blockquote = ({ textContent = '', attribution = null, distanced = false }) =>
+  `<blockquote class="${clsx('utrecht-blockquote', { 'utrecht-blockquote--distanced': distanced })}">
+  <div class="utrecht-blockquote__content">
+    <p>${textContent}</p>${
+    attribution
+      ? `
+    <div class="utrecht-blockquote__attribution">${attribution}</div>`
+      : ''
+  }
+  </div>
+</blockquote>`;

--- a/components/blockquote/bem.stories.mdx
+++ b/components/blockquote/bem.stories.mdx
@@ -4,26 +4,8 @@ Copyright (c) 2021 Robbert Broersma
 -->
 
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-import clsx from "clsx";
 import "./bem.scss";
-
-export const defaultArgs = {
-  textContent: "",
-  attribution: null,
-  distanced: false,
-};
-
-export const Template = ({ textContent = "", attribution = null, distanced = false }) =>
-  `<blockquote class="${clsx("utrecht-blockquote", { "utrecht-blockquote--distanced": distanced })}">
-  <div class="utrecht-blockquote__content">
-    <p>${textContent}</p>${
-    attribution
-      ? `
-    <div class="utrecht-blockquote__attribution">${attribution}</div>`
-      : ""
-  }
-  </div>
-</blockquote>`;
+import { defaultArgs, Blockquote } from "./bem.js";
 
 <Meta
   title="CSS Component/Blockquote"
@@ -43,7 +25,7 @@ export const Template = ({ textContent = "", attribution = null, distanced = fal
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => Blockquote(args),
     },
     status: {
       type: "WORK IN PROGRESS",
@@ -64,7 +46,7 @@ Styling via the `.utrecht-blockquote` and `.utrecht-blockquote__content` class n
       textContent: "The Quick Brown Fox Jumps Over The Lazy Dog",
     }}
   >
-    {Template.bind({})}
+    {Blockquote.bind({})}
   </Story>
 </Canvas>
 
@@ -83,6 +65,6 @@ Styling with an additional `.utrecht-blockquote__attribution` class name:
       textContent: "The Quick Brown Fox Jumps Over The Lazy Dog",
     }}
   >
-    {Template.bind({})}
+    {Blockquote.bind({})}
   </Story>
 </Canvas>

--- a/components/breadcrumb/bem.js
+++ b/components/breadcrumb/bem.js
@@ -1,0 +1,34 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+import clsx from 'clsx';
+
+export const Breadcrumb = ({ items, microdata, variant }) => `<nav class="${clsx(
+  'utrecht-breadcrumb',
+  variant === 'arrows' && 'utrecht-breadcrumb--arrows',
+)}">
+  <ol class="utrecht-breadcrumb__list"${
+    microdata ? ' itemscope itemtype="https://schema.org/BreadcrumbList"' : ''
+  }>${items
+  .map(
+    ({ href, title, current, focus }, index) => `
+    <li class="utrecht-breadcrumb__item"${
+      microdata ? ' itemscope itemtype="https://schema.org/ListItem" itemprop="itemListElement"' : ''
+    }>
+      <a class="${clsx(
+        'utrecht-breadcrumb__link',
+        focus && 'utrecht-breadcrumb__link--focus',
+        'utrecht-link',
+        current && 'utrecht-link--current',
+        focus && 'utrecht-link--focus',
+      )}" href="${href}"${current ? ' aria-current="location"' : ''}${microdata ? ' itemprop="item"' : ''}>
+      <span class="utrecht-breadcrumb__text"${microdata ? ' itemprop="name"' : ''}>${title}</span>
+      ${microdata ? `<meta itemprop="position" content="${index + 1}" />` : ''}
+    </a>
+      </li>`,
+  )
+  .join('\n')}
+  </ol>
+</nav>`;

--- a/components/breadcrumb/bem.stories.mdx
+++ b/components/breadcrumb/bem.stories.mdx
@@ -4,35 +4,8 @@ Copyright (c) 2021 Robbert Broersma
 -->
 
 import { ArgsTable, Meta, Story, Canvas } from "@storybook/addon-docs";
-import clsx from "clsx";
+import { Breadcrumb } from "./bem.js";
 import "./bem.scss";
-export const Template = ({ items, microdata, variant }) => `<nav class="${clsx(
-  "utrecht-breadcrumb",
-  variant === "arrows" && "utrecht-breadcrumb--arrows"
-)}">
-  <ol class="utrecht-breadcrumb__list"${
-    microdata ? ' itemscope itemtype="https://schema.org/BreadcrumbList"' : ""
-  }>${items
-  .map(
-    ({ href, title, current, focus }, index) => `
-    <li class="utrecht-breadcrumb__item"${
-      microdata ? ' itemscope itemtype="https://schema.org/ListItem" itemprop="itemListElement"' : ""
-    }>
-      <a class="${clsx(
-        "utrecht-breadcrumb__link",
-        focus && "utrecht-breadcrumb__link--focus",
-        "utrecht-link",
-        current && "utrecht-link--current",
-        focus && "utrecht-link--focus"
-      )}" href="${href}"${current ? ' aria-current="location"' : ""}${microdata ? ' itemprop="item"' : ""}>
-      <span class="utrecht-breadcrumb__text"${microdata ? ' itemprop="name"' : ""}>${title}</span>
-      ${microdata ? `<meta itemprop="position" content="${index + 1}" />` : ""}
-    </a>
-      </li>`
-  )
-  .join("\n")}
-  </ol>
-</nav>`;
 
 <Meta
   title="CSS Component/Breadcrumb navigation"
@@ -56,7 +29,7 @@ export const Template = ({ items, microdata, variant }) => `<nav class="${clsx(
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => Breadcrumb(args),
     },
     status: "IN DEVELOPMENT",
   }}
@@ -78,7 +51,7 @@ export const Template = ({ items, microdata, variant }) => `<nav class="${clsx(
       variant: "arrows",
     }}
   >
-    {Template.bind({})}
+    {Breadcrumb.bind({})}
   </Story>
 </Canvas>
 

--- a/components/button/bem.js
+++ b/components/button/bem.js
@@ -1,0 +1,21 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+import clsx from 'clsx';
+
+export const defaultArgs = {
+  disabled: false,
+  focus: false,
+  hover: false,
+  textContent: '',
+};
+
+export const Button = ({ textContent = '', focus = false, hover = false, disabled = false }) =>
+  `<button class="${clsx('utrecht-button', {
+    'utrecht-button--hover': hover,
+    'utrecht-button--focus': focus,
+    'utrecht-button--disabled': disabled,
+  })}"${disabled ? ' aria-disabled="true"' : ''}>${textContent}</button>`;

--- a/components/button/bem.stories.mdx
+++ b/components/button/bem.stories.mdx
@@ -5,23 +5,9 @@ Copyright (c) 2021 Robbert Broersma
 -->
 
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-import clsx from "clsx";
+import { defaultArgs, Button } from "./bem";
 
 import "./bem.scss";
-
-export const defaultArgs = {
-  disabled: false,
-  focus: false,
-  hover: false,
-  textContent: "",
-};
-
-export const Template = ({ textContent = "", focus = false, hover = false, disabled = false }) =>
-  `<button class="${clsx("utrecht-button", {
-    "utrecht-button--hover": hover,
-    "utrecht-button--focus": focus,
-    "utrecht-button--disabled": disabled,
-  })}"${disabled ? ' aria-disabled="true"' : ""}>${textContent}</button>`;
 
 <Meta
   title="CSS Component/Button"
@@ -45,7 +31,7 @@ export const Template = ({ textContent = "", focus = false, hover = false, disab
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => Button(args),
     },
     status: {
       type: "WORK IN PROGRESS",
@@ -65,7 +51,7 @@ Styling via the `.utrecht-button` class name:
       textContent: "Read more...",
     }}
   >
-    {Template.bind({})}
+    {Button.bind({})}
   </Story>
 </Canvas>
 
@@ -85,7 +71,7 @@ Styling via the `.utrecht-button--hover` class name:
       hover: true,
     }}
   >
-    {Template.bind({})}
+    {Button.bind({})}
   </Story>
 </Canvas>
 
@@ -101,7 +87,7 @@ Styling via the `.utrecht-button--focus` class name:
       focus: true,
     }}
   >
-    {Template.bind({})}
+    {Button.bind({})}
   </Story>
 </Canvas>
 
@@ -117,6 +103,6 @@ Styling via the `.utrecht-button--disabled` class name:
       disabled: true,
     }}
   >
-    {Template.bind({})}
+    {Button.bind({})}
   </Story>
 </Canvas>

--- a/components/emphasis/bem.js
+++ b/components/emphasis/bem.js
@@ -1,0 +1,19 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+import clsx from 'clsx';
+
+export const defaultArgs = {
+  stressed: false,
+  strong: false,
+  textContent: '',
+};
+
+export const Emphasis = ({ textContent = '', stressed = false, strong = false }) =>
+  `<span class="${clsx(
+    'utrecht-emphasis',
+    stressed && 'utrecht-emphasis--stressed',
+    strong && 'utrecht-emphasis--strong',
+  )}">${textContent}</span>`;

--- a/components/emphasis/bem.stories.mdx
+++ b/components/emphasis/bem.stories.mdx
@@ -4,21 +4,8 @@ Copyright (c) 2021 Robbert Broersma
 -->
 
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-import clsx from "clsx";
 import "./bem.scss";
-
-export const defaultArgs = {
-  stressed: false,
-  strong: false,
-  textContent: "",
-};
-
-export const Template = ({ textContent = "", stressed = false, strong = false }) =>
-  `<span class="${clsx(
-    "utrecht-emphasis",
-    stressed && "utrecht-emphasis--stressed",
-    strong && "utrecht-emphasis--strong"
-  )}">${textContent}</span>`;
+import { defaultArgs, Emphasis } from "./bem";
 
 <Meta
   title="CSS Component/Emphasis"
@@ -38,7 +25,7 @@ export const Template = ({ textContent = "", stressed = false, strong = false })
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => Emphasis(args),
     },
     status: {
       type: "WORK IN PROGRESS",
@@ -57,7 +44,7 @@ export const Template = ({ textContent = "", stressed = false, strong = false })
       textContent: "The Quick Brown Fox Jumps Over The Lazy Dog",
     }}
   >
-    {Template.bind({})}
+    {Emphasis.bind({})}
   </Story>
 </Canvas>
 
@@ -73,6 +60,6 @@ export const Template = ({ textContent = "", stressed = false, strong = false })
       textContent: "The Quick Brown Fox Jumps Over The Lazy Dog",
     }}
   >
-    {Template.bind({})}
+    {Emphasis.bind({})}
   </Story>
 </Canvas>

--- a/components/form-field-checkbox-group/bem.js
+++ b/components/form-field-checkbox-group/bem.js
@@ -1,0 +1,33 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+export const FormFieldCheckboxGroup = ({
+  label,
+  options,
+  groupLabelId = 'group-label',
+}) => `<div class="utrecht-form-field-checkbox-group utrecht-form-field-checkbox-group--distanced" role="group" aria-labelledby="${groupLabelId}">
+  <div class="utrecht-form-field-checkbox-group__label utrecht-form-label" id="${groupLabelId}">${label}</div>
+  ${options
+    .map((option, index) => ({
+      ...option,
+      id: options.id || `option-${index}`,
+    }))
+    .map(
+      ({
+        id,
+        label,
+        name,
+        value,
+        checked,
+      }) => `<div class="utrecht-form-field utrecht-form-field--checkbox utrecht-form-field--distanced">
+    <input type="checkbox" class="utrecht-form-field__input utrecht-checkbox" id="${id}" value="${value}"${
+        checked ? ' checked' : ''
+      } name="${name}">
+    <label class="utrecht-form-field__label utrecht-form-field__label--checkbox utrecht-form-label utrecht-form-label--checkbox" for="${id}">${label}</label>
+  </div>`,
+    )
+    .join('\n')}
+  </div>`;

--- a/components/form-field-checkbox-group/bem.stories.mdx
+++ b/components/form-field-checkbox-group/bem.stories.mdx
@@ -8,33 +8,7 @@ import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
 import "./bem.scss";
 import "../checkbox/bem.scss";
 import "../form-label/bem.scss";
-export const Template = ({
-  label,
-  options,
-  groupLabelId = "group-label",
-}) => `<div class="utrecht-form-field-checkbox-group utrecht-form-field-checkbox-group--distanced" role="group" aria-labelledby="${groupLabelId}">
-  <div class="utrecht-form-field-checkbox-group__label utrecht-form-label" id="${groupLabelId}">${label}</div>
-  ${options
-    .map((option, index) => ({
-      ...option,
-      id: options.id || `option-${index}`,
-    }))
-    .map(
-      ({
-        id,
-        label,
-        name,
-        value,
-        checked,
-      }) => `<div class="utrecht-form-field utrecht-form-field--checkbox utrecht-form-field--distanced">
-    <input type="checkbox" class="utrecht-form-field__input utrecht-checkbox" id="${id}" value="${value}"${
-        checked ? " checked" : ""
-      } name="${name}">
-    <label class="utrecht-form-field__label utrecht-form-field__label--checkbox utrecht-form-label utrecht-form-label--checkbox" for="${id}">${label}</label>
-  </div>`
-    )
-    .join("\n")}
-  </div>`;
+import { FormFieldCheckboxGroup } from "./bem";
 
 <Meta
   title="CSS Component/Form field with checkbox group"
@@ -53,7 +27,7 @@ export const Template = ({
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => FormFieldCheckboxGroup(args),
     },
     status: {
       type: "WORK IN PROGRESS",
@@ -88,7 +62,7 @@ export const Template = ({
       ],
     }}
   >
-    {Template.bind({})}
+    {FormFieldCheckboxGroup.bind({})}
   </Story>
 </Canvas>
 

--- a/components/form-field-checkbox/bem.js
+++ b/components/form-field-checkbox/bem.js
@@ -1,0 +1,10 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+export const FormFieldCheckbox = ({ label = '' }) =>
+  `<div class="utrecht-form-field utrecht-form-field--checkbox utrecht-form-field--distanced">
+    <input type="checkbox" class="utrecht-form-field__input utrecht-checkbox" id="id-ce0239e2">
+  <label class="utrecht-form-field__label utrecht-form-field__label--checkbox utrecht-form-label utrecht-form-label--checkbox" for="id-ce0239e2">${label}</label>
+</div>`;

--- a/components/form-field-checkbox/bem.stories.mdx
+++ b/components/form-field-checkbox/bem.stories.mdx
@@ -4,16 +4,10 @@ Copyright (c) 2021 Robbert Broersma
 -->
 
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-
+import { FormFieldCheckbox } from "./bem";
 import "./bem.scss";
 import "../checkbox/bem.scss";
 import "../form-label/bem.scss";
-
-export const Template = ({ label = "" }) =>
-  `<div class="utrecht-form-field utrecht-form-field--checkbox utrecht-form-field--distanced">
-    <input type="checkbox" class="utrecht-form-field__input utrecht-checkbox" id="id-ce0239e2">
-  <label class="utrecht-form-field__label utrecht-form-field__label--checkbox utrecht-form-label utrecht-form-label--checkbox" for="id-ce0239e2">${label}</label>
-</div>`;
 
 <Meta
   title="CSS Component/Form field with checkbox"
@@ -25,7 +19,7 @@ export const Template = ({ label = "" }) =>
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => FormFieldCheckbox(args),
     },
     status: {
       type: "WORK IN PROGRESS",
@@ -42,7 +36,7 @@ export const Template = ({ label = "" }) =>
       label: "I agree",
     }}
   >
-    {Template.bind({})}
+    {FormFieldCheckbox.bind({})}
   </Story>
 </Canvas>
 

--- a/components/form-field-description/bem.js
+++ b/components/form-field-description/bem.js
@@ -1,0 +1,14 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+import clsx from 'clsx';
+
+export const FormFieldDescription = ({ id = null, innerHTML = '', status = null }) =>
+  `<div id="${id}" class="${clsx(
+    'utrecht-form-field-description',
+    'utrecht-form-field-description--distanced',
+    status === 'valid' && 'utrecht-form-field-description--valid',
+    status === 'invalid' && 'utrecht-form-field-description--invalid',
+  )}">${innerHTML}</div>`;

--- a/components/form-field-description/bem.stories.mdx
+++ b/components/form-field-description/bem.stories.mdx
@@ -5,15 +5,7 @@ Copyright (c) 2021 Robbert Broersma
 
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
 import "./bem.scss";
-import clsx from "clsx";
-
-export const FormFieldDescription = ({ id = null, innerHTML = "", status = null }) =>
-  `<div id="${id}" class="${clsx(
-    "utrecht-form-field-description",
-    "utrecht-form-field-description--distanced",
-    status === "valid" && "utrecht-form-field-description--valid",
-    status === "invalid" && "utrecht-form-field-description--invalid"
-  )}">${innerHTML}</div>`;
+import { FormFieldDescription } from "./bem";
 
 <Meta
   title="CSS Component/Form field description"

--- a/components/form-field-radio-group/bem.js
+++ b/components/form-field-radio-group/bem.js
@@ -1,0 +1,20 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+export const FormFieldRadioGroup = ({ label, name, options }) =>
+  `<div class="utrecht-form-field-radio-group utrecht-form-field-radio-group--distanced" role="radiogroup" aria-labelledby="id-9e42cd3e">
+  <div class="utrecht-form-field-radio-group__label utrecht-form-label" id="id-9e42cd3e">${label}</div>
+  ${options
+    .map(
+      ({ checked, label, value }, index) => `
+  <div class="utrecht-form-field-radio utrecht-form-field-radio--distanced">
+    <input type="radio" name="${name}" value="${value}" class="utrecht-form-field-radio__input utrecht-radio-button" id="option-${index}"${
+        checked ? ' checked' : ''
+      }>
+    <label class="utrecht-form-field-radio__label utrecht-form-label utrecht-form-label--radio" for="option-${index}">${label}</label>
+  </div>`,
+    )
+    .join('\n')}
+</div>`;

--- a/components/form-field-radio-group/bem.stories.mdx
+++ b/components/form-field-radio-group/bem.stories.mdx
@@ -7,22 +7,7 @@ import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
 import "./bem.scss";
 import "../radio-button/bem.scss";
 import "../form-label/bem.scss";
-
-export const Template = ({ label, name, options }) =>
-  `<div class="utrecht-form-field-radio-group utrecht-form-field-radio-group--distanced" role="radiogroup" aria-labelledby="id-9e42cd3e">
-  <div class="utrecht-form-field-radio-group__label utrecht-form-label" id="id-9e42cd3e">${label}</div>
-  ${options
-    .map(
-      ({ checked, label, value }, index) => `
-  <div class="utrecht-form-field-radio utrecht-form-field-radio--distanced">
-    <input type="radio" name="${name}" value="${value}" class="utrecht-form-field-radio__input utrecht-radio-button" id="option-${index}"${
-        checked ? " checked" : ""
-      }>
-    <label class="utrecht-form-field-radio__label utrecht-form-label utrecht-form-label--radio" for="option-${index}">${label}</label>
-  </div>`
-    )
-    .join("\n")}
-</div>`;
+import { FormFieldRadioGroup } from "./bem";
 
 <Meta
   title="CSS Component/Form field with radio group"
@@ -45,7 +30,7 @@ export const Template = ({ label, name, options }) =>
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => FormFieldRadioGroup(args),
     },
     status: {
       type: "WORK IN PROGRESS",
@@ -78,7 +63,7 @@ export const Template = ({ label, name, options }) =>
       ],
     }}
   >
-    {Template.bind({})}
+    {FormFieldRadioGroup.bind({})}
   </Story>
 </Canvas>
 

--- a/components/form-field-radio/bem.js
+++ b/components/form-field-radio/bem.js
@@ -1,0 +1,10 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+export const FormFieldRadio = ({ label = '' }) =>
+  `<div class="utrecht-form-field-radio utrecht-form-field-radio--distanced">
+    <input type="radio" class="utrecht-form-field-radio__input utrecht-radio-button" id="id-ce0239e2">
+  <label class="utrecht-form-field-radio__label utrecht-form-label utrecht-form-label--radio" for="id-ce0239e2">${label}</label>
+</div>`;

--- a/components/form-field-radio/bem.stories.mdx
+++ b/components/form-field-radio/bem.stories.mdx
@@ -7,11 +7,7 @@ import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
 import "./bem.scss";
 import "../radio-button/bem.scss";
 import "../form-label/bem.scss";
-export const Template = ({ label = "" }) =>
-  `<div class="utrecht-form-field-radio utrecht-form-field-radio--distanced">
-    <input type="radio" class="utrecht-form-field-radio__input utrecht-radio-button" id="id-ce0239e2">
-  <label class="utrecht-form-field-radio__label utrecht-form-label utrecht-form-label--radio" for="id-ce0239e2">${label}</label>
-</div>`;
+import { FormFieldRadio } from "./bem";
 
 <Meta
   title="CSS Component/Form field with radio button"
@@ -23,7 +19,7 @@ export const Template = ({ label = "" }) =>
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => FormFieldRadio(args),
     },
     status: {
       type: "WORK IN PROGRESS",
@@ -40,7 +36,7 @@ export const Template = ({ label = "" }) =>
       label: "I agree",
     }}
   >
-    {Template.bind({})}
+    {FormFieldRadio.bind({})}
   </Story>
 </Canvas>
 

--- a/components/form-fieldset/bem.js
+++ b/components/form-fieldset/bem.js
@@ -1,0 +1,10 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+export const FormFieldset = ({ content = '', legend = '' }) =>
+  `<div class="utrecht-form-fieldset">
+  ${legend ? `<div class="utrecht-form-fieldset__legend utrecht-form-fieldset__legend--distanced">${legend}</div>` : ''}
+  ${content}
+</div>`;

--- a/components/form-fieldset/bem.stories.mdx
+++ b/components/form-fieldset/bem.stories.mdx
@@ -5,12 +5,7 @@ Copyright (c) 2021 Robbert Broersma
 
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
 import "./bem.scss";
-
-export const Template = ({ content = "", legend = "" }) =>
-  `<div class="utrecht-form-fieldset">
-  ${legend ? `<div class="utrecht-form-fieldset__legend utrecht-form-fieldset__legend--distanced">${legend}</div>` : ""}
-  ${content}
-</div>`;
+import { FormFieldset } from "./bem";
 
 <Meta
   title="CSS Component/Form fieldset"
@@ -26,7 +21,7 @@ export const Template = ({ content = "", legend = "" }) =>
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => FormFieldset(args),
     },
     status: {
       type: "WORK IN PROGRESS",
@@ -46,7 +41,7 @@ Styling via the `.utrecht-form-fieldset` and `.utrecht-form-fieldset__legend` cl
       legend: "Fieldset legend",
     }}
   >
-    {Template.bind({})}
+    {FormFieldset.bind({})}
   </Story>
 </Canvas>
 

--- a/components/form-label/bem.js
+++ b/components/form-label/bem.js
@@ -1,0 +1,22 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+import clsx from 'clsx';
+
+export const defaultArgs = {
+  checked: false,
+  disabled: false,
+  textContent: '',
+  type: null,
+};
+
+export const FormLabel = ({ checked = false, disabled = false, textContent = '', type = null }) =>
+  `<span class="${clsx(
+    'utrecht-form-label',
+    type === 'checkbox' && 'utrecht-form-label--checkbox',
+    checked && 'utrecht-form-label--checked',
+    disabled && 'utrecht-form-label--disabled',
+    type === 'radio' && 'utrecht-form-label--radio',
+  )}">${textContent}</span>`;

--- a/components/form-label/bem.stories.mdx
+++ b/components/form-label/bem.stories.mdx
@@ -4,24 +4,8 @@ Copyright (c) 2021 Robbert Broersma
 -->
 
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-import clsx from "clsx";
 import "./bem.scss";
-
-export const defaultArgs = {
-  checked: false,
-  disabled: false,
-  textContent: "",
-  type: null,
-};
-
-export const Template = ({ checked = false, disabled = false, textContent = "", type = null }) =>
-  `<span class="${clsx(
-    "utrecht-form-label",
-    type === "checkbox" && "utrecht-form-label--checkbox",
-    checked && "utrecht-form-label--checked",
-    disabled && "utrecht-form-label--disabled",
-    type === "radio" && "utrecht-form-label--radio"
-  )}">${textContent}</span>`;
+import { FormLabel } from "./bem";
 
 <Meta
   title="CSS Component/Form label"
@@ -38,7 +22,7 @@ export const Template = ({ checked = false, disabled = false, textContent = "", 
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => FormLabel(args),
     },
     status: {
       type: "WORK IN PROGRESS",
@@ -58,7 +42,7 @@ Styling via the `.utrecht-form-label` class name:
       textContent: "Username",
     }}
   >
-    {Template.bind({})}
+    {FormLabel.bind({})}
   </Story>
 </Canvas>
 
@@ -76,7 +60,7 @@ Styling via the `.utrecht-form-label--disabled` class name:
       textContent: "Username",
     }}
   >
-    {Template.bind({})}
+    {FormLabel.bind({})}
   </Story>
 </Canvas>
 
@@ -92,7 +76,7 @@ Styling via the `.utrecht-form-label--checkbox` class name:
       type: "checkbox",
     }}
   >
-    {Template.bind({})}
+    {FormLabel.bind({})}
   </Story>
 </Canvas>
 
@@ -109,7 +93,7 @@ Styling via the `.utrecht-form-label--checked` class name:
       type: "checkbox",
     }}
   >
-    {Template.bind({})}
+    {FormLabel.bind({})}
   </Story>
 </Canvas>
 
@@ -125,7 +109,7 @@ Styling via the `.utrecht-form-label--radio` class name:
       type: "radio",
     }}
   >
-    {Template.bind({})}
+    {FormLabel.bind({})}
   </Story>
 </Canvas>
 
@@ -142,6 +126,6 @@ Styling via the `.utrecht-form-label--radio` and `.utrecht-form-label--checked` 
       type: "radio",
     }}
   >
-    {Template.bind({})}
+    {FormLabel.bind({})}
   </Story>
 </Canvas>

--- a/components/form-toggle/bem.js
+++ b/components/form-toggle/bem.js
@@ -1,0 +1,47 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+import clsx from 'clsx';
+
+export const defaultArgs = {
+  checked: false,
+  disabled: false,
+  focus: false,
+  hover: false,
+};
+
+export const FormToggle = ({ checked = false, disabled = false, hover = false, focus = false }) =>
+  `<div class="${clsx(
+    'utrecht-form-toggle',
+    checked && 'utrecht-form-toggle--checked',
+    !checked && 'utrecht-form-toggle--not-checked',
+    disabled && 'utrecht-form-toggle--disabled',
+    focus && 'utrecht-form-toggle--focus',
+    hover && 'utrecht-form-toggle--hover',
+  )}" role="checkbox" tabindex="0"${checked ? ' aria-checked="true"' : ''}${disabled ? ' aria-disabled="true"' : ''}>
+  <div class="${clsx(
+    'utrecht-form-toggle__track',
+    checked && 'utrecht-form-toggle__track--checked',
+    !checked && 'utrecht-form-toggle__track--not-checked',
+    disabled && 'utrecht-form-toggle__track--disabled',
+  )}">
+    <div class="${clsx(
+      'utrecht-form-toggle__thumb',
+      checked && 'utrecht-form-toggle__thumb--checked',
+      !checked && 'utrecht-form-toggle__thumb--not-checked',
+      disabled && 'utrecht-form-toggle__thumb--disabled',
+    )}"></div>
+  </div>
+</div>`;
+
+export const FormToggleCheckbox = ({ checked = false, disabled = false, id }) =>
+  `<div class="${clsx('utrecht-form-toggle', 'utrecht-form-toggle--html-checkbox')}">
+  <input id="${id}" type="checkbox" class="utrecht-form-toggle__checkbox"${checked ? ' checked' : ''}${
+    disabled ? ' disabled' : ''
+  }>
+  <label for="${id}" class="${clsx('utrecht-form-toggle__track')}">
+    <div class="${clsx('utrecht-form-toggle__thumb')}"></div>
+  </label>
+</div>`;

--- a/components/form-toggle/bem.stories.mdx
+++ b/components/form-toggle/bem.stories.mdx
@@ -4,49 +4,8 @@ Copyright (c) 2021 Robbert Broersma
 -->
 
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-import clsx from "clsx";
 import "./bem.scss";
-
-export const defaultArgs = {
-  checked: false,
-  disabled: false,
-  focus: false,
-  hover: false,
-};
-
-export const Template = ({ checked = false, disabled = false, hover = false, focus = false }) =>
-  `<div class="${clsx(
-    "utrecht-form-toggle",
-    checked && "utrecht-form-toggle--checked",
-    !checked && "utrecht-form-toggle--not-checked",
-    disabled && "utrecht-form-toggle--disabled",
-    focus && "utrecht-form-toggle--focus",
-    hover && "utrecht-form-toggle--hover"
-  )}" role="checkbox" tabindex="0"${checked ? ' aria-checked="true"' : ""}${disabled ? ' aria-disabled="true"' : ""}>
-  <div class="${clsx(
-    "utrecht-form-toggle__track",
-    checked && "utrecht-form-toggle__track--checked",
-    !checked && "utrecht-form-toggle__track--not-checked",
-    disabled && "utrecht-form-toggle__track--disabled"
-  )}">
-    <div class="${clsx(
-      "utrecht-form-toggle__thumb",
-      checked && "utrecht-form-toggle__thumb--checked",
-      !checked && "utrecht-form-toggle__thumb--not-checked",
-      disabled && "utrecht-form-toggle__thumb--disabled"
-    )}"></div>
-  </div>
-</div>`;
-
-export const HTMLTemplate = ({ checked = false, disabled = false, id }) =>
-  `<div class="${clsx("utrecht-form-toggle", "utrecht-form-toggle--html-checkbox")}">
-  <input id="${id}" type="checkbox" class="utrecht-form-toggle__checkbox"${checked ? " checked" : ""}${
-    disabled ? " disabled" : ""
-  }>
-  <label for="${id}" class="${clsx("utrecht-form-toggle__track")}">
-    <div class="${clsx("utrecht-form-toggle__thumb")}"></div>
-  </label>
-</div>`;
+import { defaultArgs, FormToggle, FormToggleCheckbox } from "./bem";
 
 <Meta
   title="CSS Component/Form toggle"
@@ -70,7 +29,7 @@ export const HTMLTemplate = ({ checked = false, disabled = false, id }) =>
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => FormToggle(args),
     },
     status: {
       type: "WORK IN PROGRESS",
@@ -89,7 +48,7 @@ Styling via the `.utrecht-form-toggle` class name:
       ...defaultArgs,
     }}
   >
-    {Template.bind({})}
+    {FormToggle.bind({})}
   </Story>
 </Canvas>
 
@@ -105,7 +64,7 @@ Styling via the `.utrecht-form-toggle` class name:
       checked: true,
     }}
   >
-    {Template.bind({})}
+    {FormToggle.bind({})}
   </Story>
 </Canvas>
 
@@ -120,7 +79,7 @@ Styling via the `.utrecht-form-toggle` class name:
       disabled: true,
     }}
   >
-    {Template.bind({})}
+    {FormToggle.bind({})}
   </Story>
 </Canvas>
 
@@ -134,7 +93,7 @@ Styling via the `.utrecht-form-toggle` class name:
       disabled: true,
     }}
   >
-    {Template.bind({})}
+    {FormToggle.bind({})}
   </Story>
 </Canvas>
 
@@ -149,11 +108,11 @@ Styling via the `.utrecht-form-toggle` class name:
     }}
     parameters={{
       docs: {
-        transformSource: (_src, { args }) => HTMLTemplate(args),
+        transformSource: (_src, { args }) => FormToggleCheckbox(args),
       },
     }}
   >
-    {HTMLTemplate.bind({})}
+    {FormToggleCheckbox.bind({})}
   </Story>
 </Canvas>
 

--- a/components/form-toggle/stencil.stories.mdx
+++ b/components/form-toggle/stencil.stories.mdx
@@ -4,7 +4,6 @@ Copyright (c) 2021 Robbert Broersma
 -->
 
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-import clsx from "clsx";
 import "./bem.scss";
 
 export const defaultArgs = {

--- a/components/heading-1/bem.js
+++ b/components/heading-1/bem.js
@@ -1,0 +1,11 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+import clsx from 'clsx';
+
+export const Heading1 = ({ textContent = '', distanced = false }) =>
+  `<h1 class="${clsx('utrecht-heading-1', {
+    'utrecht-heading-1--distanced': distanced,
+  })}">${textContent}</h1>`;

--- a/components/heading-1/bem.stories.mdx
+++ b/components/heading-1/bem.stories.mdx
@@ -4,12 +4,8 @@ Copyright (c) 2021 Robbert Broersma
 -->
 
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-import clsx from "clsx";
 import "./bem.scss";
-export const Template = ({ textContent = "", distanced = false }) =>
-  `<h1 class="${clsx("utrecht-heading-1", {
-    "utrecht-heading-1--distanced": distanced,
-  })}">${textContent}</h1>`;
+import { Heading1 } from "./bem";
 
 <Meta
   title="CSS Component/Heading/Heading 1"
@@ -25,7 +21,7 @@ export const Template = ({ textContent = "", distanced = false }) =>
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => Heading1(args),
     },
     status: {
       type: "BETA",
@@ -45,7 +41,7 @@ Styling via `utrecht-heading-1` class name:
       textContent: "The Quick Brown Fox Jumps Over The Lazy Dog",
     }}
   >
-    {Template.bind({})}
+    {Heading1.bind({})}
   </Story>
 </Canvas>
 

--- a/components/heading-2/bem.js
+++ b/components/heading-2/bem.js
@@ -1,0 +1,11 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+import clsx from 'clsx';
+
+export const Heading2 = ({ textContent = '', distanced = false }) =>
+  `<h2 class="${clsx('utrecht-heading-2', {
+    'utrecht-heading-2--distanced': distanced,
+  })}">${textContent}</h2>`;

--- a/components/heading-2/bem.stories.mdx
+++ b/components/heading-2/bem.stories.mdx
@@ -4,12 +4,8 @@ Copyright (c) 2021 Robbert Broersma
 -->
 
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-import clsx from "clsx";
 import "./bem.scss";
-export const Template = ({ textContent = "", distanced = false }) =>
-  `<h2 class="${clsx("utrecht-heading-2", {
-    "utrecht-heading-2--distanced": distanced,
-  })}">${textContent}</h2>`;
+import { Heading2 } from "./bem";
 
 <Meta
   title="CSS Component/Heading/Heading 2"
@@ -25,7 +21,7 @@ export const Template = ({ textContent = "", distanced = false }) =>
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => Heading2(args),
     },
     status: {
       type: "BETA",
@@ -45,7 +41,7 @@ Styling via `utrecht-heading-2` class name:
       textContent: "The Quick Brown Fox Jumps Over The Lazy Dog",
     }}
   >
-    {Template.bind({})}
+    {Heading2.bind({})}
   </Story>
 </Canvas>
 

--- a/components/heading-3/bem.js
+++ b/components/heading-3/bem.js
@@ -1,0 +1,11 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+import clsx from 'clsx';
+
+export const Heading3 = ({ textContent = '', distanced = false }) =>
+  `<h3 class="${clsx('utrecht-heading-3', {
+    'utrecht-heading-3--distanced': distanced,
+  })}">${textContent}</h3>`;

--- a/components/heading-3/bem.stories.mdx
+++ b/components/heading-3/bem.stories.mdx
@@ -4,12 +4,8 @@ Copyright (c) 2021 Robbert Broersma
 -->
 
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-import clsx from "clsx";
 import "./bem.scss";
-export const Template = ({ textContent = "", distanced = false }) =>
-  `<h3 class="${clsx("utrecht-heading-3", {
-    "utrecht-heading-3--distanced": distanced,
-  })}">${textContent}</h3>`;
+import { Heading3 } from "./bem";
 
 <Meta
   title="CSS Component/Heading/Heading 3"
@@ -25,7 +21,7 @@ export const Template = ({ textContent = "", distanced = false }) =>
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => Heading3(args),
     },
     status: {
       type: "BETA",
@@ -45,7 +41,7 @@ Styling via `utrecht-heading-3` class name:
       textContent: "The Quick Brown Fox Jumps Over The Lazy Dog",
     }}
   >
-    {Template.bind({})}
+    {Heading3.bind({})}
   </Story>
 </Canvas>
 

--- a/components/heading-4/bem.js
+++ b/components/heading-4/bem.js
@@ -1,0 +1,11 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+import clsx from 'clsx';
+
+export const Heading4 = ({ textContent = '', distanced = false }) =>
+  `<h4 class="${clsx('utrecht-heading-4', {
+    'utrecht-heading-4--distanced': distanced,
+  })}">${textContent}</h4>`;

--- a/components/heading-4/bem.stories.mdx
+++ b/components/heading-4/bem.stories.mdx
@@ -4,12 +4,8 @@ Copyright (c) 2021 Robbert Broersma
 -->
 
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-import clsx from "clsx";
 import "./bem.scss";
-export const Template = ({ textContent = "", distanced = false }) =>
-  `<h4 class="${clsx("utrecht-heading-4", {
-    "utrecht-heading-4--distanced": distanced,
-  })}">${textContent}</h4>`;
+import { Heading4 } from "./bem";
 
 <Meta
   title="CSS Component/Heading/Heading 4"
@@ -25,7 +21,7 @@ export const Template = ({ textContent = "", distanced = false }) =>
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => Heading4(args),
     },
     status: {
       type: "BETA",
@@ -45,7 +41,7 @@ Styling via `utrecht-heading-4` class name:
       textContent: "The Quick Brown Fox Jumps Over The Lazy Dog",
     }}
   >
-    {Template.bind({})}
+    {Heading4.bind({})}
   </Story>
 </Canvas>
 

--- a/components/heading-5/bem.js
+++ b/components/heading-5/bem.js
@@ -1,0 +1,11 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+import clsx from 'clsx';
+
+export const Heading5 = ({ textContent = '', distanced = false }) =>
+  `<h5 class="${clsx('utrecht-heading-5', {
+    'utrecht-heading-5--distanced': distanced,
+  })}">${textContent}</h5>`;

--- a/components/heading-5/bem.stories.mdx
+++ b/components/heading-5/bem.stories.mdx
@@ -4,12 +4,8 @@ Copyright (c) 2021 Robbert Broersma
 -->
 
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-import clsx from "clsx";
 import "./bem.scss";
-export const Template = ({ textContent = "", distanced = false }) =>
-  `<h5 class="${clsx("utrecht-heading-5", {
-    "utrecht-heading-5--distanced": distanced,
-  })}">${textContent}</h5>`;
+import { Heading5 } from "./bem";
 
 <Meta
   title="CSS Component/Heading/Heading 5"
@@ -25,7 +21,7 @@ export const Template = ({ textContent = "", distanced = false }) =>
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => Heading5(args),
     },
     status: {
       type: "BETA",
@@ -45,7 +41,7 @@ Styling via `utrecht-heading-5` class name:
       textContent: "The Quick Brown Fox Jumps Over The Lazy Dog",
     }}
   >
-    {Template.bind({})}
+    {Heading5.bind({})}
   </Story>
 </Canvas>
 

--- a/components/heading-6/bem.js
+++ b/components/heading-6/bem.js
@@ -1,0 +1,11 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+import clsx from 'clsx';
+
+export const Heading6 = ({ textContent = '', distanced = false }) =>
+  `<h6 class="${clsx('utrecht-heading-6', {
+    'utrecht-heading-6--distanced': distanced,
+  })}">${textContent}</h6>`;

--- a/components/heading-6/bem.stories.mdx
+++ b/components/heading-6/bem.stories.mdx
@@ -4,12 +4,8 @@ Copyright (c) 2021 Robbert Broersma
 -->
 
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-import clsx from "clsx";
 import "./bem.scss";
-export const Template = ({ textContent = "", distanced = false }) =>
-  `<h6 class="${clsx("utrecht-heading-6", {
-    "utrecht-heading-6--distanced": distanced,
-  })}">${textContent}</h6>`;
+import { Heading6 } from "./bem";
 
 <Meta
   title="CSS Component/Heading/Heading 6"
@@ -25,7 +21,7 @@ export const Template = ({ textContent = "", distanced = false }) =>
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => Heading6(args),
     },
     status: {
       type: "BETA",
@@ -45,7 +41,7 @@ Styling via `utrecht-heading-6` class name:
       textContent: "The Quick Brown Fox Jumps Over The Lazy Dog",
     }}
   >
-    {Template.bind({})}
+    {Heading6.bind({})}
   </Story>
 </Canvas>
 

--- a/components/link-list/bem.js
+++ b/components/link-list/bem.js
@@ -1,0 +1,10 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+import { Link } from '../link/bem';
+
+export const LinkList = ({ links = [] }) => `<ul class="utrecht-link-list utrecht-link-list--html-ul">
+  ${links.map((link) => `<li class="utrecht-link-list__item">${Link(link)}</li>`).join('\n  ')}
+</ul>`;

--- a/components/link-list/bem.stories.mdx
+++ b/components/link-list/bem.stories.mdx
@@ -4,13 +4,8 @@ Copyright (c) 2021 Robbert Broersma
 -->
 
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-import clsx from "clsx";
 import "./bem.scss";
-import { Template as Link } from "../link/bem.stories.mdx";
-
-export const Template = ({ links = [] }) => `<ul class="utrecht-link-list utrecht-link-list--html-ul">
-  ${links.map((link) => `<li class="utrecht-link-list__item">${Link(link)}</li>`).join("\n  ")}
-</ul>`;
+import { LinkList } from "./bem";
 
 <Meta
   title="CSS Component/Link List"
@@ -25,7 +20,7 @@ export const Template = ({ links = [] }) => `<ul class="utrecht-link-list utrech
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => LinkList(args),
     },
     status: {
       type: "WORK IN PROGRESS",
@@ -48,7 +43,7 @@ The CSS code is currently very specific to Utrecht, and has no white label desig
       ],
     }}
   >
-    {Template.bind({})}
+    {LinkList.bind({})}
   </Story>
 </Canvas>
 

--- a/components/link-social/bem.js
+++ b/components/link-social/bem.js
@@ -1,0 +1,20 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+import clsx from 'clsx';
+
+export const SocialMediaLink = ({ href, icon, distanced }) => `<a href="${href}" class="${clsx(
+  'utrecht-link-social',
+  distanced && 'utrecht-link-social--distanced',
+)}">
+  <${icon} class="utrecht-link-social__icon"></${icon}>
+</a>`;
+
+export const SocialMediaLinkList = ({ links }) =>
+  links
+    .map((link) => ({ ...link, distanced: true }))
+    .map(SocialMediaLink)
+    .join('');

--- a/components/link-social/bem.stories.mdx
+++ b/components/link-social/bem.stories.mdx
@@ -1,18 +1,12 @@
-import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-import clsx from "clsx";
-import "./bem.scss";
-export const Template = ({ href, icon, distanced }) => `<a href="${href}" class="${clsx(
-  "utrecht-link-social",
-  distanced && "utrecht-link-social--distanced"
-)}">
-  <${icon} class="utrecht-link-social__icon"></${icon}>
-</a>`;
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Gemeente Utrecht
+Copyright (c) 2021 Robbert Broersma
+-->
 
-export const ListTemplate = ({ links }) =>
-  links
-    .map((link) => ({ ...link, distanced: true }))
-    .map(Template)
-    .join("");
+import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
+import "./bem.scss";
+import { SocialMediaLink, SocialMediaLinkList } from "./bem";
 
 <Meta
   title="CSS Component/Link to Social Media"
@@ -39,7 +33,7 @@ export const ListTemplate = ({ links }) =>
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => SocialMediaLink(args),
     },
     status: {
       type: "WORK IN PROGRESS",
@@ -58,7 +52,7 @@ export const ListTemplate = ({ links }) =>
       icon: "utrecht-icon-facebook",
     }}
   >
-    {Template.bind({})}
+    {SocialMediaLink.bind({})}
   </Story>
 </Canvas>
 
@@ -93,7 +87,12 @@ export const ListTemplate = ({ links }) =>
         },
       ],
     }}
+    parameters={{
+      docs: {
+        transformSource: (_src, { args }) => SocialMediaLinkList(args),
+      },
+    }}
   >
-    {ListTemplate.bind({})}
+    {SocialMediaLinkList.bind({})}
   </Story>
 </Canvas>

--- a/components/link/bem.js
+++ b/components/link/bem.js
@@ -1,0 +1,38 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+import clsx from 'clsx';
+
+export const defaultArgs = {
+  active: false,
+  external: false,
+  hover: false,
+  focus: false,
+  href: null,
+  focus: false,
+  telephone: false,
+  textContent: '...',
+  visited: false,
+};
+
+export const Link = ({
+  active = false,
+  external = false,
+  focus = false,
+  hover = false,
+  href = null,
+  telephone = false,
+  textContent = '',
+  visited = false,
+}) =>
+  `<a href="${href === null ? 'https://example.com/' : href}" class="${clsx('utrecht-link', {
+    'utrecht-link--active': active,
+    'utrecht-link--external': external,
+    'utrecht-link--focus': focus,
+    'utrecht-link--hover': hover,
+    'utrecht-link--telephone': telephone,
+    'utrecht-link--visited': visited,
+  })}"${external ? ' rel="external noopener noreferrer"' : ''}>${textContent}</a>`;

--- a/components/link/bem.stories.mdx
+++ b/components/link/bem.stories.mdx
@@ -5,40 +5,8 @@ Copyright (c) 2021 Robbert Broersma
 -->
 
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-import clsx from "clsx";
-
+import { defaultArgs, Link } from "./bem";
 import "./bem.scss";
-
-export const defaultArgs = {
-  active: false,
-  external: false,
-  hover: false,
-  focus: false,
-  href: null,
-  focus: false,
-  telephone: false,
-  textContent: "...",
-  visited: false,
-};
-
-export const Template = ({
-  active = false,
-  external = false,
-  focus = false,
-  hover = false,
-  href = null,
-  telephone = false,
-  textContent = "",
-  visited = false,
-}) =>
-  `<a href="${href === null ? "https://example.com/" : href}" class="${clsx("utrecht-link", {
-    "utrecht-link--active": active,
-    "utrecht-link--external": external,
-    "utrecht-link--focus": focus,
-    "utrecht-link--hover": hover,
-    "utrecht-link--telephone": telephone,
-    "utrecht-link--visited": visited,
-  })}"${external ? ' rel="external noopener noreferrer"' : ""}>${textContent}</a>`;
 
 <Meta
   title="CSS Component/Link"
@@ -84,7 +52,7 @@ export const Template = ({
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => Link(args),
     },
     status: {
       type: "WORK IN PROGRESS",
@@ -105,7 +73,7 @@ Styling via the `.utrecht-link` class name:
       textContent: "Read more...",
     }}
   >
-    {Template.bind({})}
+    {Link.bind({})}
   </Story>
 </Canvas>
 
@@ -129,7 +97,7 @@ Styling via the `.utrecht-link--hover` class name:
       textContent: "Read more...",
     }}
   >
-    {Template.bind({})}
+    {Link.bind({})}
   </Story>
 </Canvas>
 
@@ -145,7 +113,7 @@ Styling via the `.utrecht-link--focus` class name:
       textContent: "Read more...",
     }}
   >
-    {Template.bind({})}
+    {Link.bind({})}
   </Story>
 </Canvas>
 
@@ -161,7 +129,7 @@ Styling via the `.utrecht-link--active` class name:
       textContent: "Read more...",
     }}
   >
-    {Template.bind({})}
+    {Link.bind({})}
   </Story>
 </Canvas>
 
@@ -177,7 +145,7 @@ Styling via the `.utrecht-link--visited` class name:
       visited: true,
     }}
   >
-    {Template.bind({})}
+    {Link.bind({})}
   </Story>
 </Canvas>
 
@@ -194,7 +162,7 @@ Styling via the `.utrecht-link--telephone` class name. Avoid line wrap within th
       telephone: true,
     }}
   >
-    {Template.bind({})}
+    {Link.bind({})}
   </Story>
 </Canvas>
 
@@ -211,7 +179,7 @@ Styling via the `.utrecht-link--external` class name.
       textContent: "Read more...",
     }}
   >
-    {Template.bind({})}
+    {Link.bind({})}
   </Story>
 </Canvas>
 

--- a/components/logo/bem.js
+++ b/components/logo/bem.js
@@ -1,8 +1,9 @@
-import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Gemeente Utrecht
+ */
 
-import "./bem.scss";
-
-export const Template = () => `
+export const Logo = () => `
 <svg version="1.1" class="utrecht-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 110.57 58.97">
   <g>
     <path
@@ -30,24 +31,3 @@ export const Template = () => `
   </g>
 </svg>
 `;
-
-<Meta
-  title="CSS Component/Logo"
-  argTypes={{}}
-  parameters={{
-    docs: {
-      transformSource: (_src, { args }) => Template(args),
-    },
-    status: {
-      type: "WORK IN PROGRESS",
-    },
-  }}
-/>
-
-# Logo Gemeente Utrecht
-
-<Canvas>
-  <Story name="Logo">{Template.bind({})}</Story>
-</Canvas>
-
-<ArgsTable story="Logo" />

--- a/components/logo/bem.stories.mdx
+++ b/components/logo/bem.stories.mdx
@@ -1,0 +1,29 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Gemeente Utrecht
+-->
+
+import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
+import { Logo } from "./bem";
+import "./bem.scss";
+
+<Meta
+  title="CSS Component/Logo"
+  argTypes={{}}
+  parameters={{
+    docs: {
+      transformSource: (_src, { args }) => Logo(args),
+    },
+    status: {
+      type: "WORK IN PROGRESS",
+    },
+  }}
+/>
+
+# Logo Gemeente Utrecht
+
+<Canvas>
+  <Story name="Logo">{Logo.bind({})}</Story>
+</Canvas>
+
+<ArgsTable story="Logo" />

--- a/components/mapcontrolbutton/bem.js
+++ b/components/mapcontrolbutton/bem.js
@@ -1,0 +1,25 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+import clsx from 'clsx';
+
+export const defaultArgs = {
+  disabled: false,
+  focus: false,
+  hover: false,
+  icon: null,
+  label: '',
+};
+
+export const MapControlButton = ({ disabled = false, focus = false, hover = false, label = '', icon = null }) =>
+  `<button type="button" class="${clsx('utrecht-mapcontrolbutton', {
+    'utrecht-mapcontrolbutton--hover': hover,
+    'utrecht-mapcontrolbutton--focus': focus,
+    'utrecht-mapcontrolbutton--disabled': disabled,
+  })}"${disabled ? ' aria-disabled="true"' : ''}>
+    ${icon ? `<${icon} class="utrecht-mapcontrolbutton__icon"></${icon}>` : ''}
+    ${label ? `<span class="utrecht-mapcontrolbutton__label">${label}</span>` : ''}
+  </button>`;

--- a/components/mapcontrolbutton/bem.stories.mdx
+++ b/components/mapcontrolbutton/bem.stories.mdx
@@ -5,27 +5,8 @@ Copyright (c) 2021 Robbert Broersma
 -->
 
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-import clsx from "clsx";
-
+import { defaultArgs, MapControlButton } from "./bem";
 import "./bem.scss";
-
-export const defaultArgs = {
-  disabled: false,
-  focus: false,
-  hover: false,
-  icon: null,
-  label: "",
-};
-
-export const Template = ({ disabled = false, focus = false, hover = false, label = "", icon = null }) =>
-  `<button type="button" class="${clsx("utrecht-mapcontrolbutton", {
-    "utrecht-mapcontrolbutton--hover": hover,
-    "utrecht-mapcontrolbutton--focus": focus,
-    "utrecht-mapcontrolbutton--disabled": disabled,
-  })}"${disabled ? ' aria-disabled="true"' : ""}>
-    ${icon ? `<${icon} class="utrecht-mapcontrolbutton__icon"></${icon}>` : ""}
-    ${label ? `<span class="utrecht-mapcontrolbutton__label">${label}</span>` : ""}
-  </button>`;
 
 <Meta
   title="CSS Component/Map Control Button"
@@ -54,7 +35,7 @@ export const Template = ({ disabled = false, focus = false, hover = false, label
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => MapControlButton(args),
     },
     status: {
       type: "WORK IN PROGRESS",
@@ -74,7 +55,7 @@ Styling via the `.utrecht-mapcontrolbutton` class name:
       icon: "utrecht-icon-zoomin",
     }}
   >
-    {Template.bind({})}
+    {MapControlButton.bind({})}
   </Story>
 </Canvas>
 
@@ -97,7 +78,7 @@ Styling via the `.utrecht-mapcontrolbutton--hover` class name:
       },
     }}
   >
-    {Template.bind({})}
+    {MapControlButton.bind({})}
   </Story>
 </Canvas>
 
@@ -118,7 +99,7 @@ Styling via the `.utrecht-mapcontrolbutton--focus` class name:
       },
     }}
   >
-    {Template.bind({})}
+    {MapControlButton.bind({})}
   </Story>
 </Canvas>
 
@@ -139,7 +120,7 @@ Styling via the `.utrecht-mapcontrolbutton--disabled` class name:
       },
     }}
   >
-    {Template.bind({})}
+    {MapControlButton.bind({})}
   </Story>
 </Canvas>
 
@@ -160,6 +141,6 @@ Styling via the `.utrecht-mapcontrolbutton--disabled` class name:
       },
     }}
   >
-    {Template.bind({})}
+    {MapControlButton.bind({})}
   </Story>
 </Canvas>

--- a/components/menulijst/bem.js
+++ b/components/menulijst/bem.js
@@ -1,0 +1,18 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Gemeente Utrecht
+ */
+
+export const Menulijst = ({ href = 'https://example.com/' }) =>
+  `<ul class="utrecht-menulijst">
+        <li class="utrecht-menulijst__item utrecht-menulijst__item--active">
+          <a class="utrecht-menulijst__link" href="${href}">Menu item label #1</a>
+        </li>
+        <li class="utrecht-menulijst__item">
+          <a class="utrecht-menulijst__link" href="${href}">Menu item label #2</a>
+        </li>
+         <li class="utrecht-menulijst__item">
+          <a class="utrecht-menulijst__link" href="${href}">Menu item label #3</a>
+        </li>
+    </ul>
+`;

--- a/components/menulijst/bem.stories.mdx
+++ b/components/menulijst/bem.stories.mdx
@@ -1,26 +1,19 @@
+<!--
+@license EUPL-1.2
+Copyright (c) 2021 Gemeente Utrecht
+-->
+
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
 import dedent from "ts-dedent";
 
 import "./bem.scss";
-export const Template = ({ href = "https://example.com/" }) =>
-  dedent`<ul class="utrecht-menulijst">
-        <li class="utrecht-menulijst__item utrecht-menulijst__item--active">
-          <a class="utrecht-menulijst__link" href="${href}">Menu item label #1</a>
-        </li>
-        <li class="utrecht-menulijst__item">
-          <a class="utrecht-menulijst__link" href="${href}">Menu item label #2</a>
-        </li>
-         <li class="utrecht-menulijst__item">
-          <a class="utrecht-menulijst__link" href="${href}">Menu item label #3</a>
-        </li>
-    </ul>
-`;
+import { Menulijst } from "./bem";
 
 <Meta
   title="CSS Component/Menulijst"
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => Menulijst(args),
     },
     status: {
       type: "WORK IN PROGRESS",
@@ -34,7 +27,7 @@ export const Template = ({ href = "https://example.com/" }) =>
 # Menulijst
 
 <Canvas>
-  <Story name="menulijst">{Template.bind({})}</Story>
+  <Story name="menulijst">{Menulijst.bind({})}</Story>
 </Canvas>
 
 <ArgsTable story="menulijst" />

--- a/components/nav-top/bem.js
+++ b/components/nav-top/bem.js
@@ -1,0 +1,23 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Gemeente Utrecht
+ */
+
+import clsx from 'clsx';
+
+export const TopNav = ({ items }) => `<div class="utrecht-navhtml">
+  <nav class="topnav">
+    <ul class="utrecht-topnav__list">${items.map(
+      ({ href, title, current, focus }) => `
+      <li class="utrecht-topnav__item">
+        <a class="${clsx(
+          'utrecht-topnav__link',
+          current && 'utrecht-topnav__link--current',
+          focus && 'utrecht-topnav__link--focus',
+        )}" href="${href}">${title}</a>
+        </li>`,
+    )}
+    </ul>
+  </nav>
+</div>
+`;

--- a/components/nav-top/bem.stories.mdx
+++ b/components/nav-top/bem.stories.mdx
@@ -1,27 +1,11 @@
 <!--
 @license EUPL-1.2
-Copyright (c) 2021 A Herring
+Copyright (c) 2021 Gemeente Utrecht
 -->
 
 import { ArgsTable, Meta, Story, Canvas } from "@storybook/addon-docs";
-import clsx from "clsx";
 import "./bem.scss";
-export const Template = ({ items }) => `<div class="utrecht-navhtml">
-  <nav class="topnav">
-    <ul class="utrecht-topnav__list">${items.map(
-      ({ href, title, current, focus }) => `
-      <li class="utrecht-topnav__item">
-        <a class="${clsx(
-          "utrecht-topnav__link",
-          current && "utrecht-topnav__link--current",
-          focus && "utrecht-topnav__link--focus"
-        )}" href="${href}">${title}</a>
-        </li>`
-    )}
-    </ul>
-  </nav>
-</div>
-`;
+import { TopNav } from "./bem";
 
 <Meta
   title="CSS Component/Top Nav"
@@ -36,7 +20,7 @@ export const Template = ({ items }) => `<div class="utrecht-navhtml">
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => TopNav(args),
     },
     status: "IN DEVELOPMENT",
   }}
@@ -56,7 +40,7 @@ export const Template = ({ items }) => `<div class="utrecht-navhtml">
       ],
     }}
   >
-    {Template.bind({})}
+    {TopNav.bind({})}
   </Story>
 </Canvas>
 

--- a/components/navigatie sidenav/bem.js
+++ b/components/navigatie sidenav/bem.js
@@ -1,0 +1,43 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Gemeente Utrecht
+ */
+
+import clsx from 'clsx';
+
+export const SideNav = ({ items }) => `<nav class="utrecht-sidenav">
+    <ul class="utrecht-sidenav__list">${items
+      .map(
+        ({ href, title, current, focus, children, sibling, haschildren }) => `<li class="${clsx(
+          'utrecht-sidenav__item',
+          sibling && 'utrecht-sidenav__item--sibling',
+          haschildren && 'utrecht-sidenav__item--has-children',
+        )}">
+          <a class="${clsx(
+            'utrecht-sidenav__link',
+            current && 'utrecht-sidenav__link--current',
+            focus && 'utrecht-sidenav__link--focus',
+            sibling && 'utrecht-sidenav__link--sibling',
+            haschildren && 'utrecht-sidenav__link--has-children',
+          )}" href="${href}">${title}</a><span></span>
+          ${
+            children
+              ? `<ul class="utrecht-sidenav__list utrecht-sidenav__list--child">${children
+                  .map(
+                    ({ href, title, current, focus }) =>
+                      `<li class="utrecht-sidenav__item utrecht-sidenav__item--child"><a class="${clsx(
+                        'utrecht-sidenav__link utrecht-sidenav__link--child',
+                        current && 'utrecht-sidenav__link--current utrecht-sidenav__link--child--current',
+                        focus && 'utrecht-sidenav__link--focus',
+                      )}" href="${href}">${title}</a></li>`,
+                  )
+                  .join('')}
+          </ul><span></span>`
+              : ''
+          }
+        </li>`,
+      )
+      .join('')}
+    </ul>
+  </nav>
+`;

--- a/components/navigatie sidenav/bem.stories.mdx
+++ b/components/navigatie sidenav/bem.stories.mdx
@@ -1,47 +1,11 @@
 <!--
 @license EUPL-1.2
-Copyright (c) 2021 A Herring
+Copyright (c) 2021 Gemeente Utrecht
 -->
 
 import { ArgsTable, Meta, Story, Canvas } from "@storybook/addon-docs";
-import clsx from "clsx";
 import "./bem.scss";
-export const Template = ({ items }) => `<nav class="utrecht-sidenav">
-    <ul class="utrecht-sidenav__list">${items
-      .map(
-        ({ href, title, current, focus, children, sibling, haschildren }) => `<li class="${clsx(
-          "utrecht-sidenav__item",
-          sibling && "utrecht-sidenav__item--sibling",
-          haschildren && "utrecht-sidenav__item--has-children"
-        )}">
-          <a class="${clsx(
-            "utrecht-sidenav__link",
-            current && "utrecht-sidenav__link--current",
-            focus && "utrecht-sidenav__link--focus",
-            sibling && "utrecht-sidenav__link--sibling",
-            haschildren && "utrecht-sidenav__link--has-children"
-          )}" href="${href}">${title}</a><span></span>
-          ${
-            children
-              ? `<ul class="utrecht-sidenav__list utrecht-sidenav__list--child">${children
-                  .map(
-                    ({ href, title, current, focus }) =>
-                      `<li class="utrecht-sidenav__item utrecht-sidenav__item--child"><a class="${clsx(
-                        "utrecht-sidenav__link utrecht-sidenav__link--child",
-                        current && "utrecht-sidenav__link--current utrecht-sidenav__link--child--current",
-                        focus && "utrecht-sidenav__link--focus"
-                      )}" href="${href}">${title}</a></li>`
-                  )
-                  .join("")}
-          </ul><span></span>`
-              : ""
-          }
-        </li>`
-      )
-      .join("")}
-    </ul>
-  </nav>
-`;
+import { SideNav } from "./bem";
 
 <Meta
   title="CSS Component/Navigatie SideNav"
@@ -56,7 +20,7 @@ export const Template = ({ items }) => `<nav class="utrecht-sidenav">
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => SideNav(args),
     },
     status: "IN DEVELOPMENT",
   }}
@@ -86,7 +50,7 @@ export const Template = ({ items }) => `<nav class="utrecht-sidenav">
       ],
     }}
   >
-    {Template.bind({})}
+    {SideNav.bind({})}
   </Story>
 </Canvas>
 
@@ -124,7 +88,7 @@ export const Template = ({ items }) => `<nav class="utrecht-sidenav">
       },
     }}
   >
-    {Template.bind({})}
+    {SideNav.bind({})}
   </Story>
 </Canvas>
 
@@ -166,6 +130,6 @@ export const Template = ({ items }) => `<nav class="utrecht-sidenav">
       },
     }}
   >
-    {Template.bind({})}
+    {SideNav.bind({})}
   </Story>
 </Canvas>

--- a/components/navigatie topnav/bem.js
+++ b/components/navigatie topnav/bem.js
@@ -1,0 +1,25 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Gemeente Utrecht
+ */
+
+import clsx from 'clsx';
+
+export const TopNav = ({ items }) => `<div class="utrecht-navhtml">
+  <nav class="topnav">
+    <ul class="utrecht-topnav__list">${items
+      .map(
+        ({ href, title, current, focus }) => `
+      <li class="utrecht-topnav__item">
+        <a class="${clsx(
+          'utrecht-topnav__link',
+          current && 'utrecht-topnav__link--current',
+          focus && 'utrecht-topnav__link--focus',
+        )}" href="${href}">${title}</a>
+        </li>`,
+      )
+      .join('')}
+    </ul>
+  </nav>
+</div>
+`;

--- a/components/navigatie topnav/bem.stories.mdx
+++ b/components/navigatie topnav/bem.stories.mdx
@@ -1,29 +1,11 @@
 <!--
 @license EUPL-1.2
-Copyright (c) 2021 A Herring
+Copyright (c) 2021 Gemeente Utrecht
 -->
 
 import { ArgsTable, Meta, Story, Canvas } from "@storybook/addon-docs";
-import clsx from "clsx";
 import "./bem.scss";
-export const Template = ({ items }) => `<div class="utrecht-navhtml">
-  <nav class="topnav">
-    <ul class="utrecht-topnav__list">${items
-      .map(
-        ({ href, title, current, focus }) => `
-      <li class="utrecht-topnav__item">
-        <a class="${clsx(
-          "utrecht-topnav__link",
-          current && "utrecht-topnav__link--current",
-          focus && "utrecht-topnav__link--focus"
-        )}" href="${href}">${title}</a>
-        </li>`
-      )
-      .join("")}
-    </ul>
-  </nav>
-</div>
-`;
+import { TopNav } from "./bem";
 
 <Meta
   title="CSS Component/Navigatie TopNav"
@@ -38,7 +20,7 @@ export const Template = ({ items }) => `<div class="utrecht-navhtml">
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => TopNav(args),
     },
     status: "IN DEVELOPMENT",
   }}
@@ -58,7 +40,7 @@ export const Template = ({ items }) => `<div class="utrecht-navhtml">
       ],
     }}
   >
-    {Template.bind({})}
+    {TopNav.bind({})}
   </Story>
 </Canvas>
 
@@ -83,7 +65,7 @@ export const Template = ({ items }) => `<div class="utrecht-navhtml">
       },
     }}
   >
-    {Template.bind({})}
+    {TopNav.bind({})}
   </Story>
 </Canvas>
 
@@ -106,6 +88,6 @@ export const Template = ({ items }) => `<div class="utrecht-navhtml">
       },
     }}
   >
-    {Template.bind({})}
+    {TopNav.bind({})}
   </Story>
 </Canvas>

--- a/components/ordered-list/bem.js
+++ b/components/ordered-list/bem.js
@@ -1,0 +1,13 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+import clsx from 'clsx';
+
+export const OrderedList = ({ distanced = false }) =>
+  `<ol class="${clsx('utrecht-ordered-list', distanced && 'utrecht-ordered-list--distanced')}">
+  <li class="utrecht-ordered-list__item">Lorem</li>
+  <li class="utrecht-ordered-list__item">Ipsum</li>
+  <li class="utrecht-ordered-list__item">Dolor</li>
+</ol>`;

--- a/components/ordered-list/bem.stories.mdx
+++ b/components/ordered-list/bem.stories.mdx
@@ -4,15 +4,8 @@ Copyright (c) 2021 Robbert Broersma
 -->
 
 import { ArgsTable, Meta, Story, Canvas } from "@storybook/addon-docs";
-import clsx from "clsx";
 import "./bem.scss";
-
-export const Template = ({ distanced = false }) =>
-  `<ol class="${clsx("utrecht-ordered-list", distanced && "utrecht-ordered-list--distanced")}">
-  <li class="utrecht-ordered-list__item">Lorem</li>
-  <li class="utrecht-ordered-list__item">Ipsum</li>
-  <li class="utrecht-ordered-list__item">Dolor</li>
-</ol>`;
+import { OrderedList } from "./bem";
 
 <Meta
   title="CSS Component/Ordered List"
@@ -24,7 +17,7 @@ export const Template = ({ distanced = false }) =>
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => OrderedList(args),
     },
     status: "IN DEVELOPMENT",
   }}
@@ -39,7 +32,7 @@ export const Template = ({ distanced = false }) =>
       distanced: true,
     }}
   >
-    {Template.bind({})}
+    {OrderedList.bind({})}
   </Story>
 </Canvas>
 

--- a/components/page-footer/bem.js
+++ b/components/page-footer/bem.js
@@ -1,0 +1,7 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+export const PageFooter = ({ innerHTML = '' }) => `<footer class="utrecht-page-footer">
+${innerHTML}</header>`;

--- a/components/page-footer/bem.stories.mdx
+++ b/components/page-footer/bem.stories.mdx
@@ -5,9 +5,7 @@ Copyright (c) 2021 Robbert Broersma
 
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
 import "./bem.scss";
-
-export const Template = ({ innerHTML = "" }) => `<footer class="utrecht-page-footer">
-${innerHTML}</header>`;
+import { PageFooter } from "./bem";
 
 <Meta
   title="CSS Component/Page Footer"
@@ -19,7 +17,7 @@ ${innerHTML}</header>`;
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => PageFooter(args),
     },
     status: "WORK IN PROGRESS",
   }}
@@ -60,7 +58,7 @@ ${innerHTML}</header>`;
   </div>`,
     }}
   >
-    {Template.bind({})}
+    {PageFooter.bind({})}
   </Story>
 </Canvas>
 

--- a/components/pagination/bem.js
+++ b/components/pagination/bem.js
@@ -1,0 +1,54 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+import clsx from 'clsx';
+
+export const defaultArgs = {
+  distanced: false,
+};
+
+export const LinkTemplate = ({ disabled = false, href = '', rel = null, textContent = '', title = '' }) =>
+  `<${disabled ? 'span' : 'a'} href="${href}" class="${clsx(
+    'utrecht-pagination__relative-link',
+    disabled && 'utrecht-pagination__relative-link--disabled',
+    rel === 'next' && 'utrecht-pagination__relative-link--next',
+    rel === 'prev' && 'utrecht-pagination__relative-link--prev',
+  )}"${rel ? ` rel="${rel}"` : ''}${title ? ` aria-label="${title}"` : ''}>${textContent}</${disabled ? 'span' : 'a'}>`;
+
+export const ItemTemplate = ({ current = false, href = '', rel = null, textContent = '' }) =>
+  `<a class="${clsx(
+    'utrecht-pagination__page-link',
+    current && 'utrecht-pagination__page-link--current',
+  )}" href="${href}"${current ? ' aria-current="true"' : ''}${rel ? ` rel="${rel}"` : ''}>${textContent}</a>`;
+
+export const Pagination = ({ currentIndex = -1, distanced = false, links = [], next = null, prev = null }) =>
+  `<nav class="${clsx(
+    'utrecht-pagination',
+    distanced && 'utrecht-pagination--distanced',
+  )}"><span class="utrecht-pagination__before">${
+    prev ? LinkTemplate({ ...prev, rel: 'prev', textContent: 'Vorige' }) : ''
+  }</span><span role="group" class="utrecht-pagination__pages">${links
+    .sort((a, b) => (a.index === b.index ? 0 : a.index > b.index ? 1 : -1))
+    .map((link, arrayIndex) => {
+      const index = typeof link.index === 'number' ? link.index : arrayIndex;
+      return {
+        index,
+        current: typeof currentIndex === 'number' && index === currentIndex,
+        rel:
+          typeof currentIndex === 'number'
+            ? index === currentIndex + 1
+              ? 'next'
+              : index === currentIndex - 1
+              ? 'prev'
+              : null
+            : null,
+        textContent: link.index || index,
+        ...link,
+      };
+    })
+    .map((link) => ItemTemplate(link))
+    .join('')}</span><span class="utrecht-pagination__before">${
+    next ? LinkTemplate({ ...next, rel: 'next', textContent: 'Volgende' }) : ''
+  }</span></nav>`;

--- a/components/pagination/bem.stories.mdx
+++ b/components/pagination/bem.stories.mdx
@@ -4,56 +4,8 @@ Copyright (c) 2021 Robbert Broersma
 -->
 
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-import clsx from "clsx";
 import "./bem.scss";
-
-export const defaultArgs = {
-  distanced: false,
-};
-
-export const LinkTemplate = ({ disabled = false, href = "", rel = null, textContent = "", title = "" }) =>
-  `<${disabled ? "span" : "a"} href="${href}" class="${clsx(
-    "utrecht-pagination__relative-link",
-    disabled && "utrecht-pagination__relative-link--disabled",
-    rel === "next" && "utrecht-pagination__relative-link--next",
-    rel === "prev" && "utrecht-pagination__relative-link--prev"
-  )}"${rel ? ` rel="${rel}"` : ""}${title ? ` aria-label="${title}"` : ""}>${textContent}</${disabled ? "span" : "a"}>`;
-
-export const ItemTemplate = ({ current = false, href = "", rel = null, textContent = "" }) =>
-  `<a class="${clsx(
-    "utrecht-pagination__page-link",
-    current && "utrecht-pagination__page-link--current"
-  )}" href="${href}"${current ? ' aria-current="true"' : ""}${rel ? ` rel="${rel}"` : ""}>${textContent}</a>`;
-
-export const Template = ({ currentIndex = -1, distanced = false, links = [], next = null, prev = null }) =>
-  `<nav class="${clsx(
-    "utrecht-pagination",
-    distanced && "utrecht-pagination--distanced"
-  )}"><span class="utrecht-pagination__before">${
-    prev ? LinkTemplate({ ...prev, rel: "prev", textContent: "Vorige" }) : ""
-  }</span><span role="group" class="utrecht-pagination__pages">${links
-    .sort((a, b) => (a.index === b.index ? 0 : a.index > b.index ? 1 : -1))
-    .map((link, arrayIndex) => {
-      const index = typeof link.index === "number" ? link.index : arrayIndex;
-      return {
-        index,
-        current: typeof currentIndex === "number" && index === currentIndex,
-        rel:
-          typeof currentIndex === "number"
-            ? index === currentIndex + 1
-              ? "next"
-              : index === currentIndex - 1
-              ? "prev"
-              : null
-            : null,
-        textContent: link.index || index,
-        ...link,
-      };
-    })
-    .map((link) => ItemTemplate(link))
-    .join("")}</span><span class="utrecht-pagination__before">${
-    next ? LinkTemplate({ ...next, rel: "next", textContent: "Volgende" }) : ""
-  }</span></nav>`;
+import { defaultArgs, Pagination } from "./bem";
 
 <Meta
   title="CSS Component/Pagination navigation"
@@ -81,7 +33,7 @@ export const Template = ({ currentIndex = -1, distanced = false, links = [], nex
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => Pagination(args),
     },
     status: {
       type: "WORK IN PROGRESS",
@@ -133,7 +85,7 @@ export const Template = ({ currentIndex = -1, distanced = false, links = [], nex
       },
     }}
   >
-    {Template.bind({})}
+    {Pagination.bind({})}
   </Story>
 </Canvas>
 

--- a/components/paragraph/bem.js
+++ b/components/paragraph/bem.js
@@ -1,0 +1,14 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+import clsx from 'clsx';
+
+export const defaultArgs = {
+  lead: false,
+  textContent: '',
+};
+
+export const Paragraph = ({ textContent = '', lead = false }) =>
+  `<p class="${clsx('utrecht-paragraph', { 'utrecht-paragraph--lead': lead })}">${textContent}</p>`;

--- a/components/paragraph/bem.stories.mdx
+++ b/components/paragraph/bem.stories.mdx
@@ -4,16 +4,8 @@ Copyright (c) 2021 Robbert Broersma
 -->
 
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-import clsx from "clsx";
 import "./bem.scss";
-
-export const defaultArgs = {
-  lead: false,
-  textContent: "",
-};
-
-export const Template = ({ textContent = "", lead = false }) =>
-  `<p class="${clsx("utrecht-paragraph", { "utrecht-paragraph--lead": lead })}">${textContent}</p>`;
+import { defaultArgs, Paragraph } from "./bem";
 
 export const TemplateMulti = ({ textContent = "" }) =>
   `<p class="utrecht-paragraph utrecht-paragraph--lead">${textContent}</p>
@@ -34,7 +26,7 @@ export const TemplateMulti = ({ textContent = "" }) =>
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => Paragraph(args),
     },
     status: {
       type: "BETA",
@@ -55,7 +47,7 @@ Styling via the `.utrecht-paragraph` class name:
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
     }}
   >
-    {Template.bind({})}
+    {Paragraph.bind({})}
   </Story>
 </Canvas>
 
@@ -74,7 +66,7 @@ Styling via the `.utrecht-paragraph--lead` class name:
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
     }}
   >
-    {Template.bind({})}
+    {Paragraph.bind({})}
   </Story>
 </Canvas>
 

--- a/components/pre-heading/bem.js
+++ b/components/pre-heading/bem.js
@@ -1,0 +1,15 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+import clsx from 'clsx';
+
+export const defaultArgs = {
+  distanced: false,
+};
+
+export const PreHeading = ({ textContent = '', distanced = false }) =>
+  `<div class="${clsx('utrecht-pre-heading', {
+    'utrecht-pre-heading--distanced': distanced,
+  })}">${textContent}</div>`;

--- a/components/pre-heading/bem.stories.mdx
+++ b/components/pre-heading/bem.stories.mdx
@@ -4,17 +4,8 @@ Copyright (c) 2021 Robbert Broersma
 -->
 
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
-import clsx from "clsx";
 import "./bem.scss";
-
-export const defaultArgs = {
-  distanced: false,
-};
-
-export const Template = ({ textContent = "", distanced = false }) =>
-  `<div class="${clsx("utrecht-pre-heading", {
-    "utrecht-pre-heading--distanced": distanced,
-  })}">${textContent}</div>`;
+import { defaultArgs, PreHeading } from "./bem";
 
 <Meta
   title="CSS Component/Pre-heading"
@@ -30,7 +21,7 @@ export const Template = ({ textContent = "", distanced = false }) =>
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => PreHeading(args),
     },
     status: {
       type: "ALPHA",
@@ -50,7 +41,7 @@ Styling via `utrecht-pre-heading` class name:
       textContent: "The Quick Brown Fox Jumps Over The Lazy Dog",
     }}
   >
-    {Template.bind({})}
+    {PreHeading.bind({})}
   </Story>
 </Canvas>
 

--- a/components/search-bar/bem.js
+++ b/components/search-bar/bem.js
@@ -1,0 +1,15 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+export const SearchBar = ({
+  buttonLabel,
+  formLabel,
+  inputLabel,
+  value,
+}) => `<form class="utrecht-search-bar" role="search" aria-label="${formLabel}">
+  <input type="search" class="utrecht-search-bar__input utrecht-textbox utrecht-textbox utrecht-textbox--html-input" name="q" autocomplete="off" spellcheck="false" value="${value}" aria-label="${inputLabel}">
+  <button type="submit" value="Zoeken" class="utrecht-search-bar__button utrecht-button">${buttonLabel}</button>
+</form>`;

--- a/components/search-bar/bem.stories.mdx
+++ b/components/search-bar/bem.stories.mdx
@@ -1,5 +1,6 @@
 <!--
 @license EUPL-1.2
+Copyright (c) 2021 Gemeente Utrecht
 Copyright (c) 2021 Robbert Broersma
 -->
 
@@ -8,23 +9,14 @@ import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
 import "./bem.scss";
 import "../textbox/bem.scss";
 import "../button/bem.scss";
-
-export const Template = ({
-  buttonLabel,
-  formLabel,
-  inputLabel,
-  value,
-}) => `<form class="utrecht-search-bar" role="search" aria-label="${formLabel}">
-  <input type="search" class="utrecht-search-bar__input utrecht-textbox utrecht-textbox utrecht-textbox--html-input" name="q" autocomplete="off" spellcheck="false" value="${value}" aria-label="${inputLabel}">
-  <button type="submit" value="Zoeken" class="utrecht-search-bar__button utrecht-button">${buttonLabel}</button>
-</form>`;
+import { SearchBar } from "./bem";
 
 <Meta
   title="CSS Component/Search Bar"
   argTypes={{}}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => SearchBar(args),
     },
     status: {
       type: "WORK IN PROGRESS",
@@ -44,7 +36,7 @@ export const Template = ({
       value: "The answer to life, the universe, and everything",
     }}
   >
-    {Template.bind({})}
+    {SearchBar.bind({})}
   </Story>
 </Canvas>
 

--- a/components/select/bem.js
+++ b/components/select/bem.js
@@ -1,0 +1,38 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+import clsx from 'clsx';
+
+export const defaultArgs = {
+  disabled: false,
+  focus: false,
+  invalid: false,
+  options: [],
+  required: false,
+};
+
+export const Select = ({ disabled = false, focus = false, invalid = false, options = [], required = false }) =>
+  `<select${invalid ? ' aria-invalid="true"' : ''}${disabled ? ' disabled' : ''}${
+    required ? ' required' : ''
+  } class="${clsx('utrecht-select', {
+    'utrecht-select--disabled': disabled,
+    'utrecht-select--focus': focus,
+    'utrecht-select--invalid': invalid,
+    'utrecht-select--required': required,
+  })}">
+  ${options
+    .map(
+      ({ label, selected, value }) =>
+        `<option${selected ? ' selected' : ''}${value ? ` value="${value}"` : ''}>${label}</option>`,
+    )
+    .join('\n  ')}
+</select>`;
+
+export const exampleOptions = [
+  { value: '1', label: 'Option #1' },
+  { value: '2', label: 'Option #2', selected: true },
+  { value: '3', label: 'Option #3' },
+];

--- a/components/select/bem.stories.mdx
+++ b/components/select/bem.stories.mdx
@@ -1,42 +1,12 @@
 <!--
 @license EUPL-1.2
+Copyright (c) 2021 Gemeente Utrecht
 Copyright (c) 2021 Robbert Broersma
 -->
 
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
 import "./html.scss";
-import clsx from "clsx";
-
-export const defaultArgs = {
-  disabled: false,
-  focus: false,
-  invalid: false,
-  options: [],
-  required: false,
-};
-
-export const Template = ({ disabled = false, focus = false, invalid = false, options = [], required = false }) =>
-  `<select${invalid ? ' aria-invalid="true"' : ""}${disabled ? " disabled" : ""}${
-    required ? " required" : ""
-  } class="${clsx("utrecht-select", {
-    "utrecht-select--disabled": disabled,
-    "utrecht-select--focus": focus,
-    "utrecht-select--invalid": invalid,
-    "utrecht-select--required": required,
-  })}">
-  ${options
-    .map(
-      ({ label, selected, value }) =>
-        `<option${selected ? " selected" : ""}${value ? ` value="${value}"` : ""}>${label}</option>`
-    )
-    .join("\n  ")}
-</select>`;
-
-export const exampleOptions = [
-  { value: "1", label: "Option #1" },
-  { value: "2", label: "Option #2", selected: true },
-  { value: "3", label: "Option #3" },
-];
+import { defaultArgs, exampleOptions, Select } from "./bem";
 
 <Meta
   title="CSS Component/Form Select"

--- a/components/separator/bem.js
+++ b/components/separator/bem.js
@@ -1,0 +1,16 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+import clsx from 'clsx';
+
+export const defaultArgs = {
+  distanced: false,
+};
+
+export const Separator = ({ distanced = false }) =>
+  `<div role="separator" aria-orientation="horizontal" class="${clsx(
+    'utrecht-separator',
+    distanced && 'utrecht-separator--distanced',
+  )}"></div>`;

--- a/components/separator/bem.stories.mdx
+++ b/components/separator/bem.stories.mdx
@@ -5,17 +5,7 @@ Copyright (c) 2021 Robbert Broersma
 
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
 import "./bem.scss";
-import clsx from "clsx";
-
-export const defaultArgs = {
-  distanced: false,
-};
-
-export const Template = ({ distanced = false }) =>
-  `<div role="separator" aria-orientation="horizontal" class="${clsx(
-    "utrecht-separator",
-    distanced && "utrecht-separator--distanced"
-  )}"></div>`;
+import { defaultArgs, Separator } from "./bem";
 
 <Meta
   title="CSS Component/Separator"
@@ -27,7 +17,7 @@ export const Template = ({ distanced = false }) =>
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => Separator(args),
     },
     status: {
       type: "WORK IN PROGRESS",
@@ -46,7 +36,7 @@ Styling via `utrecht-separator` class name:
       distanced: true,
     }}
   >
-    {Template.bind({})}
+    {Separator.bind({})}
   </Story>
 </Canvas>
 

--- a/components/textbox/bem.js
+++ b/components/textbox/bem.js
@@ -1,0 +1,32 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+import clsx from 'clsx';
+
+export const defaultArgs = {
+  disabled: false,
+  focus: false,
+  invalid: false,
+  readOnly: false,
+  required: false,
+  value: '',
+};
+
+export const TextBox = ({
+  disabled = false,
+  focus = false,
+  invalid = false,
+  readOnly = false,
+  required = false,
+  value = '',
+}) =>
+  `<input class="${clsx(
+    'utrecht-textbox',
+    disabled && 'utrecht-textbox--disabled',
+    focus && 'utrecht-textbox--focus',
+    invalid && 'utrecht-textbox--invalid',
+    readOnly && 'utrecht-textbox--readonly',
+    required && 'utrecht-textbox--required',
+  )}" value="${value}">`;

--- a/components/textbox/bem.stories.mdx
+++ b/components/textbox/bem.stories.mdx
@@ -5,33 +5,7 @@ Copyright (c) 2021 Robbert Broersma
 
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
 import "./bem.scss";
-import clsx from "clsx";
-
-export const defaultArgs = {
-  disabled: false,
-  focus: false,
-  invalid: false,
-  readOnly: false,
-  required: false,
-  value: "",
-};
-
-export const Template = ({
-  disabled = false,
-  focus = false,
-  invalid = false,
-  readOnly = false,
-  required = false,
-  value = "",
-}) =>
-  `<input class="${clsx(
-    "utrecht-textbox",
-    disabled && "utrecht-textbox--disabled",
-    focus && "utrecht-textbox--focus",
-    invalid && "utrecht-textbox--invalid",
-    readOnly && "utrecht-textbox--readonly",
-    required && "utrecht-textbox--required"
-  )}" value="${value}">`;
+import { defaultArgs, TextBox } from "./bem";
 
 <Meta
   title="CSS Component/Text Box"
@@ -63,7 +37,7 @@ export const Template = ({
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => TextBox(args),
     },
     status: {
       type: "WORK IN PROGRESS",
@@ -83,7 +57,7 @@ Styling via the `<input>` element:
       value: "The Quick Brown Fox Jumps Over The Lazy Dog",
     }}
   >
-    {Template.bind({})}
+    {TextBox.bind({})}
   </Story>
 </Canvas>
 
@@ -101,7 +75,7 @@ Styling via the `<input>` element:
       value: "The Quick Brown Fox Jumps Over The Lazy Dog",
     }}
   >
-    {Template.bind({})}
+    {TextBox.bind({})}
   </Story>
 </Canvas>
 
@@ -115,7 +89,7 @@ Styling via the `<input>` element:
       value: "The Quick Brown Fox Jumps Over The Lazy Dog",
     }}
   >
-    {Template.bind({})}
+    {TextBox.bind({})}
   </Story>
 </Canvas>
 
@@ -129,7 +103,7 @@ Styling via the `<input>` element:
       value: "The Quick Brown Fox Jumps Over The Lazy Dog",
     }}
   >
-    {Template.bind({})}
+    {TextBox.bind({})}
   </Story>
 </Canvas>
 
@@ -143,7 +117,7 @@ Styling via the `<input>` element:
       value: "The Quick Brown Fox Jumps Over The Lazy Dog",
     }}
   >
-    {Template.bind({})}
+    {TextBox.bind({})}
   </Story>
 </Canvas>
 
@@ -159,6 +133,6 @@ Styling via the `<input>` element:
       value: "The Quick Brown Fox Jumps Over The Lazy Dog",
     }}
   >
-    {Template.bind({})}
+    {TextBox.bind({})}
   </Story>
 </Canvas>

--- a/components/unordered-list/bem.js
+++ b/components/unordered-list/bem.js
@@ -1,0 +1,25 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+import clsx from 'clsx';
+
+export const UnorderedList = ({ distanced = false }) =>
+  `<ul class="${clsx('utrecht-unordered-list', distanced && 'utrecht-unordered-list--distanced')}">
+  <li class="utrecht-unordered-list__item">Lorem</li>
+  <li class="utrecht-unordered-list__item">Ipsum</li>
+  <li class="utrecht-unordered-list__item">Dolor</li>
+</ul>`;
+
+export const UnorderedListNested = ({ distanced = false }) =>
+  `<ul class="${clsx('utrecht-unordered-list', distanced && 'utrecht-unordered-list--distanced')}">
+  <li class="utrecht-unordered-list__item">Lorem</li>
+  <li class="utrecht-unordered-list__item">Ipsum
+    <ul class="utrecht-unordered-list utrecht-unordered-list--nested">
+      <li class="utrecht-unordered-list__item">Lorem</li>
+      <li class="utrecht-unordered-list__item">Ipsum</li>
+    </ul>
+  </li>
+  <li class="utrecht-unordered-list__item">Dolor</li>
+</ul>`;

--- a/components/unordered-list/bem.stories.mdx
+++ b/components/unordered-list/bem.stories.mdx
@@ -5,26 +5,7 @@ Copyright (c) 2021 Robbert Broersma
 
 import { ArgsTable, Meta, Story, Canvas } from "@storybook/addon-docs";
 import "./bem.scss";
-import clsx from "clsx";
-
-export const Template = ({ distanced = false }) =>
-  `<ul class="${clsx("utrecht-unordered-list", distanced && "utrecht-unordered-list--distanced")}">
-  <li class="utrecht-unordered-list__item">Lorem</li>
-  <li class="utrecht-unordered-list__item">Ipsum</li>
-  <li class="utrecht-unordered-list__item">Dolor</li>
-</ul>`;
-
-export const TemplateNested = ({ distanced = false }) =>
-  `<ul class="${clsx("utrecht-unordered-list", distanced && "utrecht-unordered-list--distanced")}">
-  <li class="utrecht-unordered-list__item">Lorem</li>
-  <li class="utrecht-unordered-list__item">Ipsum
-    <ul class="utrecht-unordered-list utrecht-unordered-list--nested">
-      <li class="utrecht-unordered-list__item">Lorem</li>
-      <li class="utrecht-unordered-list__item">Ipsum</li>
-    </ul>
-  </li>
-  <li class="utrecht-unordered-list__item">Dolor</li>
-</ul>`;
+import { UnorderedList, UnorderedListNested } from "./bem";
 
 <Meta
   title="CSS Component/Unordered List"
@@ -36,7 +17,7 @@ export const TemplateNested = ({ distanced = false }) =>
   }}
   parameters={{
     docs: {
-      transformSource: (_src, { args }) => Template(args),
+      transformSource: (_src, { args }) => UnorderedList(args),
     },
     status: {
       type: "WORK IN PROGRESS",
@@ -51,7 +32,7 @@ export const TemplateNested = ({ distanced = false }) =>
       distanced: true,
     }}
   >
-    {Template.bind({})}
+    {UnorderedList.bind({})}
   </Story>
 </Canvas>
 
@@ -60,5 +41,14 @@ export const TemplateNested = ({ distanced = false }) =>
 ## Nested list
 
 <Canvas>
-  <Story name="Nested Ordered list">{TemplateNested.bind({})}</Story>
+  <Story
+    name="Nested Ordered list"
+    parameters={{
+      docs: {
+        transformSource: (_src, { args }) => UnorderedListNested(args),
+      },
+    }}
+  >
+    {UnorderedListNested.bind({})}
+  </Story>
 </Canvas>


### PR DESCRIPTION
Having the template functions available outside of `mdx` files makes it easier for other projects to reuse the templates by importing them from `@utrecht/components/button/bem.js` without having to configure Babel or anything like that for `mdx` support.