### PR TITLE
feat: new design tokens for blockquote

### DIFF
--- a/components/blockquote/css/_mixin.scss
+++ b/components/blockquote/css/_mixin.scss
@@ -4,12 +4,19 @@
  */
 
 @mixin utrecht-blockquote {
+  background-color: var(--utrecht-blockquote-background-color);
+  color: var(--utrecht-blockquote-color);
   font-family: var(--utrecht-document-font-family);
   font-size: var(--utrecht-blockquote-font-size);
+  font-style: var(--utrecht-blockquote-font-style);
   margin-block-end: calc(var(--utrecht-space-around, 0) * var(--utrecht-blockquote-margin-block-end, 0));
   margin-block-start: calc(var(--utrecht-space-around, 0) * var(--utrecht-blockquote-margin-block-start, 0));
   margin-inline-end: var(--utrecht-blockquote-margin-inline-end);
   margin-inline-start: var(--utrecht-blockquote-margin-inline-start);
+  padding-block-end: var(--utrecht-blockquote-padding-block-end);
+  padding-block-start: var(--utrecht-blockquote-padding-block-start);
+  padding-inline-end: var(--utrecht-blockquote-padding-inline-end);
+  padding-inline-start: var(--utrecht-blockquote-padding-inline-start);
 }
 
 @mixin utrecht-blockquote__attribution {

--- a/components/blockquote/tokens.json
+++ b/components/blockquote/tokens.json
@@ -1,6 +1,18 @@
 {
   "utrecht": {
     "blockquote": {
+      "background-color": {
+        "css": {
+          "syntax": "<color>",
+          "inherits": true
+        }
+      },
+      "color": {
+        "css": {
+          "syntax": "<color>",
+          "inherits": true
+        }
+      },
       "margin-inline-start": {
         "css": {
           "syntax": "<length>",
@@ -31,9 +43,39 @@
           "inherits": true
         }
       },
+      "font-style": {
+        "css": {
+          "syntax": "inherit | italic | normal",
+          "inherits": true
+        }
+      },
       "font-family": {
         "css": {
           "syntax": "*",
+          "inherits": true
+        }
+      },
+      "padding-inline-start": {
+        "css": {
+          "syntax": "<length>",
+          "inherits": true
+        }
+      },
+      "padding-inline-end": {
+        "css": {
+          "syntax": "<length>",
+          "inherits": true
+        }
+      },
+      "padding-inline-block-start": {
+        "css": {
+          "syntax": "<length>",
+          "inherits": true
+        }
+      },
+      "padding-inline-block-end": {
+        "css": {
+          "syntax": "<length>",
           "inherits": true
         }
       },

--- a/proprietary/design-tokens/src/component/den-haag/process-steps.tokens.json
+++ b/proprietary/design-tokens/src/component/den-haag/process-steps.tokens.json
@@ -27,7 +27,7 @@
         "background-color": { "value": "{utrecht.color.yellow.50}" },
         "border-width": { "value": "{utrecht.border-width.md}" },
         "color": { "value": "{utrecht.color.grey.15}" },
-        "font-size": { "value": "{utrecht.typography.scale.sm}" },
+        "font-size": { "value": "{utrecht.typography.scale.sm.font-size}" },
         "font-weight": { "value": "{utrecht.typography.weight-scale.bold.font-weight}" },
         "current": {
           "border-color": { "value": "{utrecht.color.grey.15}" },

--- a/proprietary/design-tokens/src/component/utrecht/blockquote.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/blockquote.tokens.json
@@ -3,8 +3,8 @@
     "blockquote": {
       "margin-inline-start": { "value": "1.6em" },
       "margin-inline-end": { "value": "1.6em" },
-      "margin-inline-block-start": { "value": "1.6em" },
-      "margin-inline-block-end": { "value": "1.6em" },
+      "margin-block-start": { "value": "1.6em" },
+      "margin-block-end": { "value": "1.6em" },
       "font-size": {},
       "attribution": {
         "color": {},

--- a/proprietary/design-tokens/src/component/utrecht/blockquote.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/blockquote.tokens.json
@@ -1,6 +1,12 @@
 {
   "utrecht": {
     "blockquote": {
+      "background-color": {},
+      "color": {},
+      "padding-inline-start": {},
+      "padding-inline-end": {},
+      "padding-block-start": {},
+      "padding-block-end": {},
       "margin-inline-start": { "value": "1.6em" },
       "margin-inline-end": { "value": "1.6em" },
       "margin-block-start": { "value": "1.6em" },

--- a/proprietary/design-tokens/src/style-dictionary-config.js
+++ b/proprietary/design-tokens/src/style-dictionary-config.js
@@ -47,12 +47,14 @@ const jsonConfig = {
     ...jsonListFormat,
   },
   platforms: {
-    files: [
-      {
-        destination: 'index.json',
-        format: 'json/list',
-      },
-    ].sort(destinationSort),
+    json: {
+      files: [
+        {
+          destination: 'index.json',
+          format: 'json/list',
+        },
+      ].sort(destinationSort),
+    },
   },
 };
 

--- a/proprietary/design-tokens/style-dictionary.config.json
+++ b/proprietary/design-tokens/style-dictionary.config.json
@@ -29,7 +29,7 @@
           "format": "json/nested"
         },
         {
-          "destination": "index.json",
+          "destination": "index.flat.json",
           "format": "json/flat"
         }
       ]


### PR DESCRIPTION
It is quite usual to have a `background-color` for blockquotes, which would also require a matching `color`. The RVO blockquote design requires this. When there is a background image, it makes sense to have a padding around the text. Quotes are frequently rendered as italic, so include `font-style` too.