### PR TITLE
ci: deploy docs to separate repo

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -77,6 +77,14 @@ jobs:
           branch: gh-pages
           folder: standalone/docusaurus/build/
 
+      - name: Continuous Deployment to designsystem.utrecht.nl
+        uses: JamesIves/github-pages-deploy-action@v4.2.3
+        with:
+          branch: main
+          folder: standalone/docusaurus/build/
+          repository-name: nl-design-system/designsystem.utrecht.nl
+          token: ${{ secrets.DOCS_GH_TOKEN }}
+
   publish-npm:
     runs-on: ubuntu-latest
     needs: continuous-integration


### PR DESCRIPTION
This PR aims to provide infrastructure to publish a snapshot of the documentation to a separate repository. The current approach here seems to work, the main thing missing from this setup is that the version number is not readily associated with the snapshot of the documentation.

Ideally the docs have a version number in the code, as well as git tags for the commit that is pushed to the other repository. Since at the version number is not yet known in job that runs parallel to `publish-npm`, this would mean some further refactoring that would include:

- (re)building the docs after the version has been released
- using method other than [JamesIves/github-pages-deploy-action](https://github.com/JamesIves/github-pages-deploy-action) to deploy the code, since it doesn't offer a parameter to configure any Git tag(s).