### PR TITLE
fix: use component name as display name

### DIFF
--- a/packages/component-library-react/src/Article.tsx
+++ b/packages/component-library-react/src/Article.tsx
@@ -16,4 +16,4 @@ export const Article = forwardRef(
   ),
 );
 
-Article.displayName = 'utrecht-article';
+Article.displayName = 'Article';

--- a/packages/component-library-react/src/Backdrop.tsx
+++ b/packages/component-library-react/src/Backdrop.tsx
@@ -16,4 +16,4 @@ export const Backdrop = forwardRef(
   ),
 );
 
-Backdrop.displayName = 'utrecht-backdrop';
+Backdrop.displayName = 'Backdrop';

--- a/packages/component-library-react/src/Button.tsx
+++ b/packages/component-library-react/src/Button.tsx
@@ -35,22 +35,22 @@ export const Button = forwardRef(
   },
 );
 
-Button.displayName = 'utrecht-button';
+Button.displayName = 'Button';
 
 export const PrimaryActionButton = ({ ...args }) => {
   return <Button {...args} appearance="primary-action-button" />;
 };
 
-PrimaryActionButton.displayName = 'utrecht-primary-action-button';
+PrimaryActionButton.displayName = 'PrimaryActionButton';
 
 export const SecondaryActionButton = ({ ...args }) => {
   return <Button {...args} appearance="secondary-action-button" />;
 };
 
-SecondaryActionButton.displayName = 'utrecht-secondary-action-button';
+SecondaryActionButton.displayName = 'SecondaryActionButton';
 
 export const SubtleButton = ({ ...args }) => {
   return <Button {...args} appearance="subtle-button" />;
 };
 
-SubtleButton.displayName = 'utrecht-subtle-button';
+SubtleButton.displayName = 'SubtleButton';

--- a/packages/component-library-react/src/ButtonLink.tsx
+++ b/packages/component-library-react/src/ButtonLink.tsx
@@ -74,4 +74,4 @@ export const ButtonLink = forwardRef(
   },
 );
 
-ButtonLink.displayName = 'utrecht-button-link';
+ButtonLink.displayName = 'ButtonLink';

--- a/packages/component-library-react/src/Checkbox.tsx
+++ b/packages/component-library-react/src/Checkbox.tsx
@@ -26,4 +26,4 @@ export const Checkbox = forwardRef(
   ),
 );
 
-Checkbox.displayName = 'utrecht-checkbox';
+Checkbox.displayName = 'Checkbox';

--- a/packages/component-library-react/src/CustomRadioButton.tsx
+++ b/packages/component-library-react/src/CustomRadioButton.tsx
@@ -32,4 +32,4 @@ export const CustomRadioButton = forwardRef(
   ),
 );
 
-CustomRadioButton.displayName = 'utrecht-custom-radio-button';
+CustomRadioButton.displayName = 'CustomRadioButton';

--- a/packages/component-library-react/src/Document.tsx
+++ b/packages/component-library-react/src/Document.tsx
@@ -16,4 +16,4 @@ export const Document = forwardRef(
   ),
 );
 
-Document.displayName = 'utrecht-document';
+Document.displayName = 'Document';

--- a/packages/component-library-react/src/Fieldset.tsx
+++ b/packages/component-library-react/src/Fieldset.tsx
@@ -15,4 +15,4 @@ export const Fieldset = forwardRef(
   ),
 );
 
-Fieldset.displayName = 'utrecht-form-fieldset';
+Fieldset.displayName = 'Fieldset';

--- a/packages/component-library-react/src/FieldsetLegend.tsx
+++ b/packages/component-library-react/src/FieldsetLegend.tsx
@@ -18,4 +18,4 @@ export const FieldsetLegend = forwardRef(
   ),
 );
 
-FieldsetLegend.displayName = 'utrecht-form-fieldset-legend';
+FieldsetLegend.displayName = 'FieldsetLegend';

--- a/packages/component-library-react/src/FormField.tsx
+++ b/packages/component-library-react/src/FormField.tsx
@@ -11,4 +11,4 @@ export const FormField = forwardRef(
   ),
 );
 
