### PR TITLE
docs: fix images in docusaurus

### DIFF
--- a/packages/docusaurus/src/styles/custom.scss
+++ b/packages/docusaurus/src/styles/custom.scss
@@ -52,3 +52,7 @@ h5,
 h6 {
   font-size: 110%;
 }
+
+img {
+  height: auto;
+}


### PR DESCRIPTION
# Iets slims in docusaurus voor images uit markdown

We wilden nog graag "Iets slims kunnen doen met de breedte van de afbeeldingen, want ze schalen nog niet echt mooi"

Ik heb nu in docusaurus `custom.scss` `height: auto` toegevoegd en dat lijkt prima te werken voor zover ik kan zien

```css
img {
  height: auto;
}
```

## Voor

<img width="2672" alt="Screenshot 2022-08-19 at 15 38 11" src="https://user-images.githubusercontent.com/877246/185631549-12ffe550-a3f8-4d9a-924a-cff87bcb7e63.png">


## Na
<img width="2672" alt="Screenshot 2022-08-19 at 15 38 36" src="https://user-images.githubusercontent.com/877246/185631666-e8a40a3b-6c8a-4c29-943f-42df2420a177.png">

