### PR TITLE
Update font token

### DIFF
--- a/components/navigatie sidenav/README.md
+++ b/components/navigatie sidenav/README.md
@@ -70,7 +70,7 @@ Describe the atanomy of a component, for example:
 
 Deze global design tokens worden gebruikt in dit component:
 
-- --utrecht-font-family-sans-serif
+- --utrecht-typography-sans-serif-font-family
 - --utrecht-space-inline-2xs
 - --utrecht-space-inline-xs
 - --utrecht-space-inline-md

--- a/components/navigatie sidenav/README.md
+++ b/components/navigatie sidenav/README.md
@@ -70,7 +70,7 @@ Describe the atanomy of a component, for example:
 
 Deze global design tokens worden gebruikt in dit component:
 
-- --utrecht-typography-sans-serif-font-family
+- --utrecht-document-font-family
 - --utrecht-space-inline-2xs
 - --utrecht-space-inline-xs
 - --utrecht-space-inline-md

--- a/components/navigatie topnav/README.md
+++ b/components/navigatie topnav/README.md
@@ -70,7 +70,7 @@ Describe the atanomy of a component, for example:
 
 Deze global design tokens worden gebruikt in dit component:
 
-- --utrecht-font-family-sans-serif
+- --utrecht-typography-sans-serif-font-family
 - --utrecht-space-inline-2xs
 - --utrecht-space-inline-xs
 - --utrecht-space-inline-md

--- a/components/navigatie topnav/README.md
+++ b/components/navigatie topnav/README.md
@@ -70,7 +70,7 @@ Describe the atanomy of a component, for example:
 
 Deze global design tokens worden gebruikt in dit component:
 
-- --utrecht-typography-sans-serif-font-family
+- --utrecht-document-font-family
 - --utrecht-space-inline-2xs
 - --utrecht-space-inline-xs
 - --utrecht-space-inline-md

--- a/components/navigatie topnav/css/index.scss
+++ b/components/navigatie topnav/css/index.scss
@@ -7,7 +7,7 @@
 @import "../../common/focus/mixin";
 
 .utrecht-navhtml {
-  font-family: var(--utrecht-typography-sans-serif-font-family);
+  font-family: var(--utrecht-document-font-family);
 }
 
 .utrecht-topnav__list {

--- a/components/navigatie topnav/css/index.scss
+++ b/components/navigatie topnav/css/index.scss
@@ -7,7 +7,7 @@
 @import "../../common/focus/mixin";
 
 .utrecht-navhtml {
-  font-family: var(--utrecht-font-family-sans-serif);
+  font-family: var(--utrecht-typography-sans-serif-font-family);
 }
 
 .utrecht-topnav__list {


### PR DESCRIPTION
This PR updates:
- the usage of the sans-serif token in the navigatie topnav to --utrecht-document-font-family.
- the README for topnav which mentions the use of the token
- the README for sidenav which mentions the same token (though it does not appear in the CSS?)

Fixes https://github.com/nl-design-system/utrecht/issues/1566