-FormField.displayName = 'utrecht-form-field';
+FormField.displayName = 'FormField';

--- a/packages/component-library-react/src/FormFieldDescription.tsx
+++ b/packages/component-library-react/src/FormFieldDescription.tsx
@@ -28,4 +28,4 @@ export const FormFieldDescription = forwardRef(
   ),
 );
 
-FormFieldDescription.displayName = 'utrecht-form-field-description';
+FormFieldDescription.displayName = 'FormFieldDescription';

--- a/packages/component-library-react/src/FormLabel.tsx
+++ b/packages/component-library-react/src/FormLabel.tsx
@@ -29,4 +29,4 @@ export const FormLabel = forwardRef(
   ),
 );
 
-FormLabel.displayName = 'utrecht-form-label';
+FormLabel.displayName = 'FormLabel';

--- a/packages/component-library-react/src/HTMLContent.tsx
+++ b/packages/component-library-react/src/HTMLContent.tsx
@@ -16,4 +16,4 @@ export const HTMLContent = forwardRef(
   ),
 );
 
-HTMLContent.displayName = 'utrecht-html';
+HTMLContent.displayName = 'HTMLContent';

--- a/packages/component-library-react/src/Heading1.tsx
+++ b/packages/component-library-react/src/Heading1.tsx
@@ -16,4 +16,4 @@ export const Heading1 = forwardRef(
   ),
 );
 
-Heading1.displayName = 'utrecht-heading-1';
+Heading1.displayName = 'Heading1';

--- a/packages/component-library-react/src/Heading2.tsx
+++ b/packages/component-library-react/src/Heading2.tsx
@@ -16,4 +16,4 @@ export const Heading2 = forwardRef(
   ),
 );
 
-Heading2.displayName = 'utrecht-heading-2';
+Heading2.displayName = 'Heading2';

--- a/packages/component-library-react/src/Heading3.tsx
+++ b/packages/component-library-react/src/Heading3.tsx
@@ -16,4 +16,4 @@ export const Heading3 = forwardRef(
   ),
 );
 
-Heading3.displayName = 'utrecht-heading-3';
+Heading3.displayName = 'Heading3';

--- a/packages/component-library-react/src/Heading4.tsx
+++ b/packages/component-library-react/src/Heading4.tsx
@@ -16,4 +16,4 @@ export const Heading4 = forwardRef(
   ),
 );
 
-Heading4.displayName = 'utrecht-heading-4';
+Heading4.displayName = 'Heading4';

--- a/packages/component-library-react/src/Heading5.tsx
+++ b/packages/component-library-react/src/Heading5.tsx
@@ -16,4 +16,4 @@ export const Heading5 = forwardRef(
   ),
 );
 
-Heading5.displayName = 'utrecht-heading-5';
+Heading5.displayName = 'Heading5';

--- a/packages/component-library-react/src/Heading6.tsx
+++ b/packages/component-library-react/src/Heading6.tsx
@@ -16,4 +16,4 @@ export const Heading6 = forwardRef(
   ),
 );
 
-Heading6.displayName = 'utrecht-heading-6';
+Heading6.displayName = 'Heading6';

--- a/packages/component-library-react/src/Link.tsx
+++ b/packages/component-library-react/src/Link.tsx
@@ -57,4 +57,4 @@ export const Link = forwardRef(
   ),
 );
 
-Link.displayName = 'utrecht-link';
+Link.displayName = 'Link';

--- a/packages/component-library-react/src/OrderedList.tsx
+++ b/packages/component-library-react/src/OrderedList.tsx
@@ -16,4 +16,4 @@ export const OrderedList = forwardRef(
   ),
 );
 
-OrderedList.displayName = 'utrecht-ordered-list';
+OrderedList.displayName = 'OrderedList';

--- a/packages/component-library-react/src/OrderedListItem.tsx
+++ b/packages/component-library-react/src/OrderedListItem.tsx
@@ -19,4 +19,4 @@ export const OrderedListItem = forwardRef(
   ),
 );
 
-OrderedListItem.displayName = 'utrecht-ordered-list-item';
+OrderedListItem.displayName = 'OrderedListItem';

