### PR TITLE
feat: improve social link

### DIFF
--- a/components/link-social/css/_mixin.scss
+++ b/components/link-social/css/_mixin.scss
@@ -16,6 +16,8 @@
 }
 
 @mixin utrecht-link-social--hover {
+  background-color: var(--utrecht-link-social-hover-background-color, var(--utrecht-link-social-background-color));
+  color: var(--utrecht-link-social-hover-color, var(--utrecht-link-social-color));
   transform: scale(var(--utrecht-link-social-hover-transform-scale));
 }
 

--- a/components/link-social/css/_mixin.scss
+++ b/components/link-social/css/_mixin.scss
@@ -1,0 +1,24 @@
+@mixin utrecht-link-social {
+  --utrecht-icon-size: var(--utrecht-link-social-icon-size);
+  --utrecht-icon-color: currentColor;
+
+  align-items: center;
+  background-color: var(--utrecht-link-social-background-color);
+  border-color: var(--utrecht-link-social-border-color);
+  border-radius: 50%;
+  border-style: solid;
+  border-width: var(--utrecht-link-social-border-width);
+  color: var(--utrecht-link-social-color);
+  display: inline-flex;
+  height: var(--utrecht-link-social-size);
+  justify-content: center;
+  width: var(--utrecht-link-social-size);
+}
+
+@mixin utrecht-link-social--hover {
+  transform: scale(var(--utrecht-link-social-hover-transform-scale));
+}
+
+@mixin utrecht-link-social--distanced {
+  margin-inline-start: var(--utrecht-link-social-margin-inline-start);
+}

--- a/components/link-social/css/index.scss
+++ b/components/link-social/css/index.scss
@@ -1,35 +1,28 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2022 The Knights Who Say NIH! B.V.
+ * Copyright (c) 2022 Gemeente Utrecht
  */
 
+/* stylelint-disable scss/no-global-function-names */
+
 @import "../../common/focus/mixin";
+@import "./mixin";
 
 .utrecht-link-social {
-  --utrecht-icon-size: var(--utrecht-link-social-icon-size);
-  --utrecht-icon-color: currentColor;
-
-  align-items: center;
-  background-color: var(--utrecht-link-social-background-color);
-  border-color: var(--utrecht-link-social-border-color);
-  border-radius: 50%;
-  border-style: solid;
-  border-width: var(--utrecht-link-social-border-width);
-  color: var(--utrecht-link-social-color);
-  display: inline-flex;
-  height: var(--utrecht-link-social-size);
-  justify-content: center;
-  width: var(--utrecht-link-social-size);
+  @include utrecht-link-social;
 }
 
-.utrecht-link-social:hover {
-  transform: scale(var(--utrecht-link-social-hover-scale));
+.utrecht-link-social:hover,
+.utrecht-link-social--hover {
+  @include utrecht-link-social--hover;
 }
 
-.utrecht-link-social:focus-visible {
+.utrecht-link-social:focus-visible,
+.utrecht-link-social--focus-visible {
   @include utrecht-focus-visible;
 }
 
 .utrecht-link-social--distanced {
-  margin-inline-start: var(--utrecht-link-social-margin-inline-start);
+  @include utrecht-link-social--distanced;
 }

--- a/components/link-social/css/stories/distanced.stories.mdx
+++ b/components/link-social/css/stories/distanced.stories.mdx
@@ -1,0 +1,26 @@
+<!-- @license CC0-1.0 -->
+
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { exampleArgs, SocialMediaLink } from "../story-template";
+import "../index.scss";
+
+<Meta
+  id="css-link-social"
+  title="CSS Component/Link to social media"
+  component={SocialMediaLink}
+  parameters={{
+    status: {
+      type: "WORK IN PROGRESS",
+    },
+  }}
+/>
+
+# Link to Social Media
+
+## Distanced
+
+<Canvas>
+  <Story name="Distanced" args={{ ...exampleArgs, distanced: true }}>
+    {SocialMediaLink.bind()}
+  </Story>
+</Canvas>

--- a/components/link-social/css/stories/state.stories.mdx
+++ b/components/link-social/css/stories/state.stories.mdx
@@ -1,0 +1,34 @@
+<!-- @license CC0-1.0 -->
+
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
+import { exampleArgs, SocialMediaLink } from "../story-template";
+import "../index.scss";
+
+<Meta
+  id="css-link-social"
+  title="CSS Component/Link to social media/State"
+  component={SocialMediaLink}
+  parameters={{
+    status: {
+      type: "WORK IN PROGRESS",
+    },
+  }}
+/>
+
+# Link to Social Media
+
+## Hover
+
+<Canvas>
+  <Story name="Hover" args={{ ...exampleArgs, hover: true }}>
+    {SocialMediaLink.bind({})}
+  </Story>
+</Canvas>
+
+## Focus visible
+
+<Canvas>
+  <Story name="Focus visible" args={{ ...exampleArgs, focusVisible: true }}>
+    {SocialMediaLink.bind({})}
+  </Story>
+</Canvas>

--- a/components/link-social/css/story-template.jsx
+++ b/components/link-social/css/story-template.jsx
@@ -48,9 +48,11 @@ export const argTypes = {
 
 export const defaultArgs = {
   distanced: false,
+  hover: false,
   href: '',
   icon: '',
   title: '',
+  focusVisible: false,
 };
 
 export const exampleArgs = {
@@ -64,8 +66,19 @@ export const SocialMediaLink = ({
   icon = defaultArgs.icon,
   title = defaultArgs.title,
   distanced = defaultArgs.distanced,
+  hover = defaultArgs.hover,
+  focusVisible = defaultArgs.focusVisible,
 }) => (
-  <a href={href} className={clsx('utrecht-link-social', distanced && 'utrecht-link-social--distanced')} title={title}>
+  <a
+    href={href}
+    className={clsx(
+      'utrecht-link-social',
+      distanced && 'utrecht-link-social--distanced',
+      hover && 'utrecht-link-social--hover',
+      focusVisible && 'utrecht-link-social--focus-visible',
+    )}
+    title={title}
+  >
     {parse(`<${icon}></${icon}>`)}
   </a>
 );

--- a/components/link-social/tokens.json
+++ b/components/link-social/tokens.json
@@ -43,6 +43,18 @@
             "syntax": "<length>",
             "inherits": true
           }
+        },
+        "background-color": {
+          "css": {
+            "syntax": "<color>",
+            "inherits": true
+          }
+        },
+        "color": {
+          "css": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       }
     }


### PR DESCRIPTION
For Den Haag we also need social-link and social-link-list components. We can use these Utrecht components but we don't change the size of the icons on hover but the background-color instead. 

We could continue with the Utrecht CSS if we had a mixin
- [x] Use mixins

It would be ideal to have the states in Storybook to see how Utrecht has implemented these without using the inspector
- [x] Add Stories for distanced, hover and focus-visible

If Utrecht doesn't mind we could also add the API's to the Utrecht component directly
- [x] Add API's for on-hover: background-color and color