### PR TITLE
build: add `Content-Security-Policy` to Docusaurus

### DIFF
--- a/standalone/docusaurus/docusaurus.config.js
+++ b/standalone/docusaurus/docusaurus.config.js
@@ -47,6 +47,12 @@ module.exports = {
         respectPrefersColorScheme: false,
         disableSwitch: true,
       },
+      metadata: [
+        {
+          name: 'Content-Security-Policy',
+          content: `frame-ancestors 'none'; object-src 'none'; base-uri 'none'; default-src 'self'; media-src 'none'; form-action 'self'; img-src 'self' data:; script-src 'self'; style-src 'unsafe-inline' 'self'; connect-src 'self' https://*.algolia.net https://*.algolianet.com; frame-src 'self' https://nl-design-system.github.io; font-src 'self';`,
+        },
+      ],
       prism: {
         theme: require('prism-react-renderer/themes/github'),
       },


### PR DESCRIPTION
Ik ben begonnen met de `Content-Security-Policy` van pki.utrecht.nl, en heb 'm wat stricter gemaakt door overal `https:` weg te halen zodat niet elke domeinnaam is toegestaan.

Twee dingen staan nu in de allow lists:
- `nl-design-system.github.io` voor de Storybook iframes. Idealiter gaat deze eruit en worden de stories altijd op hetzelfde domein gehost
- Algolia domeinen volgens de [Algolia Security Best Practices](https://www.algolia.com/doc/guides/security/security-best-practices/#content-security-policy), zodat de search werkt.