--- a/packages/component-library-react/src/Page.tsx
+++ b/packages/component-library-react/src/Page.tsx
@@ -16,4 +16,4 @@ export const Page = forwardRef(
   ),
 );
 
-Page.displayName = 'utrecht-page';
+Page.displayName = 'Page';

--- a/packages/component-library-react/src/PageContent.tsx
+++ b/packages/component-library-react/src/PageContent.tsx
@@ -16,7 +16,7 @@ export const PageContent = forwardRef(
   ),
 );
 
-PageContent.displayName = 'utrecht-page-content';
+PageContent.displayName = 'PageContent';
 
 export type PageContentMainProps = HTMLAttributes<HTMLDivElement>;
 
@@ -31,4 +31,4 @@ export const PageContentMain = forwardRef(
   ),
 );
 
-PageContentMain.displayName = 'utrecht-page-content-main';
+PageContentMain.displayName = 'PageContentMain';

--- a/packages/component-library-react/src/PageFooter.tsx
+++ b/packages/component-library-react/src/PageFooter.tsx
@@ -16,4 +16,4 @@ export const PageFooter = forwardRef(
   ),
 );
 
-PageFooter.displayName = 'utrecht-page-footer';
+PageFooter.displayName = 'PageFooter';

--- a/packages/component-library-react/src/PageHeader.tsx
+++ b/packages/component-library-react/src/PageHeader.tsx
@@ -16,4 +16,4 @@ export const PageHeader = forwardRef(
   ),
 );
 
-PageHeader.displayName = 'utrecht-page-header';
+PageHeader.displayName = 'PageHeader';

--- a/packages/component-library-react/src/Paragraph.tsx
+++ b/packages/component-library-react/src/Paragraph.tsx
@@ -21,4 +21,4 @@ export const Paragraph = forwardRef(
   ),
 );
 
-Paragraph.displayName = 'utrecht-paragraph';
+Paragraph.displayName = 'Paragraph';

--- a/packages/component-library-react/src/RadioButton.tsx
+++ b/packages/component-library-react/src/RadioButton.tsx
@@ -29,4 +29,4 @@ export const RadioButton = forwardRef(
   ),
 );
 
-RadioButton.displayName = 'utrecht-radio-button';
+RadioButton.displayName = 'RadioButton';

--- a/packages/component-library-react/src/Select.tsx
+++ b/packages/component-library-react/src/Select.tsx
@@ -33,7 +33,7 @@ export const Select = forwardRef(
   },
 );
 
-Select.displayName = 'utrecht-radio-button';
+Select.displayName = 'Select';
 
 export interface SelectOptionProps extends OptionHTMLAttributes<HTMLOptionElement> {
   disabled?: boolean;
@@ -65,4 +65,4 @@ export const SelectOption = forwardRef(
   },
 );
 
-SelectOption.displayName = 'utrecht-select-option';
+SelectOption.displayName = 'SelectOption';

--- a/packages/component-library-react/src/Separator.tsx
+++ b/packages/component-library-react/src/Separator.tsx
@@ -15,4 +15,4 @@ export const Separator = forwardRef(
   ),
 );
 
-Separator.displayName = 'utrecht-separator';
+Separator.displayName = 'Separator';

--- a/packages/component-library-react/src/Surface.tsx
+++ b/packages/component-library-react/src/Surface.tsx
@@ -16,4 +16,4 @@ export const Surface = forwardRef(
   ),
 );
 
-Surface.displayName = 'utrecht-surface';
+Surface.displayName = 'Surface';

--- a/packages/component-library-react/src/Table.tsx
+++ b/packages/component-library-react/src/Table.tsx
@@ -16,4 +16,4 @@ export const Table = forwardRef(
   ),
 );
 
-Table.displayName = 'utrecht-table';
+Table.displayName = 'Table';

--- a/packages/component-library-react/src/TableBody.tsx
+++ b/packages/component-library-react/src/TableBody.tsx
@@ -19,4 +19,4 @@ export const TableBody = forwardRef(
   ),
 );
 
