### PR TITLE
refactor: rename bem to css and group implementations

### DIFF
--- a/components/alternate-lang-nav/css/stories/default.stories.mdx
+++ b/components/alternate-lang-nav/css/stories/default.stories.mdx
@@ -1,10 +1,11 @@
 <!-- @license CC0-1.0 -->
 
 import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
-import { AlternateLangNav } from "./bem";
-import "../link/css/index.scss";
+import { AlternateLangNav } from "../template";
+import "../../../link/css/index.scss";
 
 <Meta
+  id="css-alternate-lang-nav"
   title="CSS Component/Alternate Language Navigation"
   argTypes={{
     languages: {

--- a/components/alternate-lang-nav/css/stories/readme.stories.mdx
+++ b/components/alternate-lang-nav/css/stories/readme.stories.mdx
@@ -1,0 +1,8 @@
+<!-- @license CC0-1.0 -->
+
+import { Description, Meta } from "@storybook/addon-docs";
+import document from "../../README.md";
+
+<Meta id="css-alternate-lang-nav" title="CSS Component/Alternate Language Navigation/README" />
+
+<Description>{document}</Description>

--- a/components/alternate-lang-nav/css/template.js
+++ b/components/alternate-lang-nav/css/template.js
@@ -4,7 +4,7 @@
  * Copyright (c) 2021 Robbert Broersma
  */
 
-import { Link } from '../link/css/template';
+import { Link } from '../../link/css/template';
 
 export const AlternateLangNav = ({ languages }) =>
   `<div class="utrecht-alternate-lang-nav">

--- a/components/alternate-lang-nav/readme.stories.mdx
+++ b/components/alternate-lang-nav/readme.stories.mdx
@@ -1,8 +1,0 @@
-<!-- @license CC0-1.0 -->
-
-import { Description, Meta } from "@storybook/addon-docs";
-import document from "./README.md";
-
-<Meta title="CSS Component/Alternate Language Navigation/README" />
-
-<Description>{document}</Description>


### PR DESCRIPTION
- [x] Rename `alternative-lang-nav/bem.js` to `alternative-lang-nav/css/template.js`
- [x] Rename `alternative-lang-nav/bem.stories.mdx` to `alternative-lang-nav/css/stories/default.stories.mdx`
- [x] Move `alternative-lang-nav/readme.stories.mdx` to `alternative-lang-nav/css/stories/readme.stories.mdx`