### PR TITLE
fix: defaultType and ArgsTable of Checkbox in Storybook Vue

### DIFF
--- a/packages/storybook-react/config/preview.js
+++ b/packages/storybook-react/config/preview.js
@@ -16,4 +16,11 @@ export const parameters = {
       date: /Date$/,
     },
   },
+  docs: {
+    // Show code by default.
+    // Stories without concise code snippets can hide the code at Story level.
+    source: {
+      state: 'open',
+    },
+  },
 };

--- a/packages/storybook-vue/config/preview.js
+++ b/packages/storybook-vue/config/preview.js
@@ -62,4 +62,11 @@ export const parameters = {
       date: /Date$/,
     },
   },
+  docs: {
+    // Show code by default.
+    // Stories without concise code snippets can hide the code at Story level.
+    source: {
+      state: 'open',
+    },
+  },
 };

--- a/packages/storybook-vue/src/stories/Article/Article.stories.mdx
+++ b/packages/storybook-vue/src/stories/Article/Article.stories.mdx
@@ -30,4 +30,4 @@ export const Template = (args) => ({
   </Story>
 </Canvas>
 
-<ArgsTable of={Article} />
+<ArgsTable story="Article" />

--- a/packages/storybook-vue/src/stories/BadgeStatus/BadgeStatus.stories.mdx
+++ b/packages/storybook-vue/src/stories/BadgeStatus/BadgeStatus.stories.mdx
@@ -1,4 +1,4 @@
-import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
 import { BadgeStatus } from "@utrecht/component-library-vue";
 import { argTypes } from "./argTypes.ts";
 
@@ -176,5 +176,3 @@ export const Template = (args) => ({
     {Template.bind({})}
   </Story>
 </Canvas>
-
-<ArgsTable of={BadgeStatus} />

--- a/packages/storybook-vue/src/stories/BadgeStatus/BadgeStatusDefault.stories.mdx
+++ b/packages/storybook-vue/src/stories/BadgeStatus/BadgeStatusDefault.stories.mdx
@@ -11,14 +11,14 @@ export const Template = (args) => ({
   setup() {
     return { args };
   },
-  template: `<BadgeStatus v-bind="args">${args.default}</BadgeStatus>`,
+  template: `<BadgeStatus v-bind="args">${args.textContent}</BadgeStatus>`,
 });
 
 <Canvas>
   <Story
     name="Badge Status Default"
     args={{
-      default: "Default",
+      textContent: "Default",
     }}
     parameters={{
       docs: {
@@ -32,4 +32,4 @@ export const Template = (args) => ({
   </Story>
 </Canvas>
 
-<ArgsTable of={BadgeStatus} />
+<ArgsTable story="Badge Status Default" />

--- a/packages/storybook-vue/src/stories/BadgeStatus/argTypes.ts
+++ b/packages/storybook-vue/src/stories/BadgeStatus/argTypes.ts
@@ -1,6 +1,15 @@
 export const argTypes = {
+  textContent: {
+    type: 'text',
+    table: {
+      defaultValue: { summary: '' },
+    },
+  },
   status: {
     type: 'select',
     options: ['neutral', 'danger', 'safe', 'invalid', 'valid', 'error', 'warning', 'success', 'inactive', 'active'],
+    table: {
+      defaultValue: { summary: '' },
+    },
   },
 };

--- a/packages/storybook-vue/src/stories/Button/Button.stories.mdx
+++ b/packages/storybook-vue/src/stories/Button/Button.stories.mdx
@@ -31,4 +31,4 @@ export const Template = (args) => ({
   </Story>
 </Canvas>
 
-<ArgsTable of={Button} />
+<ArgsTable story="Button" />

--- a/packages/storybook-vue/src/stories/Button/ButtonApearance.stories.mdx
+++ b/packages/storybook-vue/src/stories/Button/ButtonApearance.stories.mdx
@@ -1,4 +1,4 @@
-import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
 import { Button } from "@utrecht/component-library-vue";
 import argTypes from "./argTypes.ts";
 
@@ -64,5 +64,3 @@ export const Template = (args) => ({
     {Template.bind({})}
   </Story>
 </Canvas>
-
-<ArgsTable of={Button} />

--- a/packages/storybook-vue/src/stories/Button/ButtonStates.stories.mdx
+++ b/packages/storybook-vue/src/stories/Button/ButtonStates.stories.mdx
@@ -1,4 +1,4 @@
-import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
 import { Button } from "@utrecht/component-library-vue";
 import argTypes from "./argTypes.ts";
 
@@ -73,5 +73,3 @@ export const Template = (args) => ({
     {Template.bind({})}
   </Story>
 </Canvas>
-
-<ArgsTable of={Button} />

--- a/packages/storybook-vue/src/stories/ButtonGroup/ButtonGroup.stories.mdx
+++ b/packages/storybook-vue/src/stories/ButtonGroup/ButtonGroup.stories.mdx
@@ -30,4 +30,4 @@ export const Template = (args) => ({
   </Story>
 </Canvas>
 
-<ArgsTable of={ButtonGroup} />
+<ArgsTable story="Button Group" />

--- a/packages/storybook-vue/src/stories/Checkbox/Checkbox.stories.mdx
+++ b/packages/storybook-vue/src/stories/Checkbox/Checkbox.stories.mdx
@@ -26,4 +26,4 @@ export const Template = (args) => ({
   </Story>
 </Canvas>
 
-<ArgsTable of={Checkbox} />
+<ArgsTable story="Checkbox default" />

--- a/packages/storybook-vue/src/stories/Checkbox/CheckboxStates.stories.mdx
+++ b/packages/storybook-vue/src/stories/Checkbox/CheckboxStates.stories.mdx
@@ -1,5 +1,5 @@
 import { action } from "@storybook/addon-actions";
-import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
 import { Checkbox } from "@utrecht/component-library-vue";
 import { argTypes, componentArgs } from "./argTypes.ts";
 
@@ -71,5 +71,3 @@ export const Template = (args) => ({
     {Template.bind({})}
   </Story>
 </Canvas>
-
-<ArgsTable of={Checkbox} />

--- a/packages/storybook-vue/src/stories/Checkbox/CheckboxWithFieldsetAndLegend.stories.mdx
+++ b/packages/storybook-vue/src/stories/Checkbox/CheckboxWithFieldsetAndLegend.stories.mdx
@@ -1,4 +1,4 @@
-import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
 import { Checkbox } from "@utrecht/component-library-vue";
 import { argTypes, checkboxWithFieldsetAndLegendData, componentArgs } from "./argTypes.ts";
 
@@ -60,5 +60,3 @@ export const Template = (args) => ({
     {Template.bind({})}
   </Story>
 </Canvas>
-
-<ArgsTable of={Checkbox} />

--- a/packages/storybook-vue/src/stories/Checkbox/CheckboxWithLabel.stories.mdx
+++ b/packages/storybook-vue/src/stories/Checkbox/CheckboxWithLabel.stories.mdx
@@ -1,4 +1,4 @@
-import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
 import { Checkbox } from "@utrecht/component-library-vue";
 import { argTypes, componentArgs } from "./argTypes.ts";
 
@@ -35,5 +35,3 @@ export const Template = (args) => ({
     {Template.bind({})}
   </Story>
 </Canvas>
-
-<ArgsTable of={Checkbox} />

--- a/packages/storybook-vue/src/stories/Checkbox/argTypes.ts
+++ b/packages/storybook-vue/src/stories/Checkbox/argTypes.ts
@@ -2,32 +2,44 @@ export const argTypes = {
   checked: {
     name: 'checked',
     type: { name: 'boolean', required: false },
-    defaultValue: false,
+    table: {
+      defaultValue: { summary: false },
+    },
   },
   disabled: {
     name: 'disabled',
     type: { name: 'boolean', required: false },
-    defaultValue: false,
+    table: {
+      defaultValue: { summary: false },
+    },
   },
   invalid: {
     name: 'invalid',
     type: { name: 'boolean', required: false },
-    defaultValue: false,
+    table: {
+      defaultValue: { summary: false },
+    },
   },
   required: {
     name: 'required',
     type: { name: 'boolean', required: false },
-    defaultValue: false,
+    table: {
+      defaultValue: { summary: false },
+    },
   },
   modelValue: {
     name: 'modelValue',
     type: { name: 'string', required: false },
-    defaultValue: '',
+    table: {
+      defaultValue: { summary: '' },
+    },
   },
   value: {
     name: 'value',
     type: { name: 'string', required: false },
-    defaultValue: '',
+    table: {
+      defaultValue: { summary: '' },
+    },
   },
 };
 

--- a/packages/storybook-vue/src/stories/Document/Document.stories.mdx
+++ b/packages/storybook-vue/src/stories/Document/Document.stories.mdx
@@ -30,4 +30,4 @@ export const Template = (args) => ({
   </Story>
 </Canvas>
 
-<ArgsTable of={Document} />
+<ArgsTable story="Document" />

--- a/packages/storybook-vue/src/stories/Heading/Heading.stories.mdx
+++ b/packages/storybook-vue/src/stories/Heading/Heading.stories.mdx
@@ -1,4 +1,4 @@
-import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
 import { Heading } from "@utrecht/component-library-vue";
 
 <Meta id="vue-heading" title="Vue.js Component/Heading" component={Heading} />
@@ -41,5 +41,3 @@ export const Template = (args) => ({
     {Template.bind({})}
   </Story>
 </Canvas>
-
-<ArgsTable of={Heading} />

--- a/packages/storybook-vue/src/stories/Heading/HeadingLevel1.stories.mdx
+++ b/packages/storybook-vue/src/stories/Heading/HeadingLevel1.stories.mdx
@@ -33,4 +33,4 @@ export const Template = (args) => ({
   </Story>
 </Canvas>
 
-<ArgsTable of={Heading} />
+<ArgsTable story="Heading Level 1" />

--- a/packages/storybook-vue/src/stories/Heading/HeadingLevel2.stories.mdx
+++ b/packages/storybook-vue/src/stories/Heading/HeadingLevel2.stories.mdx
@@ -33,4 +33,4 @@ export const Template = (args) => ({
   </Story>
 </Canvas>
 
-<ArgsTable of={Heading} />
+<ArgsTable story="Heading Level 2" />

--- a/packages/storybook-vue/src/stories/Heading/HeadingLevel3.stories.mdx
+++ b/packages/storybook-vue/src/stories/Heading/HeadingLevel3.stories.mdx
@@ -33,4 +33,4 @@ export const Template = (args) => ({
   </Story>
 </Canvas>
 
-<ArgsTable of={Heading} />
+<ArgsTable story="Heading Level 3" />

--- a/packages/storybook-vue/src/stories/Heading/HeadingLevel4.stories.mdx
+++ b/packages/storybook-vue/src/stories/Heading/HeadingLevel4.stories.mdx
@@ -33,4 +33,4 @@ export const Template = (args) => ({
   </Story>
 </Canvas>
 
-<ArgsTable of={Heading} />
+<ArgsTable story="Heading Level 4" />

--- a/packages/storybook-vue/src/stories/Heading/HeadingLevel5.stories.mdx
+++ b/packages/storybook-vue/src/stories/Heading/HeadingLevel5.stories.mdx
@@ -33,4 +33,4 @@ export const Template = (args) => ({
   </Story>
 </Canvas>
 
-<ArgsTable of={Heading} />
+<ArgsTable story="Heading Level 5" />

--- a/packages/storybook-vue/src/stories/Heading/HeadingLevel6.stories.mdx
+++ b/packages/storybook-vue/src/stories/Heading/HeadingLevel6.stories.mdx
@@ -33,4 +33,4 @@ export const Template = (args) => ({
   </Story>
 </Canvas>
 
-<ArgsTable of={Heading} />
+<ArgsTable story="Heading Level 6" />

--- a/packages/storybook-vue/src/stories/Heading1/Heading1.stories.mdx
+++ b/packages/storybook-vue/src/stories/Heading1/Heading1.stories.mdx
@@ -27,4 +27,4 @@ export const Template = (args) => ({
   </Story>
 </Canvas>
 
-<ArgsTable of={Heading1} />
+<ArgsTable story="Heading 1" />

--- a/packages/storybook-vue/src/stories/Heading2/Heading2.stories.mdx
+++ b/packages/storybook-vue/src/stories/Heading2/Heading2.stories.mdx
@@ -27,4 +27,4 @@ export const Template = (args) => ({
   </Story>
 </Canvas>
 
-<ArgsTable of={Heading2} />
+<ArgsTable story="Heading 2" />

--- a/packages/storybook-vue/src/stories/Heading3/Heading3.stories.mdx
+++ b/packages/storybook-vue/src/stories/Heading3/Heading3.stories.mdx
@@ -27,4 +27,4 @@ export const Template = (args) => ({
   </Story>
 </Canvas>
 
-<ArgsTable of={Heading3} />
+<ArgsTable story="Heading 3" />

--- a/packages/storybook-vue/src/stories/Heading4/Heading4.stories.mdx
+++ b/packages/storybook-vue/src/stories/Heading4/Heading4.stories.mdx
@@ -27,4 +27,4 @@ export const Template = (args) => ({
   </Story>
 </Canvas>
 
-<ArgsTable of={Heading4} />
+<ArgsTable story="Heading 4" />

--- a/packages/storybook-vue/src/stories/Heading5/Heading5.stories.mdx
+++ b/packages/storybook-vue/src/stories/Heading5/Heading5.stories.mdx
@@ -27,4 +27,4 @@ export const Template = (args) => ({
   </Story>
 </Canvas>
 
-<ArgsTable of={Heading5} />
+<ArgsTable story="Heading 5" />

--- a/packages/storybook-vue/src/stories/Heading6/Heading6.stories.mdx
+++ b/packages/storybook-vue/src/stories/Heading6/Heading6.stories.mdx
@@ -27,4 +27,4 @@ export const Template = (args) => ({
   </Story>
 </Canvas>
 
-<ArgsTable of={Heading6} />
+<ArgsTable story="Heading 6" />

--- a/packages/storybook-vue/src/stories/Link/Link.stories.mdx
+++ b/packages/storybook-vue/src/stories/Link/Link.stories.mdx
@@ -30,6 +30,8 @@ export const Template = (args) => ({
   </Story>
 </Canvas>
 
+<ArgsTable story="Link" />
+
 ## External
 
 <Canvas>
@@ -149,5 +151,3 @@ export const Template = (args) => ({
     {Template.bind({})}
   </Story>
 </Canvas>
-
-<ArgsTable of={Link} />

--- a/packages/storybook-vue/src/stories/Link/LinkStates.stories.mdx
+++ b/packages/storybook-vue/src/stories/Link/LinkStates.stories.mdx
@@ -1,4 +1,4 @@
-import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
 import { Link } from "@utrecht/component-library-vue";
 import { argTypes, componentArgs } from "./argTypes.ts";
 
@@ -88,5 +88,3 @@ export const Template = (args) => ({
     {Template.bind({})}
   </Story>
 </Canvas>
-
-<ArgsTable of={Link} />

--- a/packages/storybook-vue/src/stories/Link/argTypes.ts
+++ b/packages/storybook-vue/src/stories/Link/argTypes.ts
@@ -2,12 +2,16 @@ export const argTypes = {
   external: {
     name: 'external',
     type: { name: 'boolean', required: false },
-    defaultValue: false,
+    table: {
+      defaultValue: { summary: false },
+    },
   },
   href: {
     name: 'href',
     type: { name: 'string', required: false },
-    defaultValue: false,
+    table: {
+      defaultValue: { summary: false },
+    },
   },
   target: {
     type: { name: 'string', required: false },

--- a/packages/storybook-vue/src/stories/Page/Page.stories.mdx
+++ b/packages/storybook-vue/src/stories/Page/Page.stories.mdx
@@ -30,4 +30,4 @@ export const Template = (args) => ({
   </Story>
 </Canvas>
 
-<ArgsTable of={Page} />
+<ArgsTable story="Page component" />

--- a/packages/storybook-vue/src/stories/PageContent/PageContent.stories.mdx
+++ b/packages/storybook-vue/src/stories/PageContent/PageContent.stories.mdx
@@ -29,4 +29,4 @@ export const Template = (args) => ({
   </Story>
 </Canvas>
 
-<ArgsTable of={PageContent} />
+<ArgsTable story="PageContent" />

--- a/packages/storybook-vue/src/stories/PageFooter/PageFooter.stories.mdx
+++ b/packages/storybook-vue/src/stories/PageFooter/PageFooter.stories.mdx
@@ -29,4 +29,4 @@ export const Template = (args) => ({
   </Story>
 </Canvas>
 
-<ArgsTable of={PageFooter} />
+<ArgsTable story="PageFooter" />

--- a/packages/storybook-vue/src/stories/PageHeader/PageHeader.stories.mdx
+++ b/packages/storybook-vue/src/stories/PageHeader/PageHeader.stories.mdx
@@ -29,4 +29,4 @@ export const Template = (args) => ({
   </Story>
 </Canvas>
 
-<ArgsTable of={PageHeader} />
+<ArgsTable story="PageHeader" />

--- a/packages/storybook-vue/src/stories/Paragraph/Paragraph.stories.mdx
+++ b/packages/storybook-vue/src/stories/Paragraph/Paragraph.stories.mdx
@@ -32,6 +32,8 @@ export const Template = (args) => ({
   </Story>
 </Canvas>
 
+<ArgsTable story="Default" />
+
 ## Lead
 
 <Canvas>
@@ -49,5 +51,3 @@ export const Template = (args) => ({
     {Template.bind({})}
   </Story>
 </Canvas>
-
-<ArgsTable of={Paragraph} />

--- a/packages/storybook-vue/src/stories/Paragraph/argTypes.ts
+++ b/packages/storybook-vue/src/stories/Paragraph/argTypes.ts
@@ -2,6 +2,8 @@ export const argTypes = {
   lead: {
     name: 'lead',
     type: { name: 'boolean', required: false },
-    defaultValue: false,
+    table: {
+      defaultValue: { summary: false },
+    },
   },
 };

--- a/packages/storybook-vue/src/stories/RadioButton/RadioButton.stories.mdx
+++ b/packages/storybook-vue/src/stories/RadioButton/RadioButton.stories.mdx
@@ -27,4 +27,4 @@ export const Template = (args) => ({
   </Story>
 </Canvas>
 
-<ArgsTable of={RadioButton} />
+<ArgsTable story="Default" />

--- a/packages/storybook-vue/src/stories/RadioButton/RadioButtonStates.stories.mdx
+++ b/packages/storybook-vue/src/stories/RadioButton/RadioButtonStates.stories.mdx
@@ -1,5 +1,5 @@
 import { action } from "@storybook/addon-actions";
-import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
 import { RadioButton } from "@utrecht/component-library-vue";
 import { argTypes } from "./argTypes.ts";
 
@@ -76,5 +76,3 @@ export const Template = (args) => ({
     {Template.bind({})}
   </Story>
 </Canvas>
-
-<ArgsTable of={RadioButton} />

--- a/packages/storybook-vue/src/stories/RadioButton/RadioButtonWithFieldsetAndLegend.stories.mdx
+++ b/packages/storybook-vue/src/stories/RadioButton/RadioButtonWithFieldsetAndLegend.stories.mdx
@@ -1,5 +1,5 @@
 import { action } from "@storybook/addon-actions";
-import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
 import { RadioButton } from "@utrecht/component-library-vue";
 import { argTypes, radioButtonWithFieldsetAndLegendData } from "./argTypes.ts";
 
@@ -65,5 +65,3 @@ export const Template = (args) => ({
     {Template.bind({})}
   </Story>
 </Canvas>
-
-<ArgsTable of={RadioButton} />

--- a/packages/storybook-vue/src/stories/RadioButton/RadioButtonWithLabel.stories.mdx
+++ b/packages/storybook-vue/src/stories/RadioButton/RadioButtonWithLabel.stories.mdx
@@ -1,5 +1,5 @@
 import { action } from "@storybook/addon-actions";
-import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
 import { RadioButton } from "@utrecht/component-library-vue";
 import { argTypes } from "./argTypes.ts";
 
@@ -54,5 +54,3 @@ export const Template = (args) => ({
     {Template.bind({})}
   </Story>
 </Canvas>
-
-<ArgsTable of={RadioButton} />

--- a/packages/storybook-vue/src/stories/RadioButton/argTypes.ts
+++ b/packages/storybook-vue/src/stories/RadioButton/argTypes.ts
@@ -2,22 +2,30 @@ export const argTypes = {
   checked: {
     name: 'checked',
     type: { name: 'boolean', required: false },
-    defaultValue: false,
+    table: {
+      defaultValue: { summary: false },
+    },
   },
   disabled: {
     name: 'disabled',
     type: { name: 'boolean', required: false },
-    defaultValue: false,
+    table: {
+      defaultValue: { summary: false },
+    },
   },
   invalid: {
     name: 'invalid',
     type: { name: 'boolean', required: false },
-    defaultValue: false,
+    table: {
+      defaultValue: { summary: false },
+    },
   },
   required: {
     name: 'required',
     type: { name: 'boolean', required: false },
-    defaultValue: false,
+    table: {
+      defaultValue: { summary: false },
+    },
   },
   modelValue: {
     name: 'modelValue',

--- a/packages/storybook-vue/src/stories/Select/Select.stories.mdx
+++ b/packages/storybook-vue/src/stories/Select/Select.stories.mdx
@@ -35,4 +35,4 @@ export const Template = (args) => ({
   </Story>
 </Canvas>
 
-<ArgsTable of={Select} />
+<ArgsTable story="Default" />

--- a/packages/storybook-vue/src/stories/Select/SelectStates.stories.mdx
+++ b/packages/storybook-vue/src/stories/Select/SelectStates.stories.mdx
@@ -1,5 +1,5 @@
 import { action } from "@storybook/addon-actions";
-import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
 import { Select } from "@utrecht/component-library-vue";
 import { argTypes, options } from "./argTypes.ts";
 
@@ -145,5 +145,3 @@ export const Template = (args) => ({
     {Template.bind({})}
   </Story>
 </Canvas>
-
-<ArgsTable of={Select} />

--- a/packages/storybook-vue/src/stories/Select/SelectWithLabel.stories.mdx
+++ b/packages/storybook-vue/src/stories/Select/SelectWithLabel.stories.mdx
@@ -1,5 +1,5 @@
 import { action } from "@storybook/addon-actions";
-import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
 import { Select } from "@utrecht/component-library-vue";
 import { argTypes, options } from "./argTypes.ts";
 
@@ -43,5 +43,3 @@ export const Template = (args) => ({
     {Template.bind({})}
   </Story>
 </Canvas>
-
-<ArgsTable of={Select} />

--- a/packages/storybook-vue/src/stories/Select/argTypes.ts
+++ b/packages/storybook-vue/src/stories/Select/argTypes.ts
@@ -2,26 +2,36 @@ export const argTypes = {
   disabled: {
     name: 'disabled',
     type: { name: 'boolean', required: false },
-    defaultValue: false,
+    table: {
+      defaultValue: { summary: false },
+    },
   },
   invalid: {
     name: 'invalid',
     type: { name: 'boolean', required: false },
-    defaultValue: false,
+    table: {
+      defaultValue: { summary: false },
+    },
   },
   required: {
     name: 'required',
     type: { name: 'boolean', required: false },
-    defaultValue: false,
+    table: {
+      defaultValue: { summary: false },
+    },
   },
   modelValue: {
     name: 'modelValue',
-    defaultValue: '',
+    table: {
+      defaultValue: { summary: '' },
+    },
   },
   readonly: {
     name: 'readonly',
     type: { name: 'boolean', required: false },
-    defaultValue: false,
+    table: {
+      defaultValue: { summary: false },
+    },
   },
 };
 

--- a/packages/storybook-vue/src/stories/Table/Table.stories.mdx
+++ b/packages/storybook-vue/src/stories/Table/Table.stories.mdx
@@ -1,4 +1,4 @@
-import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
 import { Table } from "@utrecht/component-library-vue";
 
 <Meta id="vue-table" title="Vue.js Component/Table" component={Table} />
@@ -68,5 +68,3 @@ export const Template = (args) => ({
     {Template.bind({})}
   </Story>
 </Canvas>
-
-<ArgsTable of={Table} />

--- a/packages/storybook-vue/src/stories/Textarea/Textarea.stories.mdx
+++ b/packages/storybook-vue/src/stories/Textarea/Textarea.stories.mdx
@@ -39,6 +39,8 @@ export const Template = (args, { argTypes }) => ({
   </Story>
 </Canvas>
 
+<ArgsTable story="Default" />
+
 ## With Placeholder
 
 <Canvas>
@@ -61,5 +63,3 @@ export const Template = (args, { argTypes }) => ({
     {Template.bind({})}
   </Story>
 </Canvas>
-
-<ArgsTable of={Textarea} />

--- a/packages/storybook-vue/src/stories/Textarea/TextareaBinding.stories.mdx
+++ b/packages/storybook-vue/src/stories/Textarea/TextareaBinding.stories.mdx
@@ -1,5 +1,5 @@
 import { action } from "@storybook/addon-actions";
-import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
 import { Textarea } from "@utrecht/component-library-vue";
 import { argTypes } from "./argTypes.ts";
 
@@ -38,5 +38,3 @@ export const Template = (args, { argTypes }) => ({
     {Template.bind({})}
   </Story>
 </Canvas>
-
-<ArgsTable of={Textarea} />

--- a/packages/storybook-vue/src/stories/Textarea/TextareaStates.stories.mdx
+++ b/packages/storybook-vue/src/stories/Textarea/TextareaStates.stories.mdx
@@ -1,5 +1,5 @@
 import { action } from "@storybook/addon-actions";
-import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
 import { Textarea } from "@utrecht/component-library-vue";
 import { argTypes } from "./argTypes.ts";
 
@@ -155,5 +155,3 @@ export const Template = (args, { argTypes }) => ({
     {Template.bind({})}
   </Story>
 </Canvas>
-
-<ArgsTable of={Textarea} />

--- a/packages/storybook-vue/src/stories/Textarea/argTypes.ts
+++ b/packages/storybook-vue/src/stories/Textarea/argTypes.ts
@@ -2,27 +2,37 @@ export const argTypes = {
   disabled: {
     name: 'disabled',
     type: { name: 'boolean', required: false },
-    defaultValue: false,
+    table: {
+      defaultValue: { summary: false },
+    },
   },
   invalid: {
     name: 'invalid',
     type: { name: 'boolean', required: false },
-    defaultValue: false,
+    table: {
+      defaultValue: { summary: false },
+    },
   },
   required: {
     name: 'required',
     type: { name: 'boolean', required: false },
-    defaultValue: false,
+    table: {
+      defaultValue: { summary: false },
+    },
   },
   readonly: {
     name: 'readonly',
     type: { name: 'boolean', required: false },
-    defaultValue: false,
+    table: {
+      defaultValue: { summary: false },
+    },
   },
   modelValue: {
     name: 'modelValue',
     type: { name: 'string', required: false },
-    defaultValue: 'The Quick Brown Fox Jumps Over The Lazy Dog',
+    table: {
+      defaultValue: { summary: 'The Quick Brown Fox Jumps Over The Lazy Dog' },
+    },
   },
   rows: {
     name: 'rows',

--- a/packages/storybook-vue/src/stories/Textbox/Textbox.stories.mdx
+++ b/packages/storybook-vue/src/stories/Textbox/Textbox.stories.mdx
@@ -39,6 +39,8 @@ export const Template = (args, { argTypes }) => ({
   </Story>
 </Canvas>
 
+<ArgsTable story="Default" />
+
 ## With Placeholder
 
 <Canvas>
@@ -61,5 +63,3 @@ export const Template = (args, { argTypes }) => ({
     {Template.bind({})}
   </Story>
 </Canvas>
-
-<ArgsTable of={Textbox} />

--- a/packages/storybook-vue/src/stories/Textbox/TextboxStates.stories.mdx
+++ b/packages/storybook-vue/src/stories/Textbox/TextboxStates.stories.mdx
@@ -1,5 +1,5 @@
 import { action } from "@storybook/addon-actions";
-import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
 import { Textbox } from "@utrecht/component-library-vue";
 import { argTypes } from "./argTypes.ts";
 
@@ -133,5 +133,3 @@ export const Template = (args, { argTypes }) => ({
     {Template.bind({})}
   </Story>
 </Canvas>
-
-<ArgsTable of={Textbox} />

--- a/packages/storybook-vue/src/stories/Textbox/TextboxTypes.stories.mdx
+++ b/packages/storybook-vue/src/stories/Textbox/TextboxTypes.stories.mdx
@@ -1,5 +1,5 @@
 import { action } from "@storybook/addon-actions";
-import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
 import { Textbox } from "@utrecht/component-library-vue";
 import { argTypes } from "./argTypes.ts";
 
@@ -155,5 +155,3 @@ export const Template = (args, { argTypes }) => ({
     {Template.bind({})}
   </Story>
 </Canvas>
-
-<ArgsTable of={Textbox} />

--- a/packages/storybook-vue/src/stories/Textbox/TextboxWithFormBinding.stories.mdx
+++ b/packages/storybook-vue/src/stories/Textbox/TextboxWithFormBinding.stories.mdx
@@ -1,5 +1,5 @@
 import { action } from "@storybook/addon-actions";
-import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
 import { Textbox } from "@utrecht/component-library-vue";
 import { argTypes } from "./argTypes.ts";
 
@@ -36,5 +36,3 @@ export const Template = (args, { argTypes }) => ({
     {Template.bind({})}
   </Story>
 </Canvas>
-
-<ArgsTable of={Textbox} />

--- a/packages/storybook-vue/src/stories/Textbox/TextboxWithLabel.stories.mdx
+++ b/packages/storybook-vue/src/stories/Textbox/TextboxWithLabel.stories.mdx
@@ -1,5 +1,5 @@
 import { action } from "@storybook/addon-actions";
-import { ArgsTable, Canvas, Meta, Story } from "@storybook/addon-docs";
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
 import { Textbox } from "@utrecht/component-library-vue";
 import { argTypes } from "./argTypes.ts";
 
@@ -38,5 +38,3 @@ export const Template = (args, { argTypes }) => ({
     {Template.bind({})}
   </Story>
 </Canvas>
-
-<ArgsTable of={Textbox} />

--- a/packages/storybook-vue/src/stories/Textbox/argTypes.ts
+++ b/packages/storybook-vue/src/stories/Textbox/argTypes.ts
@@ -2,32 +2,44 @@ export const argTypes = {
   disabled: {
     name: 'disabled',
     type: { name: 'boolean', required: false },
-    defaultValue: false,
+    table: {
+      defaultValue: { summary: false },
+    },
   },
   invalid: {
     name: 'invalid',
     type: { name: 'boolean', required: false },
-    defaultValue: false,
+    table: {
+      defaultValue: { summary: false },
+    },
   },
   required: {
     name: 'required',
     type: { name: 'boolean', required: false },
-    defaultValue: false,
+    table: {
+      defaultValue: { summary: false },
+    },
   },
   readonly: {
     name: 'readonly',
     type: { name: 'boolean', required: false },
-    defaultValue: false,
+    table: {
+      defaultValue: { summary: false },
+    },
   },
   modelValue: {
     name: 'modelValue',
     type: { name: 'string', required: false },
-    defaultValue: 'The Quick Brown Fox Jumps Over The Lazy Dog',
+    table: {
+      defaultValue: { summary: 'The Quick Brown Fox Jumps Over The Lazy Dog' },
+    },
   },
   type: {
     name: 'type',
     type: { name: 'select', required: false },
     options: ['text', 'email', 'password', 'number', 'tel', 'url'],
-    defaultValue: 'text',
+    table: {
+      defaultValue: { summary: 'text' },
+    },
   },
 };


### PR DESCRIPTION
@AliKdhim87 Whaddayathink?

Changed `defaultValue` Because of this warning in the console:

[<img width="659" alt="Screenshot 2022-08-09 at 19 26 39" src="https://user-images.githubusercontent.com/30694/183718894-7647cea1-b372-4fc6-9e99-b74611f9868c.png">](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#no-longer-inferring-default-values-of-args)

Then I wondered if we could get ArgsTable to work if we used it like in the other Storybooks.
