### PR TITLE
fix: patch Stencil to copy nonce for <style> elements

### DIFF
--- a/.patches/@stencil+core+2.9.0.patch
+++ b/.patches/@stencil+core+2.9.0.patch
@@ -1,0 +1,27 @@
+diff --git a/node_modules/@stencil/core/internal/client/index.js b/node_modules/@stencil/core/internal/client/index.js
+index eed9f0a..14b8f7b 100644
+--- a/node_modules/@stencil/core/internal/client/index.js
++++ b/node_modules/@stencil/core/internal/client/index.js
+@@ -275,6 +275,11 @@ const addStyle = (styleContainerNode, cmpMeta, mode, hostElm) => {
+                     if (BUILD.hydrateServerSide || BUILD.hotModuleReplacement) {
+                         styleElm.setAttribute(HYDRATED_STYLE_ID, scopeId);
+                     }
++                    const nonceElm = styleContainerNode.ownerDocument.querySelector('style[nonce]');
++                    if (nonceElm) {
++                      styleElm.setAttribute('nonce', nonceElm.getAttribute('nonce'));
++                      console.log(`CSP nonce-${nonceElm.getAttribute('nonce')}`);
++                    }
+                     styleContainerNode.insertBefore(styleElm, styleContainerNode.querySelector('link'));
+                 }
+                 if (appliedStyles) {
+@@ -2641,6 +2646,10 @@ const bootstrapLazy = (lazyBundles, options = {}) => {
+     if (BUILD.invisiblePrehydration && (BUILD.hydratedClass || BUILD.hydratedAttribute)) {
+         visibilityStyle.innerHTML = cmpTags + HYDRATED_CSS;
+         visibilityStyle.setAttribute('data-styles', '');
++        const nonceElm = visibilityStyle.ownerDocument.querySelector('style[nonce]');
++        if (nonceElm) {
++          visibilityStyle.setAttribute('nonce', nonceElm.getAttribute('nonce'));
++        }
+         head.insertBefore(visibilityStyle, metaCharset ? metaCharset.nextSibling : head.firstChild);
+     }
+     // Process deferred connectedCallbacks now all components have been registered

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "npm-check-updates": "11.8.5",
         "npm-package-json-lint": "5.4.1",
         "npm-run-all": "4.1.5",
+        "patch-package": "6.4.7",
         "prettier": "2.4.1",
         "rimraf": "3.0.2",
         "stylelint": "14.0.1",
@@ -47,7 +48,7 @@
     },
     "components": {
       "name": "@utrecht/components",
-      "version": "1.0.0-alpha.80",
+      "version": "1.0.0-alpha.84",
       "license": "EUPL-1.2",
       "dependencies": {
         "clsx": "1.1.1"
@@ -59,7 +60,7 @@
     },
     "components/icon": {
       "name": "@utrecht/icon",
-      "version": "1.0.0-alpha.7",
+      "version": "1.0.0-alpha.11",
       "license": "EUPL-1.2",
       "devDependencies": {
         "svgo": "2.7.0"
@@ -18994,6 +18995,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/findup-sync": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
@@ -23567,6 +23577,15 @@
         "graceful-fs": "^4.1.9"
       }
     },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -27840,6 +27859,86 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "6.4.7",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.4.7.tgz",
+      "integrity": "sha512-S0vh/ZEafZ17hbhgqdnpunKDfzHQibQizx9g8yEf5dcVk3KOflOfdufRXQX8CSEkyOQwuM/bNz1GwKvFj54kaQ==",
+      "dev": true,
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^2.4.2",
+        "cross-spawn": "^6.0.5",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^7.0.1",
+        "is-ci": "^2.0.0",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.0",
+        "open": "^7.4.2",
+        "rimraf": "^2.6.3",
+        "semver": "^5.6.0",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/patch-package/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/patch-package/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/path-browserify": {
@@ -37502,7 +37601,7 @@
     },
     "packages/component-library-css": {
       "name": "@utrecht/component-library-css",
-      "version": "1.0.0-alpha.119",
+      "version": "1.0.0-alpha.123",
       "license": "EUPL-1.2",
       "devDependencies": {
         "@utrecht/design-tokens": "file:../../proprietary/design-tokens",
@@ -37513,7 +37612,7 @@
     },
     "packages/component-library-formio": {
       "name": "@utrecht/component-library-formio",
-      "version": "1.0.0-alpha.60",
+      "version": "1.0.0-alpha.64",
       "license": "EUPL-1.2",
       "devDependencies": {
         "@utrecht/web-component-library-stencil": "file:../web-component-library-stencil/",
@@ -37620,7 +37719,7 @@
     },
     "packages/web-component-library-angular": {
       "name": "@utrecht/web-component-library-angular",
-      "version": "1.0.0-alpha.102",
+      "version": "1.0.0-alpha.106",
       "license": "EUPL-1.2",
       "dependencies": {
         "tslib": "2.3.1"
@@ -40653,7 +40752,7 @@
     },
     "packages/web-component-library-react": {
       "name": "@utrecht/web-component-library-react",
-      "version": "1.0.0-alpha.118",
+      "version": "1.0.0-alpha.122",
       "license": "EUPL-1.2",
       "devDependencies": {
         "@types/node": "16.11.6",
@@ -40728,7 +40827,7 @@
     },
     "packages/web-component-library-stencil": {
       "name": "@utrecht/web-component-library-stencil",
-      "version": "1.0.0-alpha.118",
+      "version": "1.0.0-alpha.122",
       "license": "EUPL-1.2",
       "dependencies": {
         "@stencil/angular-output-target": "0.2.0",
@@ -40746,7 +40845,7 @@
     },
     "packages/web-component-library-vue": {
       "name": "@utrecht/web-component-library-vue",
-      "version": "1.0.0-alpha.64",
+      "version": "1.0.0-alpha.68",
       "license": "EUPL-1.2",
       "devDependencies": {
         "@utrecht/web-component-library-stencil": "file:../web-component-library-stencil",
@@ -40770,7 +40869,7 @@
     },
     "proprietary/design-tokens": {
       "name": "@utrecht/design-tokens",
-      "version": "1.0.0-alpha.112",
+      "version": "1.0.0-alpha.116",
       "license": "SEE LICENSE IN ../LICENSE.md",
       "devDependencies": {
         "chokidar-cli": "3.0.0",
@@ -48978,8 +49077,8 @@
       "version": "file:documentation",
       "requires": {
         "@storybook/addon-docs": "6.3.12",
-        "lodash.clonedeepwith": "*",
-        "lodash.isplainobject": "*"
+        "lodash.clonedeepwith": "4.5.0",
+        "lodash.isplainobject": "4.0.6"
       }
     },
     "@utrecht/icon": {
@@ -58119,6 +58218,15 @@
         "path-exists": "^4.0.0"
       }
     },
+    "find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "requires": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "findup-sync": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
@@ -61836,6 +61944,15 @@
         "graceful-fs": "^4.1.9"
       }
     },
+    "klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11"
+      }
+    },
     "kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -65250,6 +65367,70 @@
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
+    },
+    "patch-package": {
+      "version": "6.4.7",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.4.7.tgz",
+      "integrity": "sha512-S0vh/ZEafZ17hbhgqdnpunKDfzHQibQizx9g8yEf5dcVk3KOflOfdufRXQX8CSEkyOQwuM/bNz1GwKvFj54kaQ==",
+      "dev": true,
+      "requires": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^2.4.2",
+        "cross-spawn": "^6.0.5",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^7.0.1",
+        "is-ci": "^2.0.0",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.0",
+        "open": "^7.4.2",
+        "rimraf": "^2.6.3",
+        "semver": "^5.6.0",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "slash": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+          "dev": true
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+          "dev": true
+        }
+      }
     },
     "path-browserify": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "npm-check-updates": "11.8.5",
     "npm-package-json-lint": "5.4.1",
     "npm-run-all": "4.1.5",
