### PR TITLE
docs: move the label after the field

### DIFF
--- a/packages/storybook-vue/src/stories/RadioButton/RadioButtonWithFieldsetAndLegend.stories.mdx
+++ b/packages/storybook-vue/src/stories/RadioButton/RadioButtonWithFieldsetAndLegend.stories.mdx
@@ -23,8 +23,8 @@ export const Template = (args) => ({
   <FormFieldsetLegend>Kies locatie</FormFieldsetLegend>
   <FormField v-for="{id, label, name} in options" :key="id">
     <FormLabel :for="id" type="radio" :checked="args.checked" :disabled="args.disabled">
-        {{label}}
         <RadioButton :name="name" v-bind="args" :id="id" @change="action" />
+        {{label}}
     </FormLabel>
      </FormField>
     </FormFieldset>
@@ -49,8 +49,8 @@ export const Template = (args) => ({
             ({ id, label, name }) => `
               <FormField>
                 <FormLabel :for="${id}">
-                  ${label}
                   <RadioButton :name="${name}" :id="${id}" />
+                  ${label}
                 </FormLabel>
               </FormField>`
           )

--- a/packages/storybook-vue/src/stories/RadioButton/RadioButtonWithLabel.stories.mdx
+++ b/packages/storybook-vue/src/stories/RadioButton/RadioButtonWithLabel.stories.mdx
@@ -15,8 +15,13 @@ export const Template = (args) => ({
   template: `
   <FormField>
     <FormLabel for="form-field-with-raio-button-and-label" type="radio" :checked="args.checked" :disabled="args.disabled">
+        <RadioButton
+        v-bind="args"
+        id="form-field-with-radio-button-and-label"
+        name="form-field-with-radio-button-and-label"
+        @change="action"
+        />
         {{args.labelText}}
-        <RadioButton v-bind="args" id="form-field-with-radio-button-and-label" @change="action" />
     </FormLabel>
   </FormField>`,
   methods: { action: action("change") },
@@ -31,9 +36,15 @@ export const Template = (args) => ({
         source: {
           code: `
   <FormField>
-    <FormLabel for="form-field-with-raio-button-and-label" type="radio">
-        Radio Button Label
-        <RadioButton id="form-field-with-radio-button-and-label"/>
+    <FormLabel 
+    for="form-field-with-raio-button-and-label" 
+    type="radio"
+    >
+        <RadioButton 
+        id="form-field-with-radio-button-and-label"
+        name="form-field-with-radio-button-and-label"
+        />
+         Radio Button Label
     </FormLabel>
   </FormField>`,
         },

--- a/packages/storybook-vue/src/stories/RadioButton/RadioButtonWithLabel.stories.mdx
+++ b/packages/storybook-vue/src/stories/RadioButton/RadioButtonWithLabel.stories.mdx
@@ -14,7 +14,7 @@ export const Template = (args) => ({
   },
   template: `
   <FormField>
-    <FormLabel for="form-field-with-raio-button-and-label" type="radio" :checked="args.checked" :disabled="args.disabled">
+    <FormLabel for="form-field-with-radio-button-and-label" type="radio" :checked="args.checked" :disabled="args.disabled">
         <RadioButton
         v-bind="args"
         id="form-field-with-radio-button-and-label"
@@ -37,7 +37,7 @@ export const Template = (args) => ({
           code: `
   <FormField>
     <FormLabel 
-    for="form-field-with-raio-button-and-label" 
+    for="form-field-with-radio-button-and-label"
     type="radio"
     >
         <RadioButton 


### PR DESCRIPTION
[Reference:](https://www.w3.org/TR/WCAG20-TECHS/G162.html#:~:text=Labels%20for%20most%20fields%20are,are%20positioned%20after%20the%20field)