### PR TITLE
style: fix web component sidenav hover

### DIFF
--- a/components/navigatie sidenav/bem.scss
+++ b/components/navigatie sidenav/bem.scss
@@ -173,6 +173,10 @@
   border: 2px solid var(--utrecht-sidenav-link-hover-color);
 }
 
+.utrecht-sidenav__link:hover .utrecht-sidenav__marker {
+  @extend .utrecht-sidenav__marker--hover;
+}
+
 .utrecht-sidenav--pseudo-elements {
   .utrecht-sidenav__link::before {
     @extend .utrecht-sidenav__marker;


### PR DESCRIPTION
Voor de CSS component van Sidenav werd het bolletje donkerblauw, maar voor de web component (die net iets anders werkt) gebeurde er niets bij `:hover`. Dat is nu gefixt.