+    "patch-package": "6.4.7",
     "prettier": "2.4.1",
     "rimraf": "3.0.2",
     "stylelint": "14.0.1",
@@ -51,6 +52,7 @@
   "scripts": {
     "build": "lerna run build",
     "clean": "lerna run clean",
+    "postinstall": "patch-package --patch-dir .patches",
     "lint": "npm-run-all --continue-on-error lint:** lint-workspaces",
     "lint:css": "stylelint '**/*.{css,scss}'",
     "lint:js": "eslint --ext '.js,.json,.jsx,.mdx,.ts,.tsx' --report-unused-disable-directives .",

--- a/packages/web-component-library-stencil/README.md
+++ b/packages/web-component-library-stencil/README.md
@@ -28,3 +28,24 @@ Then you can go ahead and see the result:
   <h1>Page styled with NL Design System</h1>
 </utrecht-html-content>
 ```
+
+## `Content-Security-Policy`
+
+Autodiscovery of the nonce will ensure the CSS for lazy loaded components can be loaded in pages with a strict CSP configuration. To safely configure the nonce, render a `style` element early in the `<head>` of your HTML page, with a cryptographically strong random value in the `nonce` attribute that you must generate for each request. For example:
+
+```html
+<html>
+  <head>
+    <style nonce="2346ad27d7568ba9896f1b7da6b5991251debdf2"></style>
+  </head>
+</html>
+```
+
+The nonce must match with the nonce you provide in the `Content-Security-Policy` HTTP header for the web page. For example:
+
+```text
+Content-Security-Policy: default-src 'self'; style-src 'self' 'nonce-2346ad27d7568ba9896f1b7da6b5991251debdf2'
+Content-Type: text/html
+```
+
+**You MUST NOT use a hardcoded value for the nonce.** Do not copy the example code as-is.


### PR DESCRIPTION
In order to support `Content-Security-Policy` without `unsafe-inline`, the `<style>` elements from Stencil must contain a `nonce` attribute. The nonce value must be generated randomly for every page request. In order to for Stencil to know what nonce to use, this patch will make Stencil look for any existing `<style nonce="123...">` attributes, and copy the value.

In order to use the Web Components with CSP (and CSP is always a good idea) include the following in the `<head>` of your page:

```html
<html>
  <head>
    <style nonce="RANDOMLY-GENERATE-THIS-STYLE-NONCE"></style>
    <script nonce="RANDOMLY-GENERATE-THIS-SCRIPT-NONCE"></script>
```

You can use empty tags like the example above, but a nonce on any `style` element will work as long as it is available before the web component code is loaded.

The nonce must match the value from the header, for example:

```text
Content-Security-Policy: default-src 'self'; script-src 'self' 'nonce-RANDOMLY-GENERATE-THIS-SCRIPT-NONCE'; style-src 'self' 'nonce-RANDOMLY-GENERATE-THIS-STYLE-NONCE';
```