### PR TITLE
ci: use higher-permission token for release job only

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -11,15 +11,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout release branch
+      - name: Checkout branch
         uses: actions/checkout@v2
-        if: github.ref == 'refs/heads/main'
-        with:
-          token: ${{ secrets.GH_TOKEN }}
-
-      - name: Checkout pull request branch
-        uses: actions/checkout@v2
-        if: github.ref != 'refs/heads/main'
 
       - name: Set up Node.js version
         uses: actions/setup-node@v2
@@ -63,7 +56,8 @@ jobs:
     if: github.ref == 'refs/heads/main'
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout release branch
+        uses: actions/checkout@v2
 
       - name: "Restore build artifact: website"
         uses: actions/download-artifact@v2
@@ -89,7 +83,10 @@ jobs:
     if: github.ref == 'refs/heads/main'
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout release branch
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Set up Node.js version
         uses: actions/setup-node@v2


### PR DESCRIPTION
Follow up to PR #752.

The previous commit did not appear to be sufficient, and the GitHub branch protection configuration was not accurat. It resulted in the following error in the release script:

```text
lerna info git Pushing tags...
[36](https://github.com/nl-design-system/utrecht/runs/5350620083?check_suite_focus=true#step:6:36)
lerna ERR! Error: Command failed with exit code 1: git push --follow-tags --no-verify --atomic origin main
[37](https://github.com/nl-design-system/utrecht/runs/5350620083?check_suite_focus=true#step:6:37)
lerna ERR! remote: error: GH006: Protected branch update failed for refs/heads/main.        
[38](https://github.com/nl-design-system/utrecht/runs/5350620083?check_suite_focus=true#step:6:38)
lerna ERR! remote: error: You're not authorized to push to this branch. Visit https://docs.github.com/articles/about-protected-branches/ for more information.        
[39](https://github.com/nl-design-system/utrecht/runs/5350620083?check_suite_focus=true#step:6:39)
lerna ERR! To https://github.com/nl-design-system/utrecht
[40](https://github.com/nl-design-system/utrecht/runs/5350620083?check_suite_focus=true#step:6:40)
lerna ERR!  ! [remote rejected]   main -> main (protected branch hook declined)
[41](https://github.com/nl-design-system/utrecht/runs/5350620083?check_suite_focus=true#step:6:41)
lerna ERR! error: failed to push some refs to 'https://github.com/nl-design-system/utrecht'
[42](https://github.com/nl-design-system/utrecht/runs/5350620083?check_suite_focus=true#step:6:42)
```

Instead of allowing `nl-design-system-ci` to bypass PR restrictions, we now configured it to allow to push to the `main` branch:

<img width="759" alt="Screenshot 2022-02-27 at 15 20 54" src="https://user-images.githubusercontent.com/30694/155886542-4f6e259b-9c2d-4ef6-9bf7-d8492547620c.png">


Also, the `GH_TOKEN` was made available to the `continuous-integration` job instead of for the `publish-npm` job. This PR should fix that.