### PR TITLE
docs: remove new unwanted breadcrumbs from documentation

### DIFF
--- a/standalone/docusaurus/docusaurus.config.js
+++ b/standalone/docusaurus/docusaurus.config.js
@@ -27,6 +27,7 @@ module.exports = {
           path: 'docs',
           routeBasePath: 'docs',
           editUrl: 'https://github.com/nl-design-system/utrecht/tree/main/documentation',
+          breadcrumbs: false,
         },
         theme: {
           customCss: [


### PR DESCRIPTION
Somehow breadcrumbs where added to Docusaurus, but we didn't design them or choose them. By setting breadcrumbs to false they are gone 🔥 
<img width="788" alt="Screenshot 2022-04-07 at 18 58 41" src="https://user-images.githubusercontent.com/877246/162257243-c7f7852b-3b21-4bf3-ba7e-687025512e41.png">
 