### PR TITLE
feat: text-decoration-thickness design tokens for Link

### DIFF
--- a/components/link/bem.scss
+++ b/components/link/bem.scss
@@ -4,12 +4,72 @@
  * Copyright (c) 2021 Gemeente Utrecht
  */
 
+// Avoid false positive for new CSS function `max()`
+/* stylelint-disable scss/no-global-function-names */
+
 @import "../common/focus/bem";
+
+/*
+
+# CSS implementation
+
+## `text-decoration-skip`
+
+`text-decoration-skip` can be helpful to avoid making some texts unreadable.
+For example by obscuring Arabic diacritics.
+
+However, the combination of a greater thickness and skipping this thick underline
+leads to a very unappealing rendering of the underline. To avoid this,
+`text-decoration-skip` is disabled for interactive states.
+
+For design token configurations that have identical thickness for normal and interactive
+states, this will lead to the (undesirable) effect that the focus/hover effect is switching
+from an interrupted to an uninterrupted underline (for some texts).
+
+Apart from making `skip-ink` configurable for normal/focus/hover, there is no good solution yet.
+
+---
+
+Disabling `text-decoration-skip` for interactive states obscures some texts, and we assume for now
+that moving the pointer away from a link or having focus elsewhere first is simple enough to
+not make this too inconvenient.
+
+---
+
+Some folks implement the underline of links using `border-bottom` or even using a finely crafted
+`linear-gradient()` with a solid color at the bottom and transparent behind the text. These approaches
+would unfortunately not be able to provide the improved readability of `text-decoration-skip`.
+
+## `text-decoration-thickness`
+
+Varying `text-decoration-thickness` can be used to distinguish interactive states.
+
+---
+
+`text-decoration-thickness` appears to have rendering differences between Chrome and Safari.
+In Safari the line becomes thicker with extra pixels added to the bottom, while in Chrome
+the underline offset also seems to increase along with the thickness, which effectively means
+the underline is closer to the next line than in Safari.
+
+---
+
+It might be nice to use font-relative units for `text-decoration-thickness`, and that is why we
+use the `max()` function to ensure the underline remains visible for every font size.
+
+## `transition`
+
+`text-decoration-thickness` could be a candidate for animating between interactive states,
+however browsers don't seem to have implemented great looking supixel tweening yet.
+
+`text-decoration-skip` also makes the transition more challenging to implement.
+
+*/
 
 .utrecht-link {
   color: var(--utrecht-link-color, blue);
   text-decoration: var(--utrecht-link-text-decoration, underline);
   text-decoration-skip-ink: all;
+  text-decoration-thickness: max(var(--utrecht-link-text-decoration-thickness), 1px);
   text-underline-offset: var(--utrecht-link-text-underline-offset);
 }
 
@@ -22,6 +82,12 @@
 .utrecht-link--hover {
   color: var(--utrecht-link-hover-color, var(--utrecht-link-color));
   text-decoration: var(--utrecht-link-hover-text-decoration, var(--utrecht-link-text-decoration, underline));
+  text-decoration-skip: none;
+  text-decoration-skip-ink: none;
+  text-decoration-thickness: max(
+    var(--utrecht-link-hover-text-decoration-thickness, var(--utrecht-link-text-decoration-thickness)),
+    1px
+  );
 }
 
 .utrecht-link:active,
@@ -34,6 +100,12 @@
 
   color: var(--utrecht-link-focus-color, var(--utrecht-link-color));
   text-decoration: var(--utrecht-link-focus-text-decoration, var(--utrecht-link-text-decoration, underline));
+  text-decoration-skip: none;
+  text-decoration-skip-ink: none;
+  text-decoration-thickness: max(
+    var(--utrecht-link-focus-text-decoration-thickness, var(--utrecht-link-text-decoration-thickness)),
+    1px
+  );
 }
 
 .utrecht-link--focus-visible {

--- a/components/link/tokens.json
+++ b/components/link/tokens.json
@@ -13,6 +13,12 @@
           "inherits": true
         }
       },
