### PR TITLE
refactor: omit .value in token reference

### DIFF
--- a/proprietary/design-tokens/src/common/utrecht/feedback-variant.tokens.json
+++ b/proprietary/design-tokens/src/common/utrecht/feedback-variant.tokens.json
@@ -3,56 +3,56 @@
     "feedback": {
       "danger": {
         "fill": {
-          "background-color": { "value": "{utrecht.feedback.danger.background-color.value}" },
-          "color": { "value": "{utrecht.color.white.value}" }
+          "background-color": { "value": "{utrecht.feedback.danger.background-color}" },
+          "color": { "value": "{utrecht.color.white}" }
         }
       },
       "warning": {
         "fill": {
-          "background-color": { "value": "{utrecht.feedback.warning.background-color.value}" },
-          "color": { "value": "{utrecht.color.black.value}" }
+          "background-color": { "value": "{utrecht.feedback.warning.background-color}" },
+          "color": { "value": "{utrecht.color.black}" }
         }
       },
       "safe": {
         "fill": {
-          "background-color": { "value": "{utrecht.feedback.safe.background-color.value}" },
-          "color": { "value": "{utrecht.color.white.value}" }
+          "background-color": { "value": "{utrecht.feedback.safe.background-color}" },
+          "color": { "value": "{utrecht.color.white}" }
         }
       },
       "invalid": {
         "fill": {
-          "background-color": { "value": "{utrecht.feedback.invalid.background-color.value}" },
-          "color": { "value": "{utrecht.color.white.value}" }
+          "background-color": { "value": "{utrecht.feedback.invalid.background-color}" },
+          "color": { "value": "{utrecht.color.white}" }
         }
       },
       "valid": {
         "fill": {
-          "background-color": { "value": "{utrecht.feedback.valid.background-color.value}" },
-          "color": { "value": "{utrecht.color.white.value}" }
+          "background-color": { "value": "{utrecht.feedback.valid.background-color}" },
+          "color": { "value": "{utrecht.color.white}" }
         }
       },
       "error": {
         "fill": {
-          "background-color": { "value": "{utrecht.feedback.error.background-color.value}" },
-          "color": { "value": "{utrecht.color.white.value}" }
+          "background-color": { "value": "{utrecht.feedback.error.background-color}" },
+          "color": { "value": "{utrecht.color.white}" }
         }
       },
       "success": {
         "fill": {
-          "background-color": { "value": "{utrecht.feedback.success.background-color.value}" },
-          "color": { "value": "{utrecht.color.white.value}" }
+          "background-color": { "value": "{utrecht.feedback.success.background-color}" },
+          "color": { "value": "{utrecht.color.white}" }
         }
       },
       "inactive": {
         "fill": {
-          "background-color": { "value": "{utrecht.feedback.inactive.background-color.value}" },
-          "color": { "value": "{utrecht.color.white.value}" }
+          "background-color": { "value": "{utrecht.feedback.inactive.background-color}" },
+          "color": { "value": "{utrecht.color.white}" }
         }
       },
       "active": {
         "fill": {
-          "background-color": { "value": "{utrecht.feedback.active.background-color.value}" },
-          "color": { "value": "{utrecht.color.white.value}" }
+          "background-color": { "value": "{utrecht.feedback.active.background-color}" },
+          "color": { "value": "{utrecht.color.white}" }
         }
       }
     }

--- a/proprietary/design-tokens/src/common/utrecht/feedback.tokens.json
+++ b/proprietary/design-tokens/src/common/utrecht/feedback.tokens.json
@@ -2,49 +2,49 @@
   "utrecht": {
     "feedback": {
       "danger": {
-        "background-color": { "value": "{utrecht.feedback.danger.color.value}" },
-        "border-color": { "value": "{utrecht.feedback.danger.color.value}" },
-        "color": { "value": "{utrecht.color.red.40.value}" }
+        "background-color": { "value": "{utrecht.feedback.danger.color}" },
+        "border-color": { "value": "{utrecht.feedback.danger.color}" },
+        "color": { "value": "{utrecht.color.red.40}" }
       },
       "warning": {
-        "background-color": { "value": "{utrecht.feedback.warning.color.value}" },
-        "border-color": { "value": "{utrecht.feedback.warning.color.value}" },
-        "color": { "value": "{utrecht.color.yellow.50.value}" }
+        "background-color": { "value": "{utrecht.feedback.warning.color}" },
+        "border-color": { "value": "{utrecht.feedback.warning.color}" },
+        "color": { "value": "{utrecht.color.yellow.50}" }
       },
       "safe": {
-        "background-color": { "value": "{utrecht.feedback.safe.color.value}" },
-        "border-color": { "value": "{utrecht.feedback.safe.color.value}" },
-        "color": { "value": "{utrecht.color.green.50.value}" }
+        "background-color": { "value": "{utrecht.feedback.safe.color}" },
+        "border-color": { "value": "{utrecht.feedback.safe.color}" },
+        "color": { "value": "{utrecht.color.green.50}" }
       },
       "invalid": {
-        "background-color": { "value": "{utrecht.color.invalid.value}" },
-        "border-color": { "value": "{utrecht.color.invalid.value}" },
-        "color": { "value": "{utrecht.color.invalid.value}" }
+        "background-color": { "value": "{utrecht.color.invalid}" },
+        "border-color": { "value": "{utrecht.color.invalid}" },
+        "color": { "value": "{utrecht.color.invalid}" }
       },
       "valid": {
-        "background-color": { "value": "{utrecht.feedback.safe.background-color.value}" },
-        "border-color": { "value": "{utrecht.feedback.safe.border-color.value}" },
-        "color": { "value": "{utrecht.feedback.safe.color.value}" }
+        "background-color": { "value": "{utrecht.feedback.safe.background-color}" },
+        "border-color": { "value": "{utrecht.feedback.safe.border-color}" },
+        "color": { "value": "{utrecht.feedback.safe.color}" }
       },
       "error": {
-        "background-color": { "value": "{utrecht.feedback.danger.background-color.value}" },
-        "border-color": { "value": "{utrecht.feedback.danger.border-color.value}" },
-        "color": { "value": "{utrecht.feedback.danger.color.value}" }
+        "background-color": { "value": "{utrecht.feedback.danger.background-color}" },
+        "border-color": { "value": "{utrecht.feedback.danger.border-color}" },
+        "color": { "value": "{utrecht.feedback.danger.color}" }
       },
       "success": {
-        "background-color": { "value": "{utrecht.feedback.safe.background-color.value}" },
-        "border-color": { "value": "{utrecht.feedback.safe.border-color.value}" },
-        "color": { "value": "{utrecht.feedback.safe.color.value}" }
+        "background-color": { "value": "{utrecht.feedback.safe.background-color}" },
+        "border-color": { "value": "{utrecht.feedback.safe.border-color}" },
+        "color": { "value": "{utrecht.feedback.safe.color}" }
       },
       "inactive": {
-        "background-color": { "value": "{utrecht.feedback.danger.background-color.value}" },
-        "border-color": { "value": "{utrecht.feedback.danger.border-color.value}" },
-        "color": { "value": "{utrecht.feedback.danger.color.value}" }
+        "background-color": { "value": "{utrecht.feedback.danger.background-color}" },
+        "border-color": { "value": "{utrecht.feedback.danger.border-color}" },
+        "color": { "value": "{utrecht.feedback.danger.color}" }
       },
       "active": {
-        "background-color": { "value": "{utrecht.feedback.safe.background-color.value}" },
-        "border-color": { "value": "{utrecht.feedback.safe.border-color.value}" },
-        "color": { "value": "{utrecht.feedback.safe.color.value}" }
+        "background-color": { "value": "{utrecht.feedback.safe.background-color}" },
+        "border-color": { "value": "{utrecht.feedback.safe.border-color}" },
+        "color": { "value": "{utrecht.feedback.safe.color}" }
       }
     }
   }

