### PR TITLE
refactor: button CSS now uses private CSS variables

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -12,7 +12,7 @@
     "scss/percent-placeholder-pattern": "^(example|utrecht)-[a-z0-9-]+$",
     "scss/operator-no-newline-after": null,
     "scss/at-extend-no-missing-placeholder": null,
-    "custom-property-pattern": "^(example|denhaag|utrecht)-[a-z0-9-]+$",
+    "custom-property-pattern": "^_?(example|denhaag|utrecht)-[a-z0-9-]+$",
     "selector-class-pattern": "^(example|denhaag|utrecht)-[a-z0-9_-]+$",
     "keyframes-name-pattern": "^(example|utrecht)-[a-z0-9-]+$",
     "at-rule-no-unknown": null,

--- a/components/button/css/_mixin.scss
+++ b/components/button/css/_mixin.scss
@@ -7,13 +7,53 @@
 @import "../../common/focus/mixin";
 
 @mixin utrecht-button {
-  background-color: var(--utrecht-button-background-color);
-  border-color: var(--utrecht-button-border-color, transparent);
-  border-bottom-color: var(--utrecht-button-border-bottom-color, var(--utrecht-button-border-color, transparent));
+  --_utrecht-button-background-color: var(--utrecht-button-background-color);
+  --_utrecht-button-color: var(--utrecht-button-color);
+  --_utrecht-button-border-color: var(--utrecht-button-border-color, transparent);
+  --_utrecht-button-border-bottom-color: var(
+    --utrecht-button-border-bottom-color,
+    var(--utrecht-button-border-color, transparent)
+  );
+  --_utrecht-button-disabled-background-color: var(
+    --utrecht-button-disabled-background-color,
+    var(--utrecht-button-background-color)
+  );
+  --_utrecht-button-disabled-border-color: var(
+    --utrecht-button-disabled-border-color,
+    var(--utrecht-button-border-color)
+  );
+  --_utrecht-button-disabled-color: var(--utrecht-button-disabled-color, var(--utrecht-button-color));
+  --_utrecht-button-focus-background-color: var(
+    --utrecht-button-focus-background-color,
+    var(--utrecht-button-background-color)
+  );
+  --_utrecht-button-focus-border-color: var(--utrecht-button-focus-border-color, var(--utrecht-button-border-color));
+  --_utrecht-button-focus-color: var(--utrecht-button-focus-color, var(--utrecht-button-color));
+  --_utrecht-button-hover-background-color: var(
+    --utrecht-button-hover-background-color,
+    var(--utrecht-button-background-color)
+  );
+  --_utrecht-button-hover-border-color: var(--utrecht-button-hover-border-color, var(--utrecht-button-border-color));
+  --_utrecht-button-hover-color: var(--utrecht-button-hover-color, var(--utrecht-button-color));
+  --_utrecht-button-active-background-color: var(
+    --utrecht-button-active-background-color,
+    var(--utrecht-button-background-color)
+  );
+  --_utrecht-button-active-border-color: var(--utrecht-button-active-border-color, var(--utrecht-button-border-color));
+  --_utrecht-button-active-color: var(--utrecht-button-active-color, var(--utrecht-button-color));
+  --_utrecht-button-border-width: var(--utrecht-button-border-width, 0);
+  --_utrecht-button-border-bottom-width: var(
+    --utrecht-button-border-bottom-width,
+    var(--utrecht-button-border-width, 0)
+  );
+
+  background-color: var(--_utrecht-button-background-color);
+  border-color: var(--_utrecht-button-border-color);
+  border-bottom-color: var(--_utrecht-button-border-bottom-color);
   border-radius: var(--utrecht-button-border-radius);
   border-style: solid;
-  border-width: var(--utrecht-button-border-width, 0);
-  border-bottom-width: var(--utrecht-button-border-bottom-width, var(--utrecht-button-border-width, 0));
+  border-width: var(--_utrecht-button-border-width);
+  border-bottom-width: var(--_utrecht-button-border-bottom-width);
   color: var(--utrecht-button-color);
   font-family: var(--utrecht-button-font-family, var(--utrecht-document-font-family));
   font-size: var(--utrecht-button-font-size, var(--utrecht-document-font-family));
@@ -47,16 +87,16 @@
 }
 
 @mixin utrecht-button--disabled {
-  background-color: var(--utrecht-button-disabled-background-color, var(--utrecht-button-background-color));
-  border-color: var(--utrecht-button-disabled-border-color, var(--utrecht-button-border-color));
-  color: var(--utrecht-button-disabled-color, var(--utrecht-button-color));
+  background-color: var(--_utrecht-button-disabled-background-color);
+  border-color: var(--_utrecht-button-disabled-border-color);
+  color: var(--_utrecht-button-disabled-color);
   cursor: var(--utrecht-action-disabled-cursor);
 }
 
 @mixin utrecht-button--active {
-  background-color: var(--utrecht-button-active-background-color, var(--utrecht-button-background-color));
-  border-color: var(--utrecht-button-active-border-color, var(--utrecht-button-border-color));
-  color: var(--utrecht-button-active-color, var(--utrecht-button-color));
+  background-color: var(--_utrecht-button-active-background-color);
+  border-color: var(--_utrecht-button-active-border-color);
+  color: var(--_utrecht-button-active-color);
 }
 
 @mixin utrecht-button--focus-visible {
@@ -65,85 +105,35 @@
 }
 
 @mixin utrecht-button--focus {
-  background-color: var(--utrecht-button-focus-background-color, var(--utrecht-button-background-color));
-  border-color: var(--utrecht-button-focus-border-color, var(--utrecht-button-border-color));
-  color: var(--utrecht-button-focus-color, var(--utrecht-button-color));
+  background-color: var(--_utrecht-button-focus-background-color);
+  border-color: var(--_utrecht-button-focus-border-color);
+  color: var(--_utrecht-button-focus-color);
 }
 
 @mixin utrecht-button--hover {
-  background-color: var(--utrecht-button-hover-background-color, var(--utrecht-button-background-color));
-  border-color: var(--utrecht-button-hover-border-color, var(--utrecht-button-border-color));
-  color: var(--utrecht-button-hover-color, var(--utrecht-button-color));
+  background-color: var(--_utrecht-button-hover-background-color);
+  border-color: var(--_utrecht-button-hover-border-color);
+  color: var(--_utrecht-button-hover-color);
   transform: scale(var(--utrecht-button-focus-transform-scale, 1));
 }
 
 @mixin utrecht-button-appearance($modifier) {
   .utrecht-button--#{$modifier} {
-    background-color: var(--utrecht-button-#{$modifier}-background-color, var(--utrecht-button-background-color));
-    border-color: var(--utrecht-button-#{$modifier}-border-color, var(--utrecht-button-border-color));
-    border-width: var(--utrecht-button-#{$modifier}-border-width, var(--utrecht-button-border-width));
-    color: var(--utrecht-button-#{$modifier}-color, var(--utrecht-button-color));
-  }
-
-  .utrecht-button--#{$modifier}.utrecht-button--hover:not(:disabled),
-  .utrecht-button--#{$modifier}.utrecht-button:hover:not(:disabled):not([aria-disabled="true"]):not(.utrecht-button--disabled) {
-    background-color: var(
-      --utrecht-button-#{$modifier}-hover-background-color,
-      var(
-        --utrecht-button-#{$modifier}-background-color,
-        var(--utrecht-button-hover-background-color, var(--utrecht-button-background-color))
-      )
-    );
-    border-color: var(
-      --utrecht-button-#{$modifier}-hover-border-color,
-      var(
-        --utrecht-button-#{$modifier}-border-color,
-        var(--utrecht-button-hover-border-color, var(--utrecht-button-border-color))
-      )
-    );
-    color: var(
-      --utrecht-button-#{$modifier}-hover-color,
-      var(--utrecht-button-#{$modifier}-color, var(--utrecht-button-hover-color, var(--utrecht-button-color)))
-    );
-  }
-
-  .utrecht-button--#{$modifier}.utrecht-button:disabled,
-  .utrecht-button--#{$modifier}.utrecht-button--disabled {
-    background-color: var(
-      --utrecht-button-#{$modifier}-disabled-background-color,
-      var(--utrecht-button-disabled-background-color, var(--utrecht-button-background-color))
-    );
-    border-color: var(
-      --utrecht-button-#{$modifier}-disabled-border-color,
-      var(--utrecht-button-disabled-border-color, var(--utrecht-button-border-color))
-    );
-    color: var(
-      --utrecht-button-#{$modifier}-disabled-color,
-      var(--utrecht-button-disabled-color, var(--utrecht-button-color))
-    );
-  }
-
-  // The workaround for missing `:focus-visible` support makes the code quite complex,
-  // keep the ideal version around to restore it easily when browser support improves.
-
-  @if $utrecht-focus-visible-fallback {
-    .utrecht-button--#{$modifier}:focus:not(:disabled):not([aria-disabled="true"]):not(.utrecht-button--disabled) {
-      @include utrecht-button--focus;
-      @include utrecht-button--focus-visible;
-    }
-
-    /* override the `:focus` selector above */
-    /* stylelint-disable-next-line no-descending-specificity */
-    .utrecht-button--#{$modifier}:focus:not(:focus-visible) {
-      @include utrecht-focus-ring-reset;
-    }
-  } @else {
-    .utrecht-button--#{$modifier}:focus-visible {
-      @include utrecht-button--focus-visible;
-    }
-
-    .utrecht-button--#{$modifier}:focus:not(:disabled):not([aria-disabled="true"]):not(.utrecht-button--disabled) {
-      @include utrecht-button--focus;
-    }
+    --utrecht-button-active-background-color: var(--utrecht-button-#{$modifier}-active-background-color);
+    --utrecht-button-active-border-color: var(--utrecht-button-#{$modifier}-active-border-color);
+    --utrecht-button-active-color: var(--utrecht-button-#{$modifier}-active-color);
+    --utrecht-button-background-color: var(--utrecht-button-#{$modifier}-background-color);
+    --utrecht-button-border-color: var(--utrecht-button-#{$modifier}-border-color);
+    --utrecht-button-border-width: var(--utrecht-button-#{$modifier}-border-width);
+    --utrecht-button-color: var(--utrecht-button-#{$modifier}-color);
+    --utrecht-button-disabled-background-color: var(--utrecht-button-#{$modifier}-disabled-background-color);
+    --utrecht-button-disabled-border-color: var(--utrecht-button-#{$modifier}-disabled-border-color);
+    --utrecht-button-disabled-color: var(--utrecht-button-#{$modifier}-disabled-color);
+    --utrecht-button-focus-background-color: var(--utrecht-button-#{$modifier}-focus-background-color);
+    --utrecht-button-focus-border-color: var(--utrecht-button-#{$modifier}-focus-border-color);
+    --utrecht-button-focus-color: var(--utrecht-button-#{$modifier}-focus-color);
+    --utrecht-button-hover-background-color: var(--utrecht-button-#{$modifier}-hover-background-color);
+    --utrecht-button-hover-border-color: var(--utrecht-button-#{$modifier}-hover-border-color);
+    --utrecht-button-hover-color: var(--utrecht-button-#{$modifier}-hover-color);
   }
 }

--- a/components/button/css/stories/02-appearance.js
+++ b/components/button/css/stories/02-appearance.js
@@ -47,7 +47,7 @@ export const ButtonTable = ({
       <td class="utrecht-table__cell">${Button({ appearance, textContent, active: true })}</td>
       <td class="utrecht-table__cell">${Button({ appearance, textContent, hover: true })}</td>
       <td class="utrecht-table__cell">${Button({ appearance, textContent, focus: true })}</td>
-      <td class="utrecht-table__cell">${Button({ appearance, textContent, focusVisible: true })}</td>
+      <td class="utrecht-table__cell">${Button({ appearance, textContent, focus: true, focusVisible: true })}</td>
       <td class="utrecht-table__cell">${Button({ appearance, textContent, disabled: true })}</td>
     </tr>`,
     )

--- a/proprietary/design-tokens/src/component/utrecht/button.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/button.tokens.json
@@ -27,13 +27,21 @@
       "primary-action": {
         "background-color": { "value": "{utrecht.color.blue.35}" },
         "border-color": { "value": "transparent" },
+        "border-width": {
+          "value": "{utrecht.border-width.md}",
+          "comment": "Although the border is not visible, it is needed to match the size of the secondary-action-button appearance"
+        },
         "color": { "value": "{utrecht.color.white}" },
+        "disabled": {
+          "border-color": { "value": "{utrecht.color.grey.90}" }
+        },
         "hover": {
           "background-color": { "value": "{utrecht.color.blue.40}" },
           "border-color": { "value": "transparent" },
           "color": { "value": "{utrecht.color.white}" }
         },
         "focus": {
+          "background-color": { "value": "{utrecht.color.blue.40}" },
           "border-color": { "value": "{utrecht.color.blue.40}" },
           "border-width": { "value": "{utrecht.border-width.md}" }
         }


### PR DESCRIPTION
The complexity of the code to support various appearances got out of hand, and it was difficult to support all the various states for each appearance. This should help.

I suspect the approach was inspired by an article by Lea Verou I had read some time last year: [Custom properties with defaults](https://lea.verou.me/2021/10/custom-properties-with-defaults/#bonus-customizable-single-checkbox-pure-css-switch)