### PR TITLE
feat: add `text-decoration-color` token for links

### DIFF
--- a/components/link/css/_mixin.scss
+++ b/components/link/css/_mixin.scss
@@ -70,6 +70,7 @@ however browsers don't seem to have implemented great looking supixel tweening y
 
   color: var(--utrecht-link-color, blue);
   text-decoration: var(--utrecht-link-text-decoration, underline);
+  text-decoration-color: var(--utrecht-link-text-decoration-color, currentColor);
   text-decoration-skip-ink: all;
   text-decoration-thickness: max(var(--utrecht-link-text-decoration-thickness), 1px);
   text-underline-offset: var(--utrecht-link-text-underline-offset);

--- a/components/link/tokens.json
+++ b/components/link/tokens.json
@@ -13,6 +13,12 @@
           "inherits": true
         }
       },
+      "text-decoration-color": {
+        "css": {
+          "syntax": "<color>",
+          "inherits": true
+        }
+      },
       "text-underline-thickness": {
         "css": {
           "syntax": "<length>",

--- a/components/link/tokens.json
+++ b/components/link/tokens.json
@@ -19,7 +19,7 @@
           "inherits": true
         }
       },
-      "text-underline-thickness": {
+      "text-decoration-thickness": {
         "css": {
           "syntax": "<length>",
           "inherits": true
@@ -52,7 +52,7 @@
             "inherits": true
           }
         },
-        "text-underline-thickness": {
+        "text-decoration-thickness": {
           "css": {
             "syntax": "<length>",
             "inherits": true
@@ -72,7 +72,7 @@
             "inherits": true
           }
         },
-        "text-underline-thickness": {
+        "text-decoration-thickness": {
           "css": {
             "syntax": "<length>",
             "inherits": true

--- a/proprietary/design-tokens/src/component/utrecht/link.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/link.tokens.json
@@ -6,6 +6,7 @@
         "size": { "value": "1.2em" }
       },
       "text-decoration": { "value": "underline" },
+      "text-decoration-color": {},
       "text-underline-offset": { "value": "3px" },
       "active": {
         "color": { "value": "{utrecht.link.color}" }


### PR DESCRIPTION
Would be very helpful for Haarlem.

Eventually we probably need text-decoration-color tokens for interactive states too.

---

- Ik heb de nieuwe token toegevoegd voor de underline kleur, omdat voor Haarlem die lichtgrijs moet zijn (en dat was geen optie met de bestaande component)
- Ik heb de token van text-underline-tickness aangepakt omdat jullie terecht hadden gezegd dat 'ie in CSS text-decoration-thickness heet