--- a/proprietary/design-tokens/src/common/utrecht/focus.tokens.json
+++ b/proprietary/design-tokens/src/common/utrecht/focus.tokens.json
@@ -2,14 +2,14 @@
   "utrecht": {
     "focus": {
       "background-color": {},
-      "border-color": { "value": "{utrecht.color.black.value}" },
-      "border-style": { "value": "{utrecht.border-style.dotted.value}" },
-      "box-shadow-color": { "value": "{utrecht.color.white.value}" },
-      "box-shadow-spread-radius": { "value": "{utrecht.border-width.md.value}" },
-      "color": { "value": "{utrecht.color.black.value}" },
-      "outline-color": { "value": "{utrecht.color.black.value}" },
-      "outline-style": { "value": "{utrecht.border-style.dotted.value}" },
-      "outline-width": { "value": "{utrecht.border-width.md.value}" }
+      "border-color": { "value": "{utrecht.color.black}" },
+      "border-style": { "value": "{utrecht.border-style.dotted}" },
+      "box-shadow-color": { "value": "{utrecht.color.white}" },
+      "box-shadow-spread-radius": { "value": "{utrecht.border-width.md}" },
+      "color": { "value": "{utrecht.color.black}" },
+      "outline-color": { "value": "{utrecht.color.black}" },
+      "outline-style": { "value": "{utrecht.border-style.dotted}" },
+      "outline-width": { "value": "{utrecht.border-width.md}" }
     }
   }
 }

