### PR TITLE
feat: textbox support `[attribute="value"]` in css

### DIFF
--- a/components/textbox/css/index.scss
+++ b/components/textbox/css/index.scss
@@ -49,4 +49,21 @@
 
 .utrecht-textbox--html-input {
   @include utrecht-textbox--html-input;
+
+  &[type="password" i] {
+    @include utrecht-textbox--password;
+  }
+  &[type="url" i],
+  &[type="email" i],
+  &[inputMode="email" i],
+  &[inputMode="url" i] {
+    @include utrecht-textbox--url;
+  }
+  &[type="number" i],
+  &[type="tel" i],
+  &[inputMode="numeric" i],
+  &[inputMode="decimal" i],
+  &[inputMode="tel" i] {
+    @include utrecht-textbox--numeric;
+  }
 }

--- a/components/textbox/html/index.scss
+++ b/components/textbox/html/index.scss
@@ -23,12 +23,9 @@ input[type="week" i] {
 }
 
 input[autocomplete~="current-password" i],
-input[autocomplete~="new-password" i] {
+input[autocomplete~="new-password" i],
+input[type="password" i] {
   @include utrecht-textbox--password;
-}
-
-input[type="url" i] {
-  @include utrecht-textbox--url;
 }
 
 input[autocomplete~="bday" i],
@@ -51,6 +48,15 @@ input[autocomplete~="tel-national" i],
 input[autocomplete~="transaction-amount" i],
 input[inputmode="decimal" i],
 input[inputmode="numeric" i],
-input[type="number" i] {
+input[inputmode="tel" i],
+input[type="number" i],
+input[type="tel" i] {
   @include utrecht-textbox--numeric;
+}
+
+input[inputmode="email" i],
+input[inputmode="url" i],
+input[type="email" i],
+input[type="url" i] {
+  @include utrecht-textbox--url;
 }

--- a/packages/component-library-react/src/Textbox.test.tsx
+++ b/packages/component-library-react/src/Textbox.test.tsx
@@ -230,14 +230,6 @@ describe('Textbox', () => {
 
       expect(textbox).toBeInTheDocument();
     });
-
-    it('renders a design system BEM modifier class name', () => {
-      const { container } = render(<Textbox type="url" />);
-
-      const textbox = container.querySelector(':only-child');
-
-      expect(textbox).toHaveClass('utrecht-textbox--url');
-    });
   });
 
   describe('variant for email values', () => {
@@ -247,14 +239,6 @@ describe('Textbox', () => {
       const textbox = container.querySelector('input[type="email"]');
 
       expect(textbox).toBeInTheDocument();
-    });
-
-    it('renders a design system BEM modifier class name', () => {
-      const { container } = render(<Textbox type="email" />);
-
-      const textbox = container.querySelector(':only-child');
-
-      expect(textbox).toHaveClass('utrecht-textbox--url');
     });
   });
 
@@ -276,14 +260,6 @@ describe('Textbox', () => {
 
       expect(textbox).toBeInTheDocument();
     });
-
-    it('renders a design system BEM modifier class name', () => {
-      const { container } = render(<Textbox type="tel" />);
-
-      const textbox = container.querySelector(':only-child');
-
-      expect(textbox).toHaveClass('utrecht-textbox--numeric');
-    });
   });
 
   describe('variant for numeric values', () => {
@@ -294,14 +270,6 @@ describe('Textbox', () => {
 
       expect(textbox).toHaveAttribute('inputMode', 'numeric');
     });
-
-    it('renders a design system BEM modifier class name', () => {
-      const { container } = render(<Textbox inputMode="numeric" />);
-
-      const textbox = container.querySelector(':only-child');
-
-      expect(textbox).toHaveClass('utrecht-textbox--numeric');
-    });
   });
 
   describe('variant for number values', () => {
@@ -311,14 +279,6 @@ describe('Textbox', () => {
       const textbox = container.querySelector(':only-child');
 
       expect(textbox).toHaveAttribute('inputMode', 'numeric');
-    });
-
-    it('renders a design system BEM modifier class name', () => {
-      const { container } = render(<Textbox type="number" />);
-
-      const textbox = container.querySelector(':only-child');
-
-      expect(textbox).toHaveClass('utrecht-textbox--numeric');
     });
   });
 

--- a/packages/component-library-react/src/Textbox.tsx
+++ b/packages/component-library-react/src/Textbox.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import { ForwardedRef, forwardRef, InputHTMLAttributes } from 'react';
-
 export type TextboxTypes = 'email' | 'number' | 'password' | 'tel' | 'text' | 'url';
 
 export interface TextboxProps extends InputHTMLAttributes<HTMLInputElement> {
@@ -30,12 +29,6 @@ export const Textbox = forwardRef(
       className={clsx(
         'utrecht-textbox',
         'utrecht-textbox--html-input',
-        type === 'email' && 'utrecht-textbox--url',
-        type === 'password' && 'utrecht-textbox--password',
-        type === 'number' && 'utrecht-textbox--numeric',
-        type === 'tel' && 'utrecht-textbox--numeric',
-        type === 'url' && 'utrecht-textbox--url',
-        inputMode === 'numeric' && 'utrecht-textbox--numeric',
         disabled && 'utrecht-textbox--disabled',
         invalid && 'utrecht-textbox--invalid',
         readOnly && 'utrecht-textbox--readonly',


### PR DESCRIPTION
The reason to minimize using javascript to deal style

**reference to the issue:**
https://github.com/nl-design-system/utrecht/blob/main/packages/component-library-react/src/Textbox.tsx#L33