### PR TITLE
fix: provide design tokens to all Storybook pages

### DIFF
--- a/packages/storybook/config/preview-head.html
+++ b/packages/storybook/config/preview-head.html
@@ -1,2 +1,5 @@
 <link rel="icon" href="favicon.ico" />
 <link href="storybook.css" type="text/css" rel="stylesheet" />
+<script defer>
+  document.documentElement.classList.add("utrecht-theme");
+</script>

--- a/packages/storybook/config/preview.js
+++ b/packages/storybook/config/preview.js
@@ -71,14 +71,6 @@ const addonDocs = {
     source: {
       state: 'open',
     },
-    // Use a custom wrapper element
-    /*
-    container: ({ children }) => (
-      <DocsContainer>
-        <div className="utrecht-theme">{children}</div>
-      </DocsContainer>
-    ),
-    */
   },
 };
 


### PR DESCRIPTION
Since adding a decorator breaks stories with HTML templates in strings, and only seems to work when all stories use JSX, I am using a new approach to add the `utrecht-theme` class name to the documents.

<img width="578" alt="Screenshot 2021-11-26 at 16 07 16" src="https://user-images.githubusercontent.com/30694/143602811-40a3c8f7-a793-4884-87cf-18cffc04b7c9.png">