-TableBody.displayName = 'utrecht-table-body';
+TableBody.displayName = 'TableBody';

--- a/packages/component-library-react/src/TableCaption.tsx
+++ b/packages/component-library-react/src/TableCaption.tsx
@@ -19,4 +19,4 @@ export const TableCaption = forwardRef(
   ),
 );
 
-TableCaption.displayName = 'utrecht-table-caption';
+TableCaption.displayName = 'TableCaption';

--- a/packages/component-library-react/src/TableCell.tsx
+++ b/packages/component-library-react/src/TableCell.tsx
@@ -19,4 +19,4 @@ export const TableCell = forwardRef(
   ),
 );
 
-TableCell.displayName = 'utrecht-table-cell';
+TableCell.displayName = 'TableCell';

--- a/packages/component-library-react/src/TableFooter.tsx
+++ b/packages/component-library-react/src/TableFooter.tsx
@@ -19,4 +19,4 @@ export const TableFooter = forwardRef(
   ),
 );
 
-TableFooter.displayName = 'utrecht-table-footer';
+TableFooter.displayName = 'TableFooter';

--- a/packages/component-library-react/src/TableHeader.tsx
+++ b/packages/component-library-react/src/TableHeader.tsx
@@ -19,4 +19,4 @@ export const TableHeader = forwardRef(
   ),
 );
 
-TableHeader.displayName = 'utrecht-table-header';
+TableHeader.displayName = 'TableHeader';

--- a/packages/component-library-react/src/TableHeaderCell.tsx
+++ b/packages/component-library-react/src/TableHeaderCell.tsx
@@ -19,4 +19,4 @@ export const TableHeaderCell = forwardRef(
   ),
 );
 
-TableHeaderCell.displayName = 'utrecht-table-header-cell';
+TableHeaderCell.displayName = 'TableHeaderCell';

--- a/packages/component-library-react/src/TableRow.tsx
+++ b/packages/component-library-react/src/TableRow.tsx
@@ -16,4 +16,4 @@ export const TableRow = forwardRef(
   ),
 );
 
-TableRow.displayName = 'utrecht-table-row';
+TableRow.displayName = 'TableRow';

--- a/packages/component-library-react/src/Textarea.tsx
+++ b/packages/component-library-react/src/Textarea.tsx
@@ -30,4 +30,4 @@ export const Textarea = forwardRef(
   ),
 );
 
-Textarea.displayName = 'utrecht-textarea';
+Textarea.displayName = 'Textarea';

--- a/packages/component-library-react/src/Textbox.tsx
+++ b/packages/component-library-react/src/Textbox.tsx
@@ -45,4 +45,4 @@ export const Textbox = forwardRef(
   ),
 );
 
-Textbox.displayName = 'utrecht-textbox';
+Textbox.displayName = 'Textbox';

--- a/packages/component-library-react/src/URLValue.tsx
+++ b/packages/component-library-react/src/URLValue.tsx
@@ -16,4 +16,4 @@ export const URLValue = forwardRef(
   ),
 );
 
-URLValue.displayName = 'utrecht-url';
+URLValue.displayName = 'URLValue';

--- a/packages/component-library-react/src/UnorderedList.tsx
+++ b/packages/component-library-react/src/UnorderedList.tsx
@@ -19,4 +19,4 @@ export const UnorderedList = forwardRef(
   ),
 );
 
-UnorderedList.displayName = 'utrecht-unordered-list';
+UnorderedList.displayName = 'UnorderedList';

--- a/packages/component-library-react/src/UnorderedListItem.tsx
+++ b/packages/component-library-react/src/UnorderedListItem.tsx
@@ -19,4 +19,4 @@ export const UnorderedListItem = forwardRef(
   ),
 );
 
-UnorderedListItem.displayName = 'utrecht-unordered-list-item';
+UnorderedListItem.displayName = 'UnorderedListItem';


### PR DESCRIPTION
the reason why is because there was an issue with storybook
with the code snippet, it was displaying the component name like this

```jsx

<utrecht-button>Click Here</utrecht-button>
{/*instead of*/}
<Button>Click Here</Button

```