### PR TITLE
ci: use higher-permission token for releases

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -11,7 +11,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout release branch
+        uses: actions/checkout@v2
+        if: github.ref == 'refs/heads/main'
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Checkout pull request branch
+        uses: actions/checkout@v2
+        if: github.ref != 'refs/heads/main'
 
       - name: Set up Node.js version
         uses: actions/setup-node@v2
@@ -99,7 +107,7 @@ jobs:
 
       - name: "Continuous Deployment: publish to GitHub repository"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
           GIT_AUTHOR_NAME: "NL Design System"
           GIT_COMMITTER_EMAIL: ${{ secrets.GIT_COMMITTER_EMAIL }}


### PR DESCRIPTION
For pulling and pushing to the `main` branch, we now use an access token from the `nl-design-system-ci` user. We have configured this repository to make `nl-design-system-ci` the exception to the branch protection rules.

<img width="739" alt="Screenshot 2022-02-27 at 13 01 53" src="https://user-images.githubusercontent.com/30694/155881550-e65e7bb1-83e9-4014-8150-cb68c1fac766.png">

While most steps will have access to the `GITHUB_TOKEN` from the environment, we make `GH_TOKEN` available with special permissions. We only configure the `GH_TOKEN` for the main branch, so only scripts that have been reviewed by folks with merge rights will have access to it.