+      "text-underline-thickness": {
+        "css": {
+          "syntax": "<length>",
+          "inherits": true
+        }
+      },
       "text-underline-offset": {
         "css": {
           "syntax": "<length>",
@@ -39,6 +45,12 @@
             "syntax": "none | underline",
             "inherits": true
           }
+        },
+        "text-underline-thickness": {
+          "css": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "hover": {
@@ -51,6 +63,12 @@
         "text-decoration": {
           "css": {
             "syntax": "none | underline",
+            "inherits": true
+          }
+        },
+        "text-underline-thickness": {
+          "css": {
+            "syntax": "<length>",
             "inherits": true
           }
         }

--- a/components/paragraph/README.md
+++ b/components/paragraph/README.md
@@ -38,6 +38,10 @@ Lead paragraph:
 - `utrecht-paragraph-lead-font-weight`
 - `utrecht-paragraph-lead-line-height`
 
+## Design
+
+Lijnhoogte moet voldoende afstand geven tot de regel eronder dat de de streep van onderstreepte tekst niet dichter bij de regel eronder staat dan de onderstreepte regel. Relevante CSS properties: `line-height`, `text-decoration-offset` en `text-decoration-thickness`.
+
 ## States
 
 Niet van toepassing.

--- a/documentation/link.stories.mdx
+++ b/documentation/link.stories.mdx
@@ -1,0 +1,57 @@
+<!-- @license CC0-1.0 -->
+
+import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Link } from "@utrecht/components/link/bem";
+import { Paragraph } from "@utrecht/components/paragraph/bem";
+
+export const ParagraphWithLink = ({ textContent, href, link }) =>
+  Paragraph({
+    textContent: textContent.replaceAll(link, () => Link({ textContent: link, href })),
+  });
+
+<Meta
+  title="CSS Component/Combining components/Link"
+  argTypes={{
+    href: {
+      description: "URL",
+      control: "text",
+    },
+    link: {
+      description: "Link text",
+      control: "text",
+    },
+    textContent: {
+      description: "Paragraph text",
+      control: "text",
+    },
+  }}
+  parameters={{
+    docs: {
+      transformSource: (_src, { args }) => ParagraphWithLink(args),
+    },
+    percy: { skip: true },
+    status: {
+      type: "WORK IN PROGRESS",
+    },
+  }}
+/>
+
+# Link with other components
+
+## Paragraph with link
+
+<Canvas>
+  <Story
+    name="Paragraph with link"
+    args={{
+      href: "https://example.com/",
+      textContent:
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+      link: "quis nostrud exercitation",
+    }}
+  >
+    {ParagraphWithLink.bind({})}
+  </Story>
+</Canvas>
+
+<ArgsTable story="Paragraph with link" />

--- a/proprietary/design-tokens/src/component/utrecht/link.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/link.tokens.json
@@ -13,7 +13,8 @@
       },
       "hover": {
         "color": { "value": "{utrecht.link.focus.color.value}" },
-        "text-decoration": { "value": "underline" }
+        "text-decoration": { "value": "underline" },
+        "text-decoration-thickness": { "value": "3px" }
       },
       "visited": {
         "color": { "value": "{utrecht.link.color.value}" }

--- a/proprietary/design-tokens/src/component/utrecht/paragraph.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/paragraph.tokens.json
@@ -4,7 +4,7 @@
       "font-family": {},
       "font-size": { "value": "{utrecht.typography.scale.md.font-size.value}" },
       "font-weight": { "value": "{utrecht.typography.weight-scale.normal.font-weight.value}" },
-      "line-height": { "value": "1.4" },
+      "line-height": { "value": "1.5" },
       "margin-block-start": { "value": "{utrecht.space.row.md.value}" },
       "margin-block-end": {},
       "lead": {


### PR DESCRIPTION
`a:hover` in a paragraph:

<img width="568" alt="Screenshot 2021-11-25 at 20 57 07" src="https://user-images.githubusercontent.com/30694/143495111-13f365ee-a772-4895-97b9-8cf7eaec45b7.png">

some findings:


## `text-decoration-skip`

`text-decoration-skip` can be helpful to avoid making some texts unreadable.
For example by obscuring Arabic diacritics.

However, the combination of a greater thickness and skipping this thick underline
leads to a very unappealing rendering of the underline. To avoid this,
`text-decoration-skip` is disabled for interactive states.

For design token configurations that have identical thickness for normal and interactive
states, this will lead to the (undesirable) effect that the focus/hover effect is switching
from an interrupted to an uninterrupted underline (for some texts).

Apart from making `skip-ink` configurable for normal/focus/hover, there is no good solution yet.

---

Disabling `text-decoration-skip` for interactive states obscures some texts, and we assume for now
that moving the pointer away from a link or having focus elsewhere first is simple enough to
not make this too inconvenient.

---

Some folks implement the underline of links using `border-bottom` or even using a finely crafted
`linear-gradient()` with a solid color at the bottom and transparent behind the text. These approaches
would unfortunately not be able to provide the improved readability of `text-decoration-skip`.

## `text-decoration-thickness`

Varying `text-decoration-thickness` can be used to distinguish interactive states.

---

`text-decoration-thickness` appears to have rendering differences between Chrome and Safari.
In Safari the line becomes thicker with extra pixels added to the bottom, while in Chrome
the underline offset also seems to increase along with the thickness, which effectively means
the underline is closer to the next line than in Safari.

---

It might be nice to use font-relative units for `text-decoration-thickness`, and that is why we
use the `max()` function to ensure the underline remains visible for every font size.

## `transition`

`text-decoration-thickness` could be a candidate for animating between interactive states,
however browsers don't seem to have implemented great looking supixel tweening yet.

`text-decoration-skip` also makes the transition more challenging to implement.
