### PR TITLE
docs: moved Checkbox documentation from Figma to Github

### DIFF
--- a/components/checkbox/README.md
+++ b/components/checkbox/README.md
@@ -1,6 +1,6 @@
 <!--
 @license EUPL-1.2
-Copyright (c) 2021 Robbert Broersma
+Copyright (c) 2021 Robbert Broersma, Gemeente Den Haag, Rogier Barendregt
 -->
 
 # Checkbox


### PR DESCRIPTION
Moved (UX) documentation from Figma to Github so it can be included in Storybook.

Design properties have not been included since these were still Den Haag’s design properties. Also not included are dos and don’ts examples, these need to be displayed in Utrecht’s components rather than Den Haag’s.