--- a/proprietary/design-tokens/src/component/utrecht/backdrop.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/backdrop.tokens.json
@@ -2,10 +2,10 @@
   "utrecht": {
     "backdrop": {
       "background-color": {
-        "value": "{utrecht.color.white.value}"
+        "value": "{utrecht.color.white}"
       },
       "color": {
-        "value": "{utrecht.color.black.value}"
+        "value": "{utrecht.color.black}"
       },
       "opacity": {
         "value": "0.8"

--- a/proprietary/design-tokens/src/component/utrecht/badge-counter.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/badge-counter.tokens.json
@@ -2,17 +2,17 @@
   "utrecht": {
     "badge-counter": {
       "background-color": {
-        "value": "{utrecht.color.red.40.value}"
+        "value": "{utrecht.color.red.40}"
       },
       "border-radius": {
         "value": "3ex"
       },
       "color": {
-        "value": "{utrecht.color.white.value}"
+        "value": "{utrecht.color.white}"
       },
       "font-weight": {},
       "font-style": {
-        "value": "{utrecht.typography.font-style.normal.value}"
+        "value": "{utrecht.typography.font-style.normal}"
       },
       "padding-block": {
         "value": "1ex"

--- a/proprietary/design-tokens/src/component/utrecht/badge.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/badge.tokens.json
@@ -2,23 +2,23 @@
   "utrecht": {
     "badge": {
       "background-color": {
-        "value": "{utrecht.color.grey.30.value}"
+        "value": "{utrecht.color.grey.30}"
       },
       "border-radius": {
         "value": "0"
       },
       "color": {
-        "value": "{utrecht.color.white.value}"
+        "value": "{utrecht.color.white}"
       },
       "font-weight": {},
       "padding-block": {
-        "value": "{utrecht.space.block.xs.value}"
+        "value": "{utrecht.space.block.xs}"
       },
       "font-style": {
-        "value": "{utrecht.typography.font-style.normal.value}"
+        "value": "{utrecht.typography.font-style.normal}"
       },
       "padding-inline": {
-        "value": "{utrecht.space.inline.sm.value}"
+        "value": "{utrecht.space.inline.sm}"
       }
     }
   }

--- a/proprietary/design-tokens/src/component/utrecht/blockquote.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/blockquote.tokens.json
@@ -11,7 +11,7 @@
         "font-size": { "value": "0.75rem" }
       },
       "content": {
-        "color": { "value": "{utrecht.color.red.40.value}" },
+        "color": { "value": "{utrecht.color.red.40}" },
         "font-size": { "value": "1.125rem" }
       }
     }

--- a/proprietary/design-tokens/src/component/utrecht/breadcrumb.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/breadcrumb.tokens.json
@@ -4,7 +4,7 @@
       "block-size": { "value": "34px" },
       "font-family": {},
       "font-size": {
-        "value": "{utrecht.typography.scale.sm.font-size.value}"
+        "value": "{utrecht.typography.scale.sm.font-size}"
       },
       "text-transform": {},
       "divider": {
@@ -14,31 +14,31 @@
       },
       "item": {
         "padding-block-start": {
-          "value": "{utrecht.space.block.xs.value}"
+          "value": "{utrecht.space.block.xs}"
         },
         "padding-block-end": {
-          "value": "{utrecht.space.block.xs.value}"
+          "value": "{utrecht.space.block.xs}"
         },
         "padding-inline-end": {
-          "value": "{utrecht.space.inline.md.value}"
+          "value": "{utrecht.space.inline.md}"
         },
         "padding-inline-start": {
-          "value": "{utrecht.space.inline.md.value}"
+          "value": "{utrecht.space.inline.md}"
         }
       },
       "link": {
         "background-color": {
-          "value": "{utrecht.color.grey.90.value}"
+          "value": "{utrecht.color.grey.90}"
         },
         "color": {
-          "value": "{utrecht.color.black.value}"
+          "value": "{utrecht.color.black}"
         },
         "focus": {
           "background-color": {
-            "value": "{utrecht.color.yellow.60.value}"
+            "value": "{utrecht.color.yellow.60}"
           },
           "color": {
-            "value": "{utrecht.color.black.value}"
+            "value": "{utrecht.color.black}"
           }
         }
       }

--- a/proprietary/design-tokens/src/component/utrecht/button.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/button.tokens.json
@@ -1,51 +1,51 @@
 {
   "utrecht": {
     "button": {
-      "background-color": { "value": "{utrecht.color.blue.35.value}" },
+      "background-color": { "value": "{utrecht.color.blue.35}" },
       "border-radius": { "value": "0" },
       "border-width": { "value": "0" },
-      "color": { "value": "{utrecht.color.white.value}" },
-      "font-family": { "value": "{utrecht.typography.sans-serif.font-family.value}" },
-      "font-size": { "value": "{utrecht.typography.scale.md.font-size.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.inline.md.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.inline.md.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.sm.value}" },
-      "padding-block-end": { "value": "{utrecht.space.block.sm.value}" },
+      "color": { "value": "{utrecht.color.white}" },
+      "font-family": { "value": "{utrecht.typography.sans-serif.font-family}" },
+      "font-size": { "value": "{utrecht.typography.scale.md.font-size}" },
+      "padding-inline-start": { "value": "{utrecht.space.inline.md}" },
+      "padding-inline-end": { "value": "{utrecht.space.inline.md}" },
+      "padding-block-start": { "value": "{utrecht.space.block.sm}" },
+      "padding-block-end": { "value": "{utrecht.space.block.sm}" },
       "margin-inline-start": { "value": "0" },
       "margin-inline-end": { "value": "0" },
-      "margin-block-start": { "value": "{utrecht.space.row.xs.value}" },
-      "margin-block-end": { "value": "{utrecht.space.row.xs.value}" },
+      "margin-block-start": { "value": "{utrecht.space.row.xs}" },
+      "margin-block-end": { "value": "{utrecht.space.row.xs}" },
       "focus": {
-        "border-color": { "value": "{utrecht.color.blue.40.value}" },
-        "border-width": { "value": "{utrecht.border-width.md.value}" },
+        "border-color": { "value": "{utrecht.color.blue.40}" },
+        "border-width": { "value": "{utrecht.border-width.md}" },
         "transform-scale": { "value": "1.02" }
       },
       "disabled": {
-        "background-color": { "value": "{utrecht.color.grey.90.value}" },
-        "color": { "value": "{utrecht.color.white.value}" }
+        "background-color": { "value": "{utrecht.color.grey.90}" },
+        "color": { "value": "{utrecht.color.white}" }
       },
       "primary-action": {
-        "background-color": { "value": "{utrecht.color.blue.35.value}" },
-        "color": { "value": "{utrecht.color.white.value}" },
+        "background-color": { "value": "{utrecht.color.blue.35}" },
+        "color": { "value": "{utrecht.color.white}" },
         "hover": {
-          "background-color": { "value": "{utrecht.color.blue.40.value}" },
-          "color": { "value": "{utrecht.color.white.value}" }
+          "background-color": { "value": "{utrecht.color.blue.40}" },
+          "color": { "value": "{utrecht.color.white}" }
         }
       },
       "secondary-action": {
-        "background-color": { "value": "{utrecht.color.white.value}" },
-        "color": { "value": "{utrecht.color.blue.35.value}" },
-        "border-color": { "value": "{utrecht.color.blue.35.value}" },
-        "border-width": { "value": "{utrecht.border-width.md.value}" },
+        "background-color": { "value": "{utrecht.color.white}" },
+        "color": { "value": "{utrecht.color.blue.35}" },
+        "border-color": { "value": "{utrecht.color.blue.35}" },
+        "border-width": { "value": "{utrecht.border-width.md}" },
         "hover": {
-          "background-color": { "value": "{utrecht.color.white.value}" },
-          "color": { "value": "{utrecht.color.blue.35.value}" },
-          "border-color": { "value": "{utrecht.color.blue.40.value}" }
+          "background-color": { "value": "{utrecht.color.white}" },
+          "color": { "value": "{utrecht.color.blue.35}" },
+          "border-color": { "value": "{utrecht.color.blue.40}" }
         },
         "disabled": {
-          "background-color": { "value": "{utrecht.color.white.value}" },
-          "color": { "value": "{utrecht.color.grey.80.value}" },
-          "border-color": { "value": "{utrecht.color.grey.80.value}" }
+          "background-color": { "value": "{utrecht.color.white}" },
+          "color": { "value": "{utrecht.color.grey.80}" },
+          "border-color": { "value": "{utrecht.color.grey.80}" }
         }
       }
     }

--- a/proprietary/design-tokens/src/component/utrecht/custom-checkbox.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/custom-checkbox.tokens.json
@@ -2,10 +2,10 @@
   "utrecht": {
     "custom-checkbox": {
       "size": { "value": "24px" },
-      "border-color": { "value": "{utrecht.form-input.border-color.value}" },
-      "color": { "value": "{utrecht.form-input.color.value}" },
+      "border-color": { "value": "{utrecht.form-input.border-color}" },
+      "color": { "value": "{utrecht.form-input.color}" },
       "border-width": { "value": "1px" },
-      "background-color": { "value": "{utrecht.form-input.background-color.value}" },
+      "background-color": { "value": "{utrecht.form-input.background-color}" },
       "border-radius": { "value": "0" },
       "padding": {},
       "icon": {
@@ -23,16 +23,16 @@
         "background-color": {}
       },
       "disabled": {
-        "border-color": { "value": "{utrecht.color.grey.80.value}" },
+        "border-color": { "value": "{utrecht.color.grey.80}" },
         "border-width": {},
-        "background-color": { "value": "{utrecht.color.white.value}" },
-        "color": { "value": "{utrecht.color.grey.80.value}" }
+        "background-color": { "value": "{utrecht.color.white}" },
+        "color": { "value": "{utrecht.color.grey.80}" }
       },
       "checked": {
-        "border-color": { "value": "{utrecht.color.blue.40.value}" },
+        "border-color": { "value": "{utrecht.color.blue.40}" },
         "border-width": {},
-        "background-color": { "value": "{utrecht.color.blue.40.value}" },
-        "color": { "value": "{utrecht.color.white.value}" },
+        "background-color": { "value": "{utrecht.color.blue.40}" },
+        "color": { "value": "{utrecht.color.white}" },
         "active": {
           "border-color": {},
           "background-color": {}
@@ -42,10 +42,10 @@
         "color": {}
       },
       "invalid": {
-        "border-color": { "value": "{utrecht.form-input.invalid.border-color.value}" },
+        "border-color": { "value": "{utrecht.form-input.invalid.border-color}" },
         "border-width": {},
-        "background-color": { "value": "{utrecht.feedback.invalid.background-color.value}" },
-        "color": { "value": "{utrecht.color.white.value}" },
+        "background-color": { "value": "{utrecht.feedback.invalid.background-color}" },
+        "color": { "value": "{utrecht.color.white}" },
         "active": {
           "border-color": {},
           "background-color": {}

--- a/proprietary/design-tokens/src/component/utrecht/document.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/document.tokens.json
@@ -1,10 +1,10 @@
 {
   "utrecht": {
     "document": {
-      "background-color": { "value": "{utrecht.color.white.value}" },
-      "color": { "value": "{utrecht.color.black.value}" },
-      "font-family": { "value": "{utrecht.typography.sans-serif.font-family.value}" },
-      "font-size": { "value": "{utrecht.typography.scale.md.font-size.value}" },
+      "background-color": { "value": "{utrecht.color.white}" },
+      "color": { "value": "{utrecht.color.black}" },
+      "font-family": { "value": "{utrecht.typography.sans-serif.font-family}" },
+      "font-size": { "value": "{utrecht.typography.scale.md.font-size}" },
       "line-height": { "value": "1.4" }
     }
   }

--- a/proprietary/design-tokens/src/component/utrecht/emphasis.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/emphasis.tokens.json
@@ -5,7 +5,7 @@
         "font-style": {}
       },
       "strong": {
-        "font-weight": { "value": "{utrecht.typography.weight-scale.bold.font-weight.value}" }
+        "font-weight": { "value": "{utrecht.typography.weight-scale.bold.font-weight}" }
       }
     }
   }

--- a/proprietary/design-tokens/src/component/utrecht/form-field.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/form-field.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "form-field": {
-      "margin-block-start": { "value": "{utrecht.space.block.2xs.value}" },
-      "margin-block-end": { "value": "{utrecht.space.block.2xs.value}" }
+      "margin-block-start": { "value": "{utrecht.space.block.2xs}" },
+      "margin-block-end": { "value": "{utrecht.space.block.2xs}" }
     }
   }
 }

--- a/proprietary/design-tokens/src/component/utrecht/form-fieldset.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/form-fieldset.tokens.json
@@ -1,16 +1,16 @@
 {
   "utrecht": {
     "form-fieldset": {
-      "margin-block-start": { "value": "{utrecht.space.block.2xs.value}" },
-      "margin-block-end": { "value": "{utrecht.space.block.2xs.value}" },
+      "margin-block-start": { "value": "{utrecht.space.block.2xs}" },
+      "margin-block-end": { "value": "{utrecht.space.block.2xs}" },
       "legend": {
         "color": {},
         "font-family": {},
         "font-size": { "value": "1rem" },
-        "font-weight": { "value": "{utrecht.typography.weight-scale.bold.font-weight.value}" },
+        "font-weight": { "value": "{utrecht.typography.weight-scale.bold.font-weight}" },
         "line-height": { "value": "1.4" },
-        "margin-block-end": { "value": "{utrecht.space.block.sm.value}" },
-        "margin-block-start": { "value": "{utrecht.space.block.xl.value}" },
+        "margin-block-end": { "value": "{utrecht.space.block.sm}" },
+        "margin-block-start": { "value": "{utrecht.space.block.xl}" },
         "text-transform": { "value": "uppercase" }
       }
     }

--- a/proprietary/design-tokens/src/component/utrecht/form-input.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/form-input.tokens.json
@@ -1,28 +1,28 @@
 {
   "utrecht": {
     "form-input": {
-      "background-color": { "value": "{utrecht.color.white.value}" },
+      "background-color": { "value": "{utrecht.color.white}" },
       "block-size": { "value": "42px" },
-      "color": { "value": "{utrecht.color.black.value}" },
-      "border-color": { "value": "{utrecht.color.grey.30.value}" },
+      "color": { "value": "{utrecht.color.black}" },
+      "border-color": { "value": "{utrecht.color.grey.30}" },
       "border-radius": { "value": "0" },
-      "border-width": { "value": "{utrecht.border-width.sm.value}" },
-      "font-family": { "value": "{utrecht.document.font-family.value}" },
-      "font-size": { "value": "{utrecht.typography.scale.md.font-size.value}" },
+      "border-width": { "value": "{utrecht.border-width.sm}" },
+      "font-family": { "value": "{utrecht.document.font-family}" },
+      "font-size": { "value": "{utrecht.typography.scale.md.font-size}" },
       "max-inline-size": { "value": "28em" },
       "padding-block-end": { "value": "8px" },
       "padding-block-start": { "value": "8px" },
       "padding-inline-end": { "value": "12px" },
       "padding-inline-start": { "value": "12px" },
       "placeholder": {
-        "color": { "value": "{utrecht.color.grey.40.value}" },
-        "font-style": { "value": "{utrecht.typography.font-style.normal.value}" }
+        "color": { "value": "{utrecht.color.grey.40}" },
+        "font-style": { "value": "{utrecht.typography.font-style.normal}" }
       },
       "focus": {
-        "border-color": { "value": "{utrecht.color.grey.80.value}" }
+        "border-color": { "value": "{utrecht.color.grey.80}" }
       },
       "invalid": {
-        "border-color": { "value": "{utrecht.feedback.invalid.border-color.value}" },
+        "border-color": { "value": "{utrecht.feedback.invalid.border-color}" },
         "border-width": {}
       },
       "disabled": {

--- a/proprietary/design-tokens/src/component/utrecht/form-label.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/form-label.tokens.json
@@ -2,12 +2,12 @@
   "utrecht": {
     "form-label": {
       "font-size": { "value": "1em" },
-      "font-weight": { "value": "{utrecht.typography.weight-scale.bold.font-weight.value}" },
+      "font-weight": { "value": "{utrecht.typography.weight-scale.bold.font-weight}" },
       "checkbox": {
-        "font-weight": { "value": "{utrecht.typography.weight-scale.normal.font-weight.value}" }
+        "font-weight": { "value": "{utrecht.typography.weight-scale.normal.font-weight}" }
       },
       "radio": {
-        "font-weight": { "value": "{utrecht.typography.weight-scale.normal.font-weight.value}" }
+        "font-weight": { "value": "{utrecht.typography.weight-scale.normal.font-weight}" }
       }
     }
   }

--- a/proprietary/design-tokens/src/component/utrecht/form-toggle.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/form-toggle.tokens.json
@@ -2,12 +2,12 @@
   "utrecht": {
     "form-toggle": {
       "accent-color": { "value": "hsla(0, 0%, 48%, 1)" },
-      "background-color": { "value": "{utrecht.color.white.value}" },
+      "background-color": { "value": "{utrecht.color.white}" },
       "border-color": { "value": "transparent" },
       "border-radius": { "value": "0" },
       "border-style": { "value": "solid" },
       "border-width": { "value": "2px" },
-      "color": { "value": "{utrecht.color.black.value}" },
+      "color": { "value": "{utrecht.color.black}" },
       "height": { "value": "24px" },
       "padding-block-end": { "value": "0" },
       "padding-block-start": { "value": "0" },
@@ -17,24 +17,24 @@
       "track": {
         "border-radius": { "value": "10em" },
         "disabled": {
-          "background-color": { "value": "{utrecht.color.grey.90.value}" }
+          "background-color": { "value": "{utrecht.color.grey.90}" }
         }
       },
       "thumb": {
-        "background-color": { "value": "{utrecht.color.white.value}" },
+        "background-color": { "value": "{utrecht.color.white}" },
         "margin-inline-start": { "value": ".25em" },
         "margin-inline-end": { "value": ".25em" },
         "min-inline-size": { "value": "18px" },
         "disabled": {
           "box-shadow": { "value": 0 },
-          "background-color": { "value": "{utrecht.color.white.value}" }
+          "background-color": { "value": "{utrecht.color.white}" }
         }
       },
       "checked": {
-        "accent-color": { "value": "{utrecht.color.blue.35.value}" }
+        "accent-color": { "value": "{utrecht.color.blue.35}" }
       },
       "focus": {
-        "border-color": { "value": "{utrecht.color.black.value}" },
+        "border-color": { "value": "{utrecht.color.black}" },
         "border-style": { "value": "dotted" },
         "border-width": { "value": "2px" }
       }

--- a/proprietary/design-tokens/src/component/utrecht/heading-1.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/heading-1.tokens.json
@@ -1,14 +1,14 @@
 {
   "utrecht": {
     "heading-1": {
-      "color": { "value": "{utrecht.color.black.value}" },
-      "font-family": { "value": "{utrecht.typography.sans-serif.font-family.value}" },
-      "font-size": { "value": "{utrecht.typography.scale.3xl.font-size.value}" },
-      "font-weight": { "value": "{utrecht.typography.weight-scale.bold.font-weight.value}" },
-      "line-height": { "value": "{utrecht.typography.line-height.sm.value}" },
+      "color": { "value": "{utrecht.color.black}" },
+      "font-family": { "value": "{utrecht.typography.sans-serif.font-family}" },
+      "font-size": { "value": "{utrecht.typography.scale.3xl.font-size}" },
+      "font-weight": { "value": "{utrecht.typography.weight-scale.bold.font-weight}" },
+      "line-height": { "value": "{utrecht.typography.line-height.sm}" },
       "margin-block-end": { "value": "0.67rem" },
       "margin-block-start": { "value": "0.67rem" },
-      "letter-spacing": { "value": "{utrecht.typography.letter-spacing.normal.value}" },
+      "letter-spacing": { "value": "{utrecht.typography.letter-spacing.normal}" },
       "text-transform": {}
     }
   }

--- a/proprietary/design-tokens/src/component/utrecht/heading-2.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/heading-2.tokens.json
@@ -1,14 +1,14 @@
 {
   "utrecht": {
     "heading-2": {
-      "color": { "value": "{utrecht.color.black.value}" },
-      "font-family": { "value": "{utrecht.typography.sans-serif.font-family.value}" },
-      "font-size": { "value": "{utrecht.typography.scale.xl.font-size.value}" },
-      "font-weight": { "value": "{utrecht.typography.weight-scale.bold.font-weight.value}" },
-      "line-height": { "value": "{utrecht.typography.line-height.sm.value}" },
+      "color": { "value": "{utrecht.color.black}" },
+      "font-family": { "value": "{utrecht.typography.sans-serif.font-family}" },
+      "font-size": { "value": "{utrecht.typography.scale.xl.font-size}" },
+      "font-weight": { "value": "{utrecht.typography.weight-scale.bold.font-weight}" },
+      "line-height": { "value": "{utrecht.typography.line-height.sm}" },
       "margin-block-end": { "value": "0.3rem" },
       "margin-block-start": { "value": "1.5rem" },
-      "letter-spacing": { "value": "{utrecht.typography.letter-spacing.normal.value}" },
+      "letter-spacing": { "value": "{utrecht.typography.letter-spacing.normal}" },
       "text-transform": {}
     }
   }

--- a/proprietary/design-tokens/src/component/utrecht/heading-3.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/heading-3.tokens.json
@@ -1,14 +1,14 @@
 {
   "utrecht": {
     "heading-3": {
-      "color": { "value": "{utrecht.color.black.value}" },
-      "font-family": { "value": "{utrecht.typography.sans-serif.font-family.value}" },
-      "font-size": { "value": "{utrecht.typography.scale.xl.font-size.value}" },
-      "font-weight": { "value": "{utrecht.typography.weight-scale.normal.font-weight.value}" },
-      "line-height": { "value": "{utrecht.typography.line-height.sm.value}" },
+      "color": { "value": "{utrecht.color.black}" },
+      "font-family": { "value": "{utrecht.typography.sans-serif.font-family}" },
+      "font-size": { "value": "{utrecht.typography.scale.xl.font-size}" },
+      "font-weight": { "value": "{utrecht.typography.weight-scale.normal.font-weight}" },
+      "line-height": { "value": "{utrecht.typography.line-height.sm}" },
       "margin-block-end": { "value": "0.2rem" },
       "margin-block-start": { "value": "1rem" },
-      "letter-spacing": { "value": "{utrecht.typography.letter-spacing.normal.value}" },
+      "letter-spacing": { "value": "{utrecht.typography.letter-spacing.normal}" },
       "text-transform": {}
     }
   }

--- a/proprietary/design-tokens/src/component/utrecht/heading-4.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/heading-4.tokens.json
@@ -1,14 +1,14 @@
 {
   "utrecht": {
     "heading-4": {
-      "color": { "value": "{utrecht.color.black.value}" },
-      "font-family": { "value": "{utrecht.typography.sans-serif.font-family.value}" },
-      "font-size": { "value": "{utrecht.typography.scale.lg.font-size.value}" },
-      "font-weight": { "value": "{utrecht.typography.weight-scale.normal.font-weight.value}" },
-      "line-height": { "value": "{utrecht.typography.line-height.md.value}" },
+      "color": { "value": "{utrecht.color.black}" },
+      "font-family": { "value": "{utrecht.typography.sans-serif.font-family}" },
+      "font-size": { "value": "{utrecht.typography.scale.lg.font-size}" },
+      "font-weight": { "value": "{utrecht.typography.weight-scale.normal.font-weight}" },
+      "line-height": { "value": "{utrecht.typography.line-height.md}" },
       "margin-block-end": { "value": "0.3rem" },
       "margin-block-start": { "value": "1.2rem" },
-      "letter-spacing": { "value": "{utrecht.typography.letter-spacing.normal.value}" },
+      "letter-spacing": { "value": "{utrecht.typography.letter-spacing.normal}" },
       "text-transform": {}
     }
   }

--- a/proprietary/design-tokens/src/component/utrecht/heading-5.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/heading-5.tokens.json
@@ -1,15 +1,15 @@
 {
   "utrecht": {
     "heading-5": {
-      "color": { "value": "{utrecht.color.black.value}" },
-      "font-family": { "value": "{utrecht.typography.sans-serif.font-family.value}" },
-      "font-size": { "value": "{utrecht.typography.scale.sm.font-size.value}" },
-      "font-weight": { "value": "{utrecht.typography.weight-scale.normal.font-weight.value}" },
-      "line-height": { "value": "{utrecht.typography.line-height.md.value}" },
+      "color": { "value": "{utrecht.color.black}" },
+      "font-family": { "value": "{utrecht.typography.sans-serif.font-family}" },
+      "font-size": { "value": "{utrecht.typography.scale.sm.font-size}" },
+      "font-weight": { "value": "{utrecht.typography.weight-scale.normal.font-weight}" },
+      "line-height": { "value": "{utrecht.typography.line-height.md}" },
       "margin-block-end": { "value": "0.2rem" },
       "margin-block-start": { "value": "1rem" },
-      "letter-spacing": { "value": "{utrecht.typography.letter-spacing.sm.value}" },
-      "text-transform": { "value": "{utrecht.typography.text-transform.uppercase.value}" }
+      "letter-spacing": { "value": "{utrecht.typography.letter-spacing.sm}" },
+      "text-transform": { "value": "{utrecht.typography.text-transform.uppercase}" }
     }
   }
 }

--- a/proprietary/design-tokens/src/component/utrecht/heading-6.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/heading-6.tokens.json
@@ -1,15 +1,15 @@
 {
   "utrecht": {
     "heading-6": {
-      "color": { "value": "{utrecht.color.black.value}" },
-      "font-family": { "value": "{utrecht.typography.sans-serif.font-family.value}" },
-      "font-size": { "value": "{utrecht.typography.scale.sm.font-size.value}" },
-      "font-weight": { "value": "{utrecht.typography.weight-scale.normal.font-weight.value}" },
-      "line-height": { "value": "{utrecht.typography.line-height.md.value}" },
+      "color": { "value": "{utrecht.color.black}" },
+      "font-family": { "value": "{utrecht.typography.sans-serif.font-family}" },
+      "font-size": { "value": "{utrecht.typography.scale.sm.font-size}" },
+      "font-weight": { "value": "{utrecht.typography.weight-scale.normal.font-weight}" },
+      "line-height": { "value": "{utrecht.typography.line-height.md}" },
       "margin-block-end": {},
       "margin-block-start": {},
-      "letter-spacing": { "value": "{utrecht.typography.letter-spacing.sm.value}" },
-      "text-transform": { "value": "{utrecht.typography.text-transform.uppercase.value}" }
+      "letter-spacing": { "value": "{utrecht.typography.letter-spacing.sm}" },
+      "text-transform": { "value": "{utrecht.typography.text-transform.uppercase}" }
     }
   }
 }

--- a/proprietary/design-tokens/src/component/utrecht/heading.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/heading.tokens.json
@@ -3,7 +3,7 @@
     "heading": {
       "color": {},
       "font-family": {},
-      "font-weight": { "value": "{utrecht.typography.weight-scale.bold.font-weight.value}" }
+      "font-weight": { "value": "{utrecht.typography.weight-scale.bold.font-weight}" }
     }
   }
 }

--- a/proprietary/design-tokens/src/component/utrecht/link-list.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/link-list.tokens.json
@@ -3,10 +3,10 @@
     "link-list": {
       "item": {
         "margin-block-start": {
-          "value": "{utrecht.space.block.xs.value}"
+          "value": "{utrecht.space.block.xs}"
         },
         "font-weight": {
-          "value": "{utrecht.typography.weight-scale.bold.font-weight.value}"
+          "value": "{utrecht.typography.weight-scale.bold.font-weight}"
         }
       },
       "marker": {

--- a/proprietary/design-tokens/src/component/utrecht/link.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/link.tokens.json
@@ -1,23 +1,23 @@
 {
   "utrecht": {
     "link": {
-      "color": { "value": "{utrecht.color.blue.35.value}" },
+      "color": { "value": "{utrecht.color.blue.35}" },
       "text-decoration": { "value": "underline" },
       "text-underline-offset": { "value": "3px" },
       "active": {
-        "color": { "value": "{utrecht.link.color.value}" }
+        "color": { "value": "{utrecht.link.color}" }
       },
       "focus": {
-        "color": { "value": "{utrecht.color.blue.40.value}" },
+        "color": { "value": "{utrecht.color.blue.40}" },
         "text-decoration": { "value": "none" }
       },
       "hover": {
-        "color": { "value": "{utrecht.link.focus.color.value}" },
+        "color": { "value": "{utrecht.link.focus.color}" },
         "text-decoration": { "value": "underline" },
         "text-decoration-thickness": { "value": "3px" }
       },
       "visited": {
-        "color": { "value": "{utrecht.link.color.value}" }
+        "color": { "value": "{utrecht.link.color}" }
       }
     }
   }

--- a/proprietary/design-tokens/src/component/utrecht/mapcontrolbutton.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/mapcontrolbutton.tokens.json
@@ -1,43 +1,43 @@
 {
   "utrecht": {
     "mapcontrolbutton": {
-      "background-color": { "value": "{utrecht.color.white.value}" },
-      "border-color": { "value": "{utrecht.color.grey.40.value}" },
+      "background-color": { "value": "{utrecht.color.white}" },
+      "border-color": { "value": "{utrecht.color.grey.40}" },
       "border-radius": { "value": "2px" },
-      "border-style": { "value": "{utrecht.border-style.solid.value}" },
-      "border-width": { "value": "{utrecht.border-width.sm.value}" },
-      "color": { "value": "{utrecht.color.grey.40.value}" },
-      "margin-block-end": { "value": "{utrecht.space.row.xs.value}" },
-      "margin-block-start": { "value": "{utrecht.space.row.xs.value}" },
+      "border-style": { "value": "{utrecht.border-style.solid}" },
+      "border-width": { "value": "{utrecht.border-width.sm}" },
+      "color": { "value": "{utrecht.color.grey.40}" },
+      "margin-block-end": { "value": "{utrecht.space.row.xs}" },
+      "margin-block-start": { "value": "{utrecht.space.row.xs}" },
       "margin-inline-end": { "value": "0" },
       "margin-inline-start": { "value": "0" },
-      "min-block-size": { "value": "{utrecht.space.block.2xl.value}" },
-      "min-inline-size": { "value": "{utrecht.space.block.2xl.value}" },
-      "padding-block-end": { "value": "{utrecht.space.block.2xs.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.2xs.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.inline.2xs.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.inline.2xs.value}" },
+      "min-block-size": { "value": "{utrecht.space.block.2xl}" },
+      "min-inline-size": { "value": "{utrecht.space.block.2xl}" },
+      "padding-block-end": { "value": "{utrecht.space.block.2xs}" },
+      "padding-block-start": { "value": "{utrecht.space.block.2xs}" },
+      "padding-inline-end": { "value": "{utrecht.space.inline.2xs}" },
+      "padding-inline-start": { "value": "{utrecht.space.inline.2xs}" },
       "label": {
-        "margin-inline-start": { "value": "{utrecht.space.inline.xs.value}" },
-        "margin-inline-end": { "value": "{utrecht.space.inline.xs.value}" }
+        "margin-inline-start": { "value": "{utrecht.space.inline.xs}" },
+        "margin-inline-end": { "value": "{utrecht.space.inline.xs}" }
       },
       "focus": {
-        "color": { "value": "{utrecht.focus.color.value}" },
-        "box-shadow-color": { "value": "{utrecht.focus.box-shadow-color.value}" },
-        "border-style": { "value": "{utrecht.focus.border-style.value}" },
+        "color": { "value": "{utrecht.focus.color}" },
+        "box-shadow-color": { "value": "{utrecht.focus.box-shadow-color}" },
+        "border-style": { "value": "{utrecht.focus.border-style}" },
         "text-decoration": { "value": "none" },
         "background-color": {},
-        "outline-color": { "value": "{utrecht.focus.outline-color.value}" },
-        "border-color": { "value": "{utrecht.focus.border-color.value}" }
+        "outline-color": { "value": "{utrecht.focus.outline-color}" },
+        "border-color": { "value": "{utrecht.focus.border-color}" }
       },
       "hover": {
-        "background-color": { "value": "{utrecht.color.grey.90.value}" },
-        "color": { "value": "{utrecht.color.white.value}" }
+        "background-color": { "value": "{utrecht.color.grey.90}" },
+        "color": { "value": "{utrecht.color.white}" }
       },
       "disabled": {
-        "background-color": { "value": "{utrecht.color.grey.90.value}" },
-        "color": { "value": "{utrecht.color.grey.80.value}" },
-        "border-color": { "value": "{utrecht.color.grey.80.value}" }
+        "background-color": { "value": "{utrecht.color.grey.90}" },
+        "color": { "value": "{utrecht.color.grey.80}" },
+        "border-color": { "value": "{utrecht.color.grey.80}" }
       }
     }
   }

--- a/proprietary/design-tokens/src/component/utrecht/menulijst.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/menulijst.tokens.json
@@ -2,9 +2,9 @@
   "utrecht": {
     "menulijst": {
       "item": {
-        "color": { "value": "{utrecht.color.blue.35.value}" },
+        "color": { "value": "{utrecht.color.blue.35}" },
         "hover": {
-          "color": { "value": "{utrecht.color.blue.40.value}" }
+          "color": { "value": "{utrecht.color.blue.40}" }
         }
       }
     }

--- a/proprietary/design-tokens/src/component/utrecht/page-footer.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/page-footer.tokens.json
@@ -1,10 +1,10 @@
 {
   "utrecht": {
     "page-footer": {
-      "color": { "value": "{utrecht.color.white.value}" },
-      "background-color": { "value": "{utrecht.color.red.40.value}" },
+      "color": { "value": "{utrecht.color.white}" },
+      "background-color": { "value": "{utrecht.color.red.40}" },
       "background-image": {
-        "value": "linear-gradient(45deg, {utrecht.color.red.40.value}, {utrecht.color.red.40.value} 50%, hsl(5 54% 59%) 50%);"
+        "value": "linear-gradient(45deg, {utrecht.color.red.40}, {utrecht.color.red.40} 50%, hsl(5 54% 59%) 50%);"
       },
       "padding-inline-end": { "value": "1em" },
       "padding-inline-start": { "value": "1em" },

--- a/proprietary/design-tokens/src/component/utrecht/page.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/page.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "page": {
-      "background-color": { "value": "{utrecht.color.white.value}" },
-      "color": { "value": "{utrecht.color.black.value}" },
+      "background-color": { "value": "{utrecht.color.white}" },
+      "color": { "value": "{utrecht.color.black}" },
       "margin-inline-start": { "value": "2em" },
       "margin-inline-end": { "value": "2em" },
       "max-inline-size": { "value": "1184px" },

--- a/proprietary/design-tokens/src/component/utrecht/pagination.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/pagination.tokens.json
@@ -10,34 +10,34 @@
         "border-color": { "value": "transparent" },
         "border-radius": {},
         "border-width": { "value": "2px" },
-        "color": { "value": "{utrecht.color.blue.35.value}" },
-        "font-weight": { "value": "{utrecht.typography.weight-scale.bold.font-weight.value}" },
+        "color": { "value": "{utrecht.color.blue.35}" },
+        "font-weight": { "value": "{utrecht.typography.weight-scale.bold.font-weight}" },
         "padding-inline-start": { "value": "0.5em" },
         "padding-inline-end": { "value": "0.5em" },
         "padding-block-start": { "value": "0.5em" },
         "padding-block-end": { "value": "0.5em" },
         "text-decoration": { "value": "none" },
         "current": {
-          "background-color": { "value": "{utrecht.color.blue.35.value}" },
-          "border-color": { "value": "{utrecht.color.blue.35.value}" },
-          "color": { "value": "{utrecht.color.white.value}" }
+          "background-color": { "value": "{utrecht.color.blue.35}" },
+          "border-color": { "value": "{utrecht.color.blue.35}" },
+          "color": { "value": "{utrecht.color.white}" }
         },
         "distanced": {
           "margin-inline-start": { "value": "0.5em" }
         },
         "hover": {
-          "background-color": { "value": "{utrecht.color.blue.35.value}" },
-          "border-color": { "value": "{utrecht.color.blue.35.value}" },
-          "color": { "value": "{utrecht.color.white.value}" }
+          "background-color": { "value": "{utrecht.color.blue.35}" },
+          "border-color": { "value": "{utrecht.color.blue.35}" },
+          "color": { "value": "{utrecht.color.white}" }
         }
       },
       "relative-link": {
-        "background-color": { "value": "{utrecht.color.white.value}" },
-        "border-color": { "value": "{utrecht.color.blue.35.value}" },
+        "background-color": { "value": "{utrecht.color.white}" },
+        "border-color": { "value": "{utrecht.color.blue.35}" },
         "border-radius": {},
         "border-width": { "value": "2px" },
-        "color": { "value": "{utrecht.color.blue.35.value}" },
-        "font-weight": { "value": "{utrecht.typography.weight-scale.bold.font-weight.value}" },
+        "color": { "value": "{utrecht.color.blue.35}" },
+        "font-weight": { "value": "{utrecht.typography.weight-scale.bold.font-weight}" },
         "padding-inline-start": { "value": "0.5em" },
         "padding-inline-end": { "value": "0.5em" },
         "padding-block-start": { "value": "0.5em" },
@@ -49,9 +49,9 @@
           "margin-inline-start": { "value": "0.5em" }
         },
         "hover": {
-          "background-color": { "value": "{utrecht.color.blue.35.value}" },
-          "border-color": { "value": "{utrecht.color.blue.35.value}" },
-          "color": { "value": "{utrecht.color.white.value}" }
+          "background-color": { "value": "{utrecht.color.blue.35}" },
+          "border-color": { "value": "{utrecht.color.blue.35}" },
+          "color": { "value": "{utrecht.color.white}" }
         }
       }
     }

--- a/proprietary/design-tokens/src/component/utrecht/paragraph.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/paragraph.tokens.json
@@ -1,16 +1,16 @@
 {
   "utrecht": {
     "paragraph": {
-      "color": { "value": "{utrecht.document.color.value}" },
-      "font-family": { "value": "{utrecht.typography.sans-serif.font-family.value}" },
-      "font-size": { "value": "{utrecht.typography.scale.md.font-size.value}" },
-      "font-weight": { "value": "{utrecht.typography.weight-scale.normal.font-weight.value}" },
-      "line-height": { "value": "{utrecht.typography.line-height.md.value}" },
+      "color": { "value": "{utrecht.document.color}" },
+      "font-family": { "value": "{utrecht.typography.sans-serif.font-family}" },
+      "font-size": { "value": "{utrecht.typography.scale.md.font-size}" },
+      "font-weight": { "value": "{utrecht.typography.weight-scale.normal.font-weight}" },
+      "line-height": { "value": "{utrecht.typography.line-height.md}" },
       "lead": {
-        "color": { "value": "{utrecht.document.color.value}" },
-        "font-size": { "value": "{utrecht.typography.scale.lg.font-size.value}" },
-        "font-weight": { "value": "{utrecht.typography.weight-scale.normal.font-weight.value}" },
-        "line-height": { "value": "{utrecht.typography.line-height.md.value}" }
+        "color": { "value": "{utrecht.document.color}" },
+        "font-size": { "value": "{utrecht.typography.scale.lg.font-size}" },
+        "font-weight": { "value": "{utrecht.typography.weight-scale.normal.font-weight}" },
+        "line-height": { "value": "{utrecht.typography.line-height.md}" }
       }
     }
   }

--- a/proprietary/design-tokens/src/component/utrecht/pre-heading.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/pre-heading.tokens.json
@@ -4,13 +4,13 @@
       "color": {},
       "font-family": {},
       "font-size": {
-        "value": "{utrecht.typography.scale.md.font-size.value}"
+        "value": "{utrecht.typography.scale.md.font-size}"
       },
       "font-weight": {},
       "line-height": {},
       "margin-block-end": {},
       "margin-block-start": {
-        "value": "{utrecht.space.row.2xl.value}"
+        "value": "{utrecht.space.row.2xl}"
       },
       "text-transform": {
         "value": "uppercase"

--- a/proprietary/design-tokens/src/component/utrecht/search-bar.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/search-bar.tokens.json
@@ -5,15 +5,15 @@
         "background-position-x": { "value": ".5em" },
         "background-position-y": { "value": "50%" },
         "background-size": { "value": "1em" },
-        "border-color": { "value": "{utrecht.color.red.40.value}" },
-        "padding-inline-start": { "value": "{utrecht.space.inline.3xl.value}" }
+        "border-color": { "value": "{utrecht.color.red.40}" },
+        "padding-inline-start": { "value": "{utrecht.space.inline.3xl}" }
       },
       "button": {
-        "background-color": { "value": "{utrecht.color.red.40.value}" },
-        "border-color": { "value": "{utrecht.color.red.40.value}" },
-        "color": { "value": "{utrecht.color.white.value}" },
-        "font-size": { "value": "{utrecht.typography.scale.sm.font-size.value}" },
-        "font-weight": { "value": "{utrecht.typography.weight-scale.bold.font-weight.value}" },
+        "background-color": { "value": "{utrecht.color.red.40}" },
+        "border-color": { "value": "{utrecht.color.red.40}" },
+        "color": { "value": "{utrecht.color.white}" },
+        "font-size": { "value": "{utrecht.typography.scale.sm.font-size}" },
+        "font-weight": { "value": "{utrecht.typography.weight-scale.bold.font-weight}" },
         "letter-spacing": { "value": ".05em" },
         "text-transform": { "value": "uppercase" }
       },
@@ -22,7 +22,7 @@
         "color": {}
       },
       "invalid": {
-        "border-color": { "value": "{utrecht.feedback.invalid.border-color.value}" },
+        "border-color": { "value": "{utrecht.feedback.invalid.border-color}" },
         "border-width": {}
       },
       "read-only": {

--- a/proprietary/design-tokens/src/component/utrecht/separator.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/separator.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "separator": {
-      "color": { "value": "{utrecht.color.grey.90.value}" },
+      "color": { "value": "{utrecht.color.grey.90}" },
       "block-size": { "value": "8px" },
       "margin-block-end": {},
       "margin-block-start": {}

--- a/proprietary/design-tokens/src/component/utrecht/sidenav.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/sidenav.tokens.json
@@ -2,24 +2,24 @@
   "utrecht": {
     "sidenav": {
       "item": {
-        "margin-block-start": { "value": "{utrecht.space.block.xs.value}" },
-        "margin-block-end": { "value": "{utrecht.space.block.xs.value}" },
-        "margin-inline-start": { "value": "{utrecht.space.inline.3xs.value}" },
-        "margin-inline-end": { "value": "{utrecht.space.inline.3xs.value}" },
+        "margin-block-start": { "value": "{utrecht.space.block.xs}" },
+        "margin-block-end": { "value": "{utrecht.space.block.xs}" },
+        "margin-inline-start": { "value": "{utrecht.space.inline.3xs}" },
+        "margin-inline-end": { "value": "{utrecht.space.inline.3xs}" },
         "hover": {
-          "color": { "value": "{utrecht.color.blue.40.value}" }
+          "color": { "value": "{utrecht.color.blue.40}" }
         }
       },
       "item-marker": {
-        "color": { "value": "{utrecht.color.grey.80.value}" },
+        "color": { "value": "{utrecht.color.grey.80}" },
         "hover": {
-          "color": { "value": "{utrecht.color.blue.50.value}" }
+          "color": { "value": "{utrecht.color.blue.50}" }
         }
       },
       "link": {
-        "color": { "value": "{utrecht.color.blue.40.value}" },
+        "color": { "value": "{utrecht.color.blue.40}" },
         "hover": {
-          "color": { "value": "{utrecht.color.blue.40.value}" }
+          "color": { "value": "{utrecht.color.blue.40}" }
         }
       }
     }

--- a/proprietary/design-tokens/src/component/utrecht/surface.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/surface.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "surface": {
-      "background-color": { "value": "{utrecht.color.grey.95.value}" },
-      "color": { "value": "{utrecht.color.grey.10.value}" }
+      "background-color": { "value": "{utrecht.color.grey.95}" },
+      "color": { "value": "{utrecht.color.grey.10}" }
     }
   }
 }

--- a/proprietary/design-tokens/src/component/utrecht/table.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/table.tokens.json
@@ -5,7 +5,7 @@
       "margin-block-start": {},
       "caption": {
         "font-size": { "value": "1.125em" },
-        "font-weight": { "value": "{utrecht.typography.weight-scale.bold.font-weight.value}" },
+        "font-weight": { "value": "{utrecht.typography.weight-scale.bold.font-weight}" },
         "font-family": {},
         "color": {},
         "line-height": {},
@@ -13,11 +13,11 @@
         "margin-block-end": { "value": "1em" }
       },
       "header": {
-        "font-weight": { "value": "{utrecht.typography.weight-scale.bold.font-weight.value}" },
+        "font-weight": { "value": "{utrecht.typography.weight-scale.bold.font-weight}" },
         "color": {},
         "text-transform": {},
-        "border-block-end-color": { "value": "{utrecht.color.red.40.value}" },
-        "border-block-end-width": { "value": "{utrecht.border-width.md.value}" }
+        "border-block-end-color": { "value": "{utrecht.color.red.40}" },
+        "border-block-end-width": { "value": "{utrecht.border-width.md}" }
       },
       "heading": {
         "font-weight": {},
@@ -34,8 +34,8 @@
       "row": {
         "padding-inline-end": {},
         "padding-inline-start": {},
-        "border-block-end-width": { "value": "{utrecht.border-width.sm.value}" },
-        "border-block-end-color": { "value": "{utrecht.color.grey.90.value}" },
+        "border-block-end-width": { "value": "{utrecht.border-width.sm}" },
+        "border-block-end-color": { "value": "{utrecht.color.grey.90}" },
         "alternate-odd": {
           "background-color": {},
           "color": {}

--- a/proprietary/design-tokens/src/component/utrecht/topnav.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/topnav.tokens.json
@@ -2,22 +2,22 @@
   "utrecht": {
     "topnav": {
       "list": {
-        "background-color": { "value": "{utrecht.color.grey.15.value}" },
-        "border-color": { "value": "{utrecht.color.grey.40.value}" }
+        "background-color": { "value": "{utrecht.color.grey.15}" },
+        "border-color": { "value": "{utrecht.color.grey.40}" }
       },
       "link": {
-        "color": { "value": "{utrecht.color.white.value}" },
-        "background-color": { "value": "{utrecht.color.blue.40.value}" },
+        "color": { "value": "{utrecht.color.white}" },
+        "background-color": { "value": "{utrecht.color.blue.40}" },
         "focus": {
-          "color": { "value": "{utrecht.color.black.value}" },
-          "box-shadow-color": { "value": "{utrecht.color.yellow.80.value}" },
+          "color": { "value": "{utrecht.color.black}" },
+          "box-shadow-color": { "value": "{utrecht.color.yellow.80}" },
           "border-type": { "value": "dotted" },
           "text-decoration": { "value": "none" },
-          "background-color": { "value": "{utrecht.color.yellow.80.value}" },
-          "outline-color": { "value": "{utrecht.color.black.value}" }
+          "background-color": { "value": "{utrecht.color.yellow.80}" },
+          "outline-color": { "value": "{utrecht.color.black}" }
         },
         "hover": {
-          "background-color": { "value": "{utrecht.color.black.value}" }
+          "background-color": { "value": "{utrecht.color.black}" }
         }
       }
     }

--- a/proprietary/design-tokens/src/component/utrecht/toptask-link.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/toptask-link.tokens.json
@@ -1,19 +1,19 @@
 {
   "utrecht": {
     "toptask-link": {
-      "background-color": { "value": "{utrecht.button.background-color.value}" },
-      "color": { "value": "{utrecht.button.color.value}" },
+      "background-color": { "value": "{utrecht.button.background-color}" },
+      "color": { "value": "{utrecht.button.color}" },
       "font-size": { "value": "1rem" },
       "line-height": { "value": "1.2" },
       "min-block-size": { "value": "8.25rem" },
       "min-inline-size": { "value": "15rem" },
-      "padding-block-end": { "value": "{utrecht.space.block.xl.value}" },
-      "padding-block-start": { "value": "{utrecht.space.block.xl.value}" },
-      "padding-inline-end": { "value": "{utrecht.space.inline.xl.value}" },
-      "padding-inline-start": { "value": "{utrecht.space.inline.xl.value}" },
+      "padding-block-end": { "value": "{utrecht.space.block.xl}" },
+      "padding-block-start": { "value": "{utrecht.space.block.xl}" },
+      "padding-inline-end": { "value": "{utrecht.space.inline.xl}" },
+      "padding-inline-start": { "value": "{utrecht.space.inline.xl}" },
       "hover": {
-        "background-color": { "value": "{utrecht.button.primary-action.hover.background-color.value}" },
-        "color": { "value": "{utrecht.button.primary-action.hover.color.value}" },
+        "background-color": { "value": "{utrecht.button.primary-action.hover.background-color}" },
+        "color": { "value": "{utrecht.button.primary-action.hover.color}" },
         "transform-scale": { "value": "1.02" }
       },
       "focus": {

--- a/proprietary/design-tokens/src/component/utrecht/toptask-nav.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/toptask-nav.tokens.json
@@ -1,7 +1,7 @@
 {
   "utrecht": {
     "toptask-nav": {
-      "gap": { "value": "{utrecht.space.column.md.value}" },
+      "gap": { "value": "{utrecht.space.column.md}" },
       "link": {
         "grid": {
           "max-inline-size": {

--- a/proprietary/design-tokens/src/component/utrecht/unordered-list.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/unordered-list.tokens.json
@@ -8,7 +8,7 @@
         "margin-block-end": { "value": "0.5rem" }
       },
       "marker": {
-        "color": { "value": "{utrecht.color.red.40.value}" }
+        "color": { "value": "{utrecht.color.red.40}" }
       }
     }
   }

--- a/proprietary/design-tokens/src/component/utrecht/unordered-list/element.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/unordered-list/element.tokens.json
@@ -6,7 +6,7 @@
         "margin-block-end": { "value": "0.5rem" }
       },
       "marker": {
-        "color": { "value": "{utrecht.color.red.40.value}" }
+        "color": { "value": "{utrecht.color.red.40}" }
       }
     }
   }


### PR DESCRIPTION
Let's get rid of the most annoying thing of the design token JSONs: the .value at the end of references. Omitting .value is supported since style-dictionary@3.1.0.

Tested by starting and smoke testing Storybook.