### PR TITLE
refactor: logical tokens and minimum size for logo

### DIFF
--- a/components/digid-button/css/index.scss
+++ b/components/digid-button/css/index.scss
@@ -5,8 +5,8 @@
 
 .utrecht-digid-button {
   --utrecht-button-min-block-size: var(--utrecht-digid-button-block-size, 50px);
-  --utrecht-logo-max-height: var(--utrecht-digid-button-block-size, 50px);
-  --utrecht-logo-max-width: var(--utrecht-digid-button-block-size, 50px);
+  --utrecht-logo-max-block-size: var(--utrecht-digid-button-block-size, 50px);
+  --utrecht-logo-max-inline-size: var(--utrecht-digid-button-block-size, 50px);
 
   block-size: var(--utrecht-digid-button-block-size, 50px);
   display: inline-flex;

--- a/components/digid-logo/web-component/index.scss
+++ b/components/digid-logo/web-component/index.scss
@@ -13,7 +13,7 @@
 
 svg {
   height: 100%;
-  max-height: var(--utrecht-digid-logo-max-height, var(--utrecht-logo-max-height, 50px));
-  max-width: var(--utrecht-digid-logo-max-width, var(--utrecht-logo-max-width, 50px));
+  max-height: var(--utrecht-digid-logo-max-block-size, var(--utrecht-logo-max-block-size, 50px));
+  max-width: var(--utrecht-digid-logo-max-inline-size, var(--utrecht-logo-max-inline-size, 50px));
   width: 100%;
 }

--- a/components/eherkenning-logo/web-component/index.scss
+++ b/components/eherkenning-logo/web-component/index.scss
@@ -13,7 +13,7 @@
 
 svg {
   height: 100%;
-  max-height: var(--utrecht-digid-logo-max-height, var(--utrecht-logo-max-height, 50px));
-  max-width: var(--utrecht-digid-logo-max-width, var(--utrecht-logo-max-width, 50px));
+  max-height: var(--utrecht-digid-logo-max-block-size, var(--utrecht-logo-max-block-size, 50px));
+  max-width: var(--utrecht-digid-logo-max-inline-size, var(--utrecht-logo-max-inline-size, 50px));
   width: 100%;
 }

--- a/components/eidas-logo/web-component/index.scss
+++ b/components/eidas-logo/web-component/index.scss
@@ -13,7 +13,7 @@
 
 svg {
   height: 100%;
-  max-height: var(--utrecht-digid-logo-max-height, var(--utrecht-logo-max-height, 50px));
-  max-width: var(--utrecht-digid-logo-max-width, var(--utrecht-logo-max-width, 50px));
+  max-height: var(--utrecht-digid-logo-max-block-size, var(--utrecht-logo-max-block-size, 50px));
+  max-width: var(--utrecht-digid-logo-max-inline-size, var(--utrecht-logo-max-inline-size, 50px));
   width: 100%;
 }

--- a/components/logo-button/css/index.scss
+++ b/components/logo-button/css/index.scss
@@ -5,8 +5,8 @@
 
 .utrecht-logo-button {
   --utrecht-button-min-block-size: var(--utrecht-logo-button-block-size, 50px);
-  --utrecht-logo-max-height: var(--utrecht-logo-button-block-size, 50px);
-  --utrecht-logo-max-width: var(--utrecht-logo-button-block-size, 50px);
+  --utrecht-logo-max-block-size: var(--utrecht-logo-button-block-size, 50px);
+  --utrecht-logo-max-inline-size: var(--utrecht-logo-button-block-size, 50px);
 
   display: inline-flex;
   gap: var(--utrecht-space-inline-sm);

--- a/components/logo/css/_mixin.scss
+++ b/components/logo/css/_mixin.scss
@@ -5,6 +5,8 @@
  */
 
 @mixin utrecht-logo {
-  max-height: var(--utrecht-logo-max-height, 192px);
-  max-width: var(--utrecht-logo-max-width, 96px);
+  max-block-size: var(--utrecht-logo-max-block-size, 192px);
+  max-inline-size: var(--utrecht-logo-max-inline-size, 96px);
+  min-block-size: var(--utrecht-logo-min-block-size);
+  min-inline-size: var(--utrecht-logo-min-inline-size);
 }

--- a/components/logo/tokens.json
+++ b/components/logo/tokens.json
@@ -1,13 +1,25 @@
 {
   "utrecht": {
     "logo": {
-      "max-height": {
+      "max-block-size": {
         "css": {
           "syntax": "<length>",
           "inherits": true
         }
       },
-      "max-width": {
+      "max-inline-size": {
+        "css": {
+          "syntax": "<length>",
+          "inherits": true
+        }
+      },
+      "min-block-size": {
+        "css": {
+          "syntax": "<length>",
+          "inherits": true
+        }
+      },
+      "min-inline-size": {
         "css": {
           "syntax": "<length>",
           "inherits": true

--- a/proprietary/design-tokens/src/component/utrecht/logo.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/logo.tokens.json
@@ -1,8 +1,8 @@
 {
   "utrecht": {
     "logo": {
-      "max-height": { "value": "58.97px" },
-      "max-width": { "value": "110.57px" }
+      "max-block-size": { "value": "58.97px" },
+      "max-inline-size": { "value": "110.57px" }
     }
   }
 }


### PR DESCRIPTION
To make the logo actually visible it helps a lot to be able to specify some minimum size.