### PR TITLE
docs: quick fix to display process steps code snippet in canvas

### DIFF
--- a/components/process-steps/react.stories.mdx
+++ b/components/process-steps/react.stories.mdx
@@ -1,14 +1,27 @@
 <!-- @license CC0-1.0 -->
 
-import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import {
+  Step,
+  StepExpandedIcon,
+  StepHeader,
+  StepHeading,
+  StepList,
+  StepMarker,
+  StepSection,
+  SubStep,
+  SubStepHeading,
+  SubStepList,
+  SubStepMarker,
+} from "@gemeente-denhaag/process-steps";
+import { Canvas, Meta } from "@storybook/addon-docs";
 import { ProcessSteps } from "./react.jsx";
+
 import "@gemeente-denhaag/process-steps/index.css";
 
 export const Template = (args) => <ProcessSteps {...args} />;
 
 <Meta
   title="React Component/Process Steps"
-  argTypes={{}}
   parameters={{
     status: {
       type: "WORK IN PROGRESS",
@@ -18,12 +31,65 @@ export const Template = (args) => <ProcessSteps {...args} />;
 
 # Process steps
 
-<ProcessSteps />
-
 <Canvas>
-  <Story name="Process steps" args={{}}>
-    {Template.bind({})}
-  </Story>
+  <StepList>
+    <Step checked expanded>
+      <StepSection>
+        <StepHeader>
+          <StepMarker>
+            <div>1</div>
+          </StepMarker>
+          <StepHeading>Deelname aan geluidsonderzoek</StepHeading>
+          <StepExpandedIcon />
+        </StepHeader>
+      </StepSection>
+      <SubStepList>
+        <SubStep>
+          <SubStepMarker />
+          <SubStepHeading>Aanmelding ontvangen</SubStepHeading>
+        </SubStep>
+      </SubStepList>
+    </Step>
+    <Step current expanded>
+      <StepSection>
+        <StepHeader>
+          <StepMarker>
+            <div>2</div>
+          </StepMarker>
+          <StepHeading>Onderzoek naar geluidsoverlast</StepHeading>
+          <StepExpandedIcon />
+        </StepHeader>
+      </StepSection>
+      <SubStepList>
+        <SubStep>
+          <SubStepMarker />
+          <SubStepHeading>Afspraak meten geluidsoverlast gemaakt</SubStepHeading>
+        </SubStep>
+        <SubStep>
+          <SubStepMarker />
+          <SubStepHeading>Geluidsoverlast gemeten</SubStepHeading>
+        </SubStep>
+        <SubStep>
+          <SubStepMarker />
+          <SubStepHeading>Onderzoek resultaten verwerkt</SubStepHeading>
+        </SubStep>
+      </SubStepList>
+    </Step>
+    <Step>
+      <StepSection>
+        <StepHeader>
+          <StepMarker>3</StepMarker>
+          <StepHeading>Uitvoeren van maatregelen</StepHeading>
+        </StepHeader>
+      </StepSection>
+    </Step>
+    <Step>
+      <StepSection>
+        <StepHeader>
+          <StepMarker>4</StepMarker>
+          <StepHeading>Maatregelen zijn uitgevoerd</StepHeading>
+        </StepHeader>
+      </StepSection>
+    </Step>
+  </StepList>
 </Canvas>
-
-<ArgsTable story="Process steps" />


### PR DESCRIPTION
For some unknown reason the denhaag-process-steps components cause `<Story/>` to render `[object Object]` instead of the component. There are no other errors and I haven't found a fix (yet).

By not using `Story` and directly putting the code in `Canvas` it displays the component and the `view source` button with the correct source. This seems like a good MVP for now

<img width="1028" alt="Screenshot 2022-05-05 at 11 24 16" src="https://user-images.githubusercontent.com/877246/166895934-c2f12308-46d2-4c4a-aa2a-8baf320dc160.png">
