### PR TITLE
docs: relicense most documentation as CC0

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,3 +1,5 @@
+<!-- @license CC0-1.0 -->
+
 # Auteursrecht Gemeente Utrecht
 
 Copyright (c) 2021 Gemeente Utrecht

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- @license CC0-1.0 -->
+
 # Utrecht Design System
 
 **This project is very much WORK IN PROGRESS and all components are released as _alpha_ version. Always define the exact version you want to use, and test for breaking changes before upgrading to a newer alpha release.**
@@ -124,6 +126,6 @@ We pledge to act and interact in ways that contribute to an open, welcoming, div
 
 ## License
 
-This project is free and open-source software licensed under the [European Union Public License (EUPL) v1.2](LICENSE.md).
+This project is free and open-source software licensed under the [European Union Public License (EUPL) v1.2](LICENSE.md). Most documentation is licensed as [Creative Commons Zero 1.0 Universal (`CC0-1.0`)](https://creativecommons.org/publicdomain/zero/1.0/legalcode)
 
 For information about proprietary assets in this repository, please carefully read the [NOTICE file](NOTICE.md).

--- a/components/alternate-lang-link/README.md
+++ b/components/alternate-lang-link/README.md
@@ -1,7 +1,4 @@
-<!--
-@license EUPL-1.2
-Copyright (c) 2021 Robbert Broersma
--->
+<!-- @license CC0-1.0 -->
 
 # Alternate Language Link
 

--- a/components/alternate-lang-nav/README.md
+++ b/components/alternate-lang-nav/README.md
@@ -1,7 +1,4 @@
-<!--
-@license EUPL-1.2
-Copyright (c) 2021 Robbert Broersma
--->
+<!-- @license CC0-1.0 -->
 
 # Alternate Language Navigation
 

--- a/components/article/README.md
+++ b/components/article/README.md
@@ -1,1 +1,3 @@
+<!-- @license CC0-1.0 -->
+
 # Article

--- a/components/badge-counter/README.md
+++ b/components/badge-counter/README.md
@@ -1,1 +1,3 @@
+<!-- @license CC0-1.0 -->
+
 # Counter badge

--- a/components/badge-data/README.md
+++ b/components/badge-data/README.md
@@ -1,1 +1,3 @@
+<!-- @license CC0-1.0 -->
+
 # Data badge

--- a/components/badge-status/README.md
+++ b/components/badge-status/README.md
@@ -1,1 +1,3 @@
+<!-- @license CC0-1.0 -->
+
 # Status badge

--- a/components/badge/README.md
+++ b/components/badge/README.md
@@ -1,3 +1,5 @@
+<!-- @license CC0-1.0 -->
+
 # Badge
 
 Badge is an "abstract component", where design tokens can be configured that apply to all badge types.

--- a/components/breadcrumb/README.md
+++ b/components/breadcrumb/README.md
@@ -1,3 +1,5 @@
+<!-- @license CC0-1.0 -->
+
 # Breadcrumb navigation
 
 ## Related info

--- a/components/checkbox/README.md
+++ b/components/checkbox/README.md
@@ -1,7 +1,4 @@
-<!--
-@license EUPL-1.2
-Copyright (c) 2021 Robbert Broersma, Gemeente Den Haag, Rogier Barendregt
--->
+<!-- @license CC0-1.0 -->
 
 # Checkbox
 

--- a/components/common/focus/README.md
+++ b/components/common/focus/README.md
@@ -1,7 +1,4 @@
-<!--
-@license EUPL-1.2
-Copyright (c) 2021 Robbert Broersma
--->
+<!-- @license CC0-1.0 -->
 
 # Focus
 

--- a/components/custom-checkbox/README.md
+++ b/components/custom-checkbox/README.md
@@ -1,1 +1,3 @@
+<!-- @license CC0-1.0 -->
+
 # Custom Checkbox

--- a/components/digid-button/README.md
+++ b/components/digid-button/README.md
@@ -1,1 +1,3 @@
+<!-- @license CC0-1.0 -->
+
 # DigiD button

--- a/components/document/README.md
+++ b/components/document/README.md
@@ -1,1 +1,3 @@
+<!-- @license CC0-1.0 -->
+
 # Document root

--- a/components/emphasis/README.md
+++ b/components/emphasis/README.md
@@ -1,1 +1,3 @@
+<!-- @license CC0-1.0 -->
+
 # Emphasis

--- a/components/favicon/README.md
+++ b/components/favicon/README.md
@@ -1,6 +1,3 @@
-<!--
-@license EUPL-1.2
-Copyright (c) 2021 Gemeente Utrecht
--->
+<!-- @license CC0-1.0 -->
 
 # Favicon

--- a/components/form-field-checkbox-group/README.md
+++ b/components/form-field-checkbox-group/README.md
@@ -1,1 +1,3 @@
+<!-- @license CC0-1.0 -->
+
 # Form field with checkbox group

--- a/components/form-field-description/README.md
+++ b/components/form-field-description/README.md
@@ -1,3 +1,5 @@
+<!-- @license CC0-1.0 -->
+
 # Form Field Description
 
 Use this component in forms to describe why a form input is invalid.

--- a/components/form-field-radio-group/README.md
+++ b/components/form-field-radio-group/README.md
@@ -1,1 +1,3 @@
+<!-- @license CC0-1.0 -->
+
 # Form field with radio group

--- a/components/form-field-radio/README.md
+++ b/components/form-field-radio/README.md
@@ -1,1 +1,3 @@
+<!-- @license CC0-1.0 -->
+
 # Form field with radio

--- a/components/form-field-textbox/README.md
+++ b/components/form-field-textbox/README.md
@@ -1,1 +1,3 @@
+<!-- @license CC0-1.0 -->
+
 # Form field with textbox

--- a/components/form-fieldset/README.md
+++ b/components/form-fieldset/README.md
@@ -1,1 +1,3 @@
+<!-- @license CC0-1.0 -->
+
 # Fieldset

--- a/components/form-input/README.md
+++ b/components/form-input/README.md
@@ -1,3 +1,5 @@
+<!-- @license CC0-1.0 -->
+
 # Form Input
 
 Form input is an "abstract component", where design tokens can be configured that apply to the following form input components:

--- a/components/form-label/README.md
+++ b/components/form-label/README.md
@@ -1,3 +1,5 @@
+<!-- @license CC0-1.0 -->
+
 # Form label
 
 ## Terminologie

--- a/components/form-toggle/README.md
+++ b/components/form-toggle/README.md
@@ -1,1 +1,3 @@
+<!-- @license CC0-1.0 -->
+
 # Form Toggle

--- a/components/form-toggle/design.md
+++ b/components/form-toggle/design.md
@@ -1,3 +1,5 @@
+<!-- @license CC0-1.0 -->
+
 <!-- markdownlint-disable first-line-h1 -->
 
 ## Design

--- a/components/heading-1/README.md
+++ b/components/heading-1/README.md
@@ -1,6 +1,3 @@
-<!--
-@license EUPL-1.2
-Copyright (c) 2021 Gemeente Utrecht
--->
+<!-- @license CC0-1.0 -->
 
 # Heading 1

--- a/components/heading-2/README.md
+++ b/components/heading-2/README.md
@@ -1,6 +1,3 @@
-<!--
-@license EUPL-1.2
-Copyright (c) 2021 Gemeente Utrecht
--->
+<!-- @license CC0-1.0 -->
 
 # Heading 2

--- a/components/heading-3/README.md
+++ b/components/heading-3/README.md
@@ -1,6 +1,3 @@
-<!--
-@license EUPL-1.2
-Copyright (c) 2021 Gemeente Utrecht
--->
+<!-- @license CC0-1.0 -->
 
 # Heading 3

--- a/components/heading-4/README.md
+++ b/components/heading-4/README.md
@@ -1,6 +1,3 @@
-<!--
-@license EUPL-1.2
-Copyright (c) 2021 Gemeente Utrecht
--->
+<!-- @license CC0-1.0 -->
 
 # Heading 4

--- a/components/heading-5/README.md
+++ b/components/heading-5/README.md
@@ -1,6 +1,3 @@
-<!--
-@license EUPL-1.2
-Copyright (c) 2021 Gemeente Utrecht
--->
+<!-- @license CC0-1.0 -->
 
 # Heading 5

--- a/components/heading-6/README.md
+++ b/components/heading-6/README.md
@@ -1,6 +1,3 @@
-<!--
-@license EUPL-1.2
-Copyright (c) 2021 Gemeente Utrecht
--->
+<!-- @license CC0-1.0 -->
 
 # Heading 6

--- a/components/heading/README.md
+++ b/components/heading/README.md
@@ -1,7 +1,4 @@
-<!--
-@license EUPL-1.2
-Copyright (c) 2021 Gemeente Utrecht
--->
+<!-- @license CC0-1.0 -->
 
 # Heading
 

--- a/components/html-content/README.md
+++ b/components/html-content/README.md
@@ -1,1 +1,3 @@
+<!-- @license CC0-1.0 -->
+
 # HTML Content

--- a/components/icon/CONTRIBUTING.md
+++ b/components/icon/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+<!-- @license CC0-1.0 -->
+
 # Contributing
 
 Updating an icon SVG needs to happen in two files: the `icon.stencil.tsx` and in the `icon.svg` file.

--- a/components/icon/README.md
+++ b/components/icon/README.md
@@ -1,7 +1,4 @@
-<!--
-@license EUPL-1.2
-Copyright (c) 2021 Robbert Broersma
--->
+<!-- @license CC0-1.0 -->
 
 # Icons
 

--- a/components/icon/design.md
+++ b/components/icon/design.md
@@ -1,3 +1,5 @@
+<!-- @license CC0-1.0 -->
+
 <!-- markdownlint-disable first-line-h1 -->
 
 ## Design

--- a/components/link-list/README.md
+++ b/components/link-list/README.md
@@ -1,1 +1,3 @@
+<!-- @license CC0-1.0 -->
+
 # Link List

--- a/components/link-social/README.md
+++ b/components/link-social/README.md
@@ -1,1 +1,3 @@
+<!-- @license CC0-1.0 -->
+
 # Link to Social Media

--- a/components/logo/README.md
+++ b/components/logo/README.md
@@ -1,3 +1,5 @@
+<!-- @license CC0-1.0 -->
+
 # Logo Gemeente Utrecht
 
 ## Text content

--- a/components/menulijst/README.md
+++ b/components/menulijst/README.md
@@ -1,1 +1,3 @@
+<!-- @license CC0-1.0 -->
+
 # Menulijst

--- a/components/nav-top/README.md
+++ b/components/nav-top/README.md
@@ -1,1 +1,3 @@
+<!-- @license CC0-1.0 -->
+
 # Navigatie - Top Nav

--- a/components/ordered-list/README.md
+++ b/components/ordered-list/README.md
@@ -1,6 +1,3 @@
-<!--
-@license EUPL-1.2
-Copyright (c) 2021 Gemeente Utrecht
--->
+<!-- @license CC0-1.0 -->
 
 # Lijsten

--- a/components/page-content/README.md
+++ b/components/page-content/README.md
@@ -1,1 +1,3 @@
+<!-- @license CC0-1.0 -->
+
 # Page content

--- a/components/page-footer/README.md
+++ b/components/page-footer/README.md
@@ -1,1 +1,3 @@
+<!-- @license CC0-1.0 -->
+
 # Page Footer

--- a/components/page-header/README.md
+++ b/components/page-header/README.md
@@ -1,1 +1,3 @@
+<!-- @license CC0-1.0 -->
+
 # Page Header

--- a/components/page/README.md
+++ b/components/page/README.md
@@ -1,3 +1,5 @@
+<!-- @license CC0-1.0 -->
+
 # Page component
 
 Component that centers the page. The page maximizes the width of the content for large viewports, to keep the line length of texts readable and avoid large horizontal distances between related components.

--- a/components/pagination/README.md
+++ b/components/pagination/README.md
@@ -1,1 +1,3 @@
+<!-- @license CC0-1.0 -->
+
 # Pagination navigation

--- a/components/paragraph/README.md
+++ b/components/paragraph/README.md
@@ -1,7 +1,4 @@
-<!--
-@license EUPL-1.2
-Copyright (c) 2021 Robbert Broersma
--->
+<!-- @license CC0-1.0 -->
 
 # Paragraph
 

--- a/components/pre-heading/README.md
+++ b/components/pre-heading/README.md
@@ -1,1 +1,3 @@
+<!-- @license CC0-1.0 -->
+
 # Pre-heading

--- a/components/radio-button/README.md
+++ b/components/radio-button/README.md
@@ -1,7 +1,4 @@
-<!--
-@license EUPL-1.2
-Copyright (c) 2021 Robbert Broersma
--->
+<!-- @license CC0-1.0 -->
 
 # Radio button
 

--- a/components/search-bar/README.md
+++ b/components/search-bar/README.md
@@ -1,3 +1,5 @@
+<!-- @license CC0-1.0 -->
+
 # Search Bar
 
 De search bar bestaat uit een button element en een input element. Het is onderdeel van het header patroon.

--- a/components/surface/README.md
+++ b/components/surface/README.md
@@ -1,7 +1,4 @@
-<!--
-@license EUPL-1.2
-Copyright (c) 2021 Robbert Broersma
--->
+<!-- @license CC0-1.0 -->
 
 # Surface component
 

--- a/components/table/README.md
+++ b/components/table/README.md
@@ -1,1 +1,3 @@
+<!-- @license CC0-1.0 -->
+
 # Table

--- a/components/textarea/README.md
+++ b/components/textarea/README.md
@@ -1,7 +1,4 @@
-<!--
-@license EUPL-1.2
-Copyright (c) 2021 Robbert Broersma
--->
+<!-- @license CC0-1.0 -->
 
 # Textarea
 

--- a/components/textbox/README.md
+++ b/components/textbox/README.md
@@ -1,7 +1,4 @@
-<!--
-@license EUPL-1.2
-Copyright (c) 2021 Robbert Broersma
--->
+<!-- @license CC0-1.0 -->
 
 # Text box
 

--- a/components/url/README.md
+++ b/components/url/README.md
@@ -1,3 +1,5 @@
+<!-- @license CC0-1.0 -->
+
 # URL component
 
 Component to display URLs in a page.

--- a/documentation/accessibility.md
+++ b/documentation/accessibility.md
@@ -1,3 +1,5 @@
+<!-- @license CC0-1.0 -->
+
 # Accessibility
 
 **_The following are general accessibility guidelines and pointers, please refer to each individual pattern or component for their specific guidelines._**

--- a/documentation/content-richtlijnen.md
+++ b/documentation/content-richtlijnen.md
@@ -1,3 +1,5 @@
+<!-- @license CC0-1.0 -->
+
 # Tekst en taalgebruik
 
 ## Introductie

--- a/documentation/content-translation.md
+++ b/documentation/content-translation.md
@@ -1,7 +1,4 @@
-<!--
-@license EUPL-1.2
-Copyright (c) 2021 Robbert Broersma
--->
+<!-- @license CC0-1.0 -->
 
 # Content translation
 

--- a/documentation/design-tokens.md
+++ b/documentation/design-tokens.md
@@ -1,1 +1,3 @@
+<!-- @license CC0-1.0 -->
+
 # Design tokens

--- a/documentation/form-patterns.md
+++ b/documentation/form-patterns.md
@@ -1,3 +1,5 @@
+<!-- @license CC0-1.0 -->
+
 # Forms
 
 For individual form component guidelines please consult the documentation for that specific component.

--- a/documentation/nl-design-system/contributing-a11y.md
+++ b/documentation/nl-design-system/contributing-a11y.md
@@ -1,7 +1,4 @@
-<!--
-@license EUPL-1.2
-Copyright (c) 2021 Robbert Broersma
--->
+<!-- @license CC0-1.0 -->
 
 # Contribution Guidelines for accessibility
 

--- a/documentation/nl-design-system/contributing-css.md
+++ b/documentation/nl-design-system/contributing-css.md
@@ -1,7 +1,4 @@
-<!--
-@license EUPL-1.2
-Copyright (c) 2021 Robbert Broersma
--->
+<!-- @license CC0-1.0 -->
 
 # Contribution Guidelines for CSS
 

--- a/documentation/nl-design-system/contributing-design-token.md
+++ b/documentation/nl-design-system/contributing-design-token.md
@@ -1,3 +1,5 @@
+<!-- @license CC0-1.0 -->
+
 # Contribution Guidelines for Design Tokens
 
 ## Naming order

--- a/documentation/nl-design-system/contributing-html.md
+++ b/documentation/nl-design-system/contributing-html.md
@@ -1,7 +1,4 @@
-<!--
-@license EUPL-1.2
-Copyright (c) 2021 Robbert Broersma
--->
+<!-- @license CC0-1.0 -->
 
 # Contribution Guidelines for HTML
 

--- a/documentation/nl-design-system/contributing-npm-package.md
+++ b/documentation/nl-design-system/contributing-npm-package.md
@@ -1,7 +1,4 @@
-<!--
-@license EUPL-1.2
-Copyright (c) 2021 Robbert Broersma
--->
+<!-- @license CC0-1.0 -->
 
 # Contribution Guidelines for npm packages
 

--- a/documentation/nl-design-system/contributing-storybook.md
+++ b/documentation/nl-design-system/contributing-storybook.md
@@ -1,7 +1,4 @@
-<!--
-@license EUPL-1.2
-Copyright (c) 2021 Robbert Broersma
--->
+<!-- @license CC0-1.0 -->
 
 # Contribution Guidelines for Storybook
 

--- a/documentation/release-strategy.md
+++ b/documentation/release-strategy.md
@@ -1,7 +1,4 @@
-<!--
-@license EUPL-1.2
-Copyright (c) 2021 Robbert Broersma
--->
+<!-- @license CC0-1.0 -->
 
 # Release strategy
 

--- a/proprietary/design-tokens/README.md
+++ b/proprietary/design-tokens/README.md
@@ -1,3 +1,5 @@
+<!-- @license CC0-1.0 -->
+
 # Design Tokens for the Utrecht Design System
 
 **This project is very much WORK IN PROGRESS and most parts are released as _alpha_ version. Always define the exact version you want to use, and test for breaking changes before upgrading to a newer alpha release.**


### PR DESCRIPTION
Being able to copy and modify the documentation without having to manage all the copyright notices will greatly improve the ability to share and enjoy our work.

https://creativecommons.org/publicdomain/zero/1.0/legalcode

Documentation to which Gemeente Utrecht has contributed remains EUPL-1.2, until agreement has been reached regarding the relicensing. Contributions by Gemeente Den Haag and by the NL Design System team have approval for licensing as CC0.