### PR TITLE
fix: provide design tokens to all Storybook pages

### DIFF
--- a/packages/storybook/config/preview.js
+++ b/packages/storybook/config/preview.js
@@ -1,5 +1,7 @@
+import { DocsContainer } from '@storybook/addon-docs';
 import { defineCustomElements } from '@utrecht/web-component-library-stencil';
 import defaultsDeep from 'lodash.defaultsdeep';
+import React from 'react';
 
 import '@utrecht/components/document/bem.scss';
 import '@utrecht/design-tokens/dist/theme/index.css';
@@ -72,13 +74,11 @@ const addonDocs = {
       state: 'open',
     },
     // Use a custom wrapper element
-    /*
     container: ({ children }) => (
       <DocsContainer>
         <div className="utrecht-theme">{children}</div>
       </DocsContainer>
     ),
-    */
   },
 };
 


### PR DESCRIPTION
The color pages didn't have any colors, because the design tokens were unavailable.

If I recall correctly, we had to disable the decorators after upgrading to Storybook 6.3, but they seem to be working again.

<img width="578" alt="Screenshot 2021-11-26 at 16 07 16" src="https://user-images.githubusercontent.com/30694/143600454-9b6d9688-b58a-4133-9f08-df48ac4c8255.png">

