### PR TITLE
refactor: rename css property to ['$extensions']['nl.nldesignsystem.css.property']

### DIFF
--- a/components/alert-dialog/tokens.json
+++ b/components/alert-dialog/tokens.json
@@ -2,51 +2,67 @@
   "utrecht": {
     "alert-dialog": {
       "border-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "border-radius": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "border-width": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "box-shadow": {
-        "css": {
-          "syntax": "*",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "*",
+            "inherits": true
+          }
         }
       },
       "max-block-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "max-inline-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "min-block-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "min-inline-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       }
     }

--- a/components/alert/tokens.json
+++ b/components/alert/tokens.json
@@ -2,171 +2,223 @@
   "utrecht": {
     "alert": {
       "background-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "border-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "border-width": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "padding-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-inline-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-inline-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "warning": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-width": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       },
       "error": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-width": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       },
       "ok": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-width": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       },
       "icon": {
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "error": {
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         },
         "warning": {
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         },
         "ok": {
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         }

--- a/components/article/tokens.json
+++ b/components/article/tokens.json
@@ -2,9 +2,11 @@
   "utrecht": {
     "article": {
       "max-inline-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       }
     }

--- a/components/backdrop/tokens.json
+++ b/components/backdrop/tokens.json
@@ -2,42 +2,54 @@
   "utrecht": {
     "backdrop": {
       "background-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "opacity": {
-        "css": {
-          "syntax": "<number>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<number>",
+            "inherits": true
+          }
         }
       },
       "z-index": {
-        "css": {
-          "syntax": "<number>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<number>",
+            "inherits": true
+          }
         }
       },
       "fade-in": {
         "animation-duration": {
-          "css": {
-            "syntax": "<time>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<time>",
+              "inherits": true
+            }
           }
         }
       },
       "reduced-transparency": {
         "opacity": {
-          "css": {
-            "syntax": "<number>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<number>",
+              "inherits": true
+            }
           }
         }
       }

--- a/components/badge-data/tokens.json
+++ b/components/badge-data/tokens.json
@@ -2,15 +2,19 @@
   "utrecht": {
     "badge-data": {
       "letter-spacing": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "text-transform": {
-        "css": {
-          "syntax": "inherit | uppercase",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "inherit | uppercase",
+            "inherits": true
+          }
         }
       }
     }

--- a/components/badge-status/tokens.json
+++ b/components/badge-status/tokens.json
@@ -2,15 +2,19 @@
   "utrecht": {
     "badge-status": {
       "letter-spacing": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "text-transform": {
-        "css": {
-          "syntax": "inherit | uppercase",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "inherit | uppercase",
+            "inherits": true
+          }
         }
       }
     }

--- a/components/badge/tokens.json
+++ b/components/badge/tokens.json
@@ -3,61 +3,79 @@
     "badge": {
       "background-color": {
         "comment": "Default background color for badge components",
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "border-radius": {
         "comment": "Default corner radius for badge components",
-        "css": {
-          "syntax": "<length-percentage>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length-percentage>",
+            "inherits": true
+          }
         }
       },
       "color": {
         "comment": "Default text color for badge components",
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "font-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "font-weight": {
-        "css": {
-          "syntax": "<number>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<number>",
+            "inherits": true
+          }
         }
       },
       "line-height": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-block": {
         "comment": "Default block padding for badge components",
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-inline": {
         "comment": "Default inline padding color for badge components",
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "text-transform": {
-        "css": {
-          "syntax": "inherit | uppercase",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "inherit | uppercase",
+            "inherits": true
+          }
         }
       }
     }

--- a/components/blockquote/tokens.json
+++ b/components/blockquote/tokens.json
@@ -2,108 +2,142 @@
   "utrecht": {
     "blockquote": {
       "background-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "margin-inline-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-inline-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-inline-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-inline-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "font-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "font-style": {
-        "css": {
-          "syntax": "inherit | italic | normal",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "inherit | italic | normal",
+            "inherits": true
+          }
         }
       },
       "font-family": {
-        "css": {
-          "syntax": "*",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "*",
+            "inherits": true
+          }
         }
       },
       "padding-inline-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-inline-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-inline-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-inline-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "attribution": {
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "font-size": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       },
       "content": {
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "font-size": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       }

--- a/components/breadcrumb/tokens.json
+++ b/components/breadcrumb/tokens.json
@@ -2,93 +2,121 @@
   "utrecht": {
     "breadcrumb": {
       "block-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "font-family": {
-        "css": {
-          "syntax": "*",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "*",
+            "inherits": true
+          }
         }
       },
       "font-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "text-transform": {
-        "css": {
-          "syntax": "inherit | none | uppercase",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "inherit | none | uppercase",
+            "inherits": true
+          }
         }
       },
       "divider": {
         "content": {
-          "css": {
-            "syntax": "*",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "*",
+              "inherits": true
+            }
           }
         },
         "inline-size": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       },
       "item": {
         "padding-block-start": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "padding-block-end": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "padding-inline-end": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "padding-inline-start": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       },
       "link": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "focus": {
           "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         }

--- a/components/button-group/tokens.json
+++ b/components/button-group/tokens.json
@@ -2,46 +2,60 @@
   "utrecht": {
     "button-group": {
       "background-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "column-gap": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         },
         "comment": "'column-gap', for lack of a better existing property"
       },
       "margin-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "row-gap": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         },
         "comment": "'row-gap', for lack of a better existing property"
       }

--- a/components/button/tokens.json
+++ b/components/button/tokens.json
@@ -2,581 +2,761 @@
   "utrecht": {
     "button": {
       "background-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "border-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "border-radius": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "border-width": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "font-family": {
-        "css": {
-          "syntax": "*",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "*",
+            "inherits": true
+          }
         }
       },
       "font-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "font-weight": {
-        "css": {
-          "syntax": "<number>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<number>",
+            "inherits": true
+          }
         }
       },
       "inline-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "letter-spacing": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "line-height": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-inline-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-inline-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "min-block-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "min-inline-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-inline-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-inline-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "text-transform": {
-        "css": {
-          "syntax": "inherit | uppercase",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "inherit | uppercase",
+            "inherits": true
+          }
         }
       },
       "active": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "icon": {
         "gap": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "size": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       },
       "disabled": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "focus": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "scale": {
-          "css": {
-            "syntax": "<number>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<number>",
+              "inherits": true
+            }
           }
         }
       },
       "hover": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "scale": {
-          "css": {
-            "syntax": "<number>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<number>",
+              "inherits": true
+            }
           }
         }
       },
       "primary-action": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-width": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "font-weight": {
-          "css": {
-            "syntax": "<number>",
-            "inherits": true
-          }
-        },
-        "active": {
-          "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
-            }
-          },
-          "border-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
-            }
-          },
-          "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
-            }
-          }
-        },
-        "disabled": {
-          "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
-            }
-          },
-          "border-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
-            }
-          },
-          "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
-            }
-          }
-        },
-        "hover": {
-          "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
-            }
-          },
-          "border-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
-            }
-          },
-          "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
-            }
-          },
-          "transform": {
-            "css": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
               "syntax": "<number>",
               "inherits": true
             }
           }
         },
-        "focus": {
+        "active": {
           "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "border-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
+            }
+          }
+        },
+        "disabled": {
+          "background-color": {
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
+            }
+          },
+          "border-color": {
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
+            }
+          },
+          "color": {
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
+            }
+          }
+        },
+        "hover": {
+          "background-color": {
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
+            }
+          },
+          "border-color": {
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
+            }
+          },
+          "color": {
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
+            }
+          },
+          "transform": {
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<number>",
+                "inherits": true
+              }
+            }
+          }
+        },
+        "focus": {
+          "background-color": {
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
+            }
+          },
+          "border-color": {
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
+            }
+          },
+          "color": {
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         }
       },
       "secondary-action": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-width": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "font-weight": {
-          "css": {
-            "syntax": "<number>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<number>",
+              "inherits": true
+            }
           }
         },
         "active": {
           "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "border-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         },
         "disabled": {
           "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "border-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         },
         "hover": {
           "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "border-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         },
         "focus": {
           "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "border-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         }
       },
       "subtle": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-width": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "font-weight": {
-          "css": {
-            "syntax": "<number>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<number>",
+              "inherits": true
+            }
           }
         },
         "active": {
           "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "border-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         },
         "disabled": {
           "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "border-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         },
         "hover": {
           "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "border-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         },
         "focus": {
           "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "border-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         }

--- a/components/calendar/tokens.json
+++ b/components/calendar/tokens.json
@@ -2,238 +2,310 @@
   "utrecht": {
     "calendar": {
       "width": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "background-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "table": {
         "padding-block-start": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "padding-block-end": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "weeks-item": {
           "width": {
-            "css": {
-              "syntax": "<length>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<length>",
+                "inherits": true
+              }
             }
           }
         },
         "days-item-day": {
           "size": {
-            "css": {
-              "syntax": "<length>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<length>",
+                "inherits": true
+              }
             }
           },
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "border-width": {
-            "css": {
-              "syntax": "<length>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<length>",
+                "inherits": true
+              }
             }
           },
           "border-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "hover": {
             "background-color": {
-              "css": {
-                "syntax": "<color>",
-                "inherits": true
+              "$extensions": {
+                "nl.nldesignsystem.css.property": {
+                  "syntax": "<color>",
+                  "inherits": true
+                }
               }
             },
             "color": {
-              "css": {
-                "syntax": "<color>",
-                "inherits": true
+              "$extensions": {
+                "nl.nldesignsystem.css.property": {
+                  "syntax": "<color>",
+                  "inherits": true
+                }
               }
             },
             "border-color": {
-              "css": {
-                "syntax": "<color>",
-                "inherits": true
+              "$extensions": {
+                "nl.nldesignsystem.css.property": {
+                  "syntax": "<color>",
+                  "inherits": true
+                }
               }
             }
           },
           "focus": {
             "background-color": {
-              "css": {
-                "syntax": "<color>",
-                "inherits": true
+              "$extensions": {
+                "nl.nldesignsystem.css.property": {
+                  "syntax": "<color>",
+                  "inherits": true
+                }
               }
             },
             "color": {
-              "css": {
-                "syntax": "<color>",
-                "inherits": true
+              "$extensions": {
+                "nl.nldesignsystem.css.property": {
+                  "syntax": "<color>",
+                  "inherits": true
+                }
               }
             },
             "border-color": {
-              "css": {
-                "syntax": "<color>",
-                "inherits": true
+              "$extensions": {
+                "nl.nldesignsystem.css.property": {
+                  "syntax": "<color>",
+                  "inherits": true
+                }
               }
             }
           },
           "active": {
             "background-color": {
-              "css": {
-                "syntax": "<color>",
-                "inherits": true
+              "$extensions": {
+                "nl.nldesignsystem.css.property": {
+                  "syntax": "<color>",
+                  "inherits": true
+                }
               }
             },
             "color": {
-              "css": {
-                "syntax": "<color>",
-                "inherits": true
+              "$extensions": {
+                "nl.nldesignsystem.css.property": {
+                  "syntax": "<color>",
+                  "inherits": true
+                }
               }
             },
             "border-color": {
-              "css": {
-                "syntax": "<color>",
-                "inherits": true
+              "$extensions": {
+                "nl.nldesignsystem.css.property": {
+                  "syntax": "<color>",
+                  "inherits": true
+                }
               }
             }
           },
           "out-of-the-month": {
             "background-color": {
-              "css": {
-                "syntax": "<color>",
-                "inherits": true
+              "$extensions": {
+                "nl.nldesignsystem.css.property": {
+                  "syntax": "<color>",
+                  "inherits": true
+                }
               }
             },
             "color": {
-              "css": {
-                "syntax": "<color>",
-                "inherits": true
+              "$extensions": {
+                "nl.nldesignsystem.css.property": {
+                  "syntax": "<color>",
+                  "inherits": true
+                }
               }
             },
             "border-color": {
-              "css": {
-                "syntax": "<color>",
-                "inherits": true
+              "$extensions": {
+                "nl.nldesignsystem.css.property": {
+                  "syntax": "<color>",
+                  "inherits": true
+                }
               }
             }
           },
           "is-today": {
             "background-color": {
-              "css": {
-                "syntax": "<color>",
-                "inherits": true
+              "$extensions": {
+                "nl.nldesignsystem.css.property": {
+                  "syntax": "<color>",
+                  "inherits": true
+                }
               }
             },
             "color": {
-              "css": {
-                "syntax": "<color>",
-                "inherits": true
+              "$extensions": {
+                "nl.nldesignsystem.css.property": {
+                  "syntax": "<color>",
+                  "inherits": true
+                }
               }
             },
             "border-color": {
-              "css": {
-                "syntax": "<color>",
-                "inherits": true
+              "$extensions": {
+                "nl.nldesignsystem.css.property": {
+                  "syntax": "<color>",
+                  "inherits": true
+                }
               }
             },
             "font-weight": {
-              "css": {
-                "syntax": "<number>",
-                "inherits": true
+              "$extensions": {
+                "nl.nldesignsystem.css.property": {
+                  "syntax": "<number>",
+                  "inherits": true
+                }
               }
             }
           },
           "emphasis": {
             "background-color": {
-              "css": {
-                "syntax": "<color>",
-                "inherits": true
+              "$extensions": {
+                "nl.nldesignsystem.css.property": {
+                  "syntax": "<color>",
+                  "inherits": true
+                }
               }
             },
             "color": {
-              "css": {
-                "syntax": "<color>",
-                "inherits": true
+              "$extensions": {
+                "nl.nldesignsystem.css.property": {
+                  "syntax": "<color>",
+                  "inherits": true
+                }
               }
             },
             "border-color": {
-              "css": {
-                "syntax": "<color>",
-                "inherits": true
+              "$extensions": {
+                "nl.nldesignsystem.css.property": {
+                  "syntax": "<color>",
+                  "inherits": true
+                }
               }
             },
             "font-weight": {
-              "css": {
-                "syntax": "<number>",
-                "inherits": true
+              "$extensions": {
+                "nl.nldesignsystem.css.property": {
+                  "syntax": "<number>",
+                  "inherits": true
+                }
               }
             }
           },
           "selected": {
             "background-color": {
-              "css": {
-                "syntax": "<color>",
-                "inherits": true
+              "$extensions": {
+                "nl.nldesignsystem.css.property": {
+                  "syntax": "<color>",
+                  "inherits": true
+                }
               }
             },
             "color": {
-              "css": {
-                "syntax": "<color>",
-                "inherits": true
+              "$extensions": {
+                "nl.nldesignsystem.css.property": {
+                  "syntax": "<color>",
+                  "inherits": true
+                }
               }
             },
             "border-color": {
-              "css": {
-                "syntax": "<color>",
-                "inherits": true
+              "$extensions": {
+                "nl.nldesignsystem.css.property": {
+                  "syntax": "<color>",
+                  "inherits": true
+                }
               }
             },
             "font-weight": {
-              "css": {
-                "syntax": "<number>",
-                "inherits": true
+              "$extensions": {
+                "nl.nldesignsystem.css.property": {
+                  "syntax": "<number>",
+                  "inherits": true
+                }
               }
             }
           },
           "disabled": {
             "background-color": {
-              "css": {
-                "syntax": "<color>",
-                "inherits": true
+              "$extensions": {
+                "nl.nldesignsystem.css.property": {
+                  "syntax": "<color>",
+                  "inherits": true
+                }
               }
             },
             "color": {
-              "css": {
-                "syntax": "<color>",
-                "inherits": true
+              "$extensions": {
+                "nl.nldesignsystem.css.property": {
+                  "syntax": "<color>",
+                  "inherits": true
+                }
               }
             },
             "border-color": {
-              "css": {
-                "syntax": "<color>",
-                "inherits": true
+              "$extensions": {
+                "nl.nldesignsystem.css.property": {
+                  "syntax": "<color>",
+                  "inherits": true
+                }
               }
             }
           }
@@ -241,49 +313,63 @@
       },
       "navigation": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "padding-block-start": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "padding-block-end": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "label": {
           "min-inline-size": {
-            "css": {
-              "syntax": "<length>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<length>",
+                "inherits": true
+              }
             }
           },
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         }
       },
       "icon": {
         "size": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       }

--- a/components/code-block/tokens.json
+++ b/components/code-block/tokens.json
@@ -2,81 +2,107 @@
   "utrecht": {
     "code-block": {
       "background-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "font-family": {
-        "css": {
-          "syntax": "*",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "*",
+            "inherits": true
+          }
         }
       },
       "font-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "line-height": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-inline-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-inline-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-inline-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-inline-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       }
     }

--- a/components/code/tokens.json
+++ b/components/code/tokens.json
@@ -2,33 +2,43 @@
   "utrecht": {
     "code": {
       "background-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "font-family": {
-        "css": {
-          "syntax": "*",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "*",
+            "inherits": true
+          }
         }
       },
       "font-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "line-height": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       }
     }

--- a/components/common/action/tokens.json
+++ b/components/common/action/tokens.json
@@ -3,33 +3,41 @@
     "action": {
       "busy": {
         "cursor": {
-          "css": {
-            "syntax": "*",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "*",
+              "inherits": true
+            }
           }
         }
       },
       "disabled": {
         "cursor": {
-          "css": {
-            "syntax": "*",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "*",
+              "inherits": true
+            }
           }
         }
       },
       "navigate": {
         "cursor": {
-          "css": {
-            "syntax": "*",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "*",
+              "inherits": true
+            }
           }
         }
       },
       "submit": {
         "cursor": {
-          "css": {
-            "syntax": "*",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "*",
+              "inherits": true
+            }
           }
         }
       }

--- a/components/common/feedback/tokens.json
+++ b/components/common/feedback/tokens.json
@@ -3,306 +3,396 @@
     "feedback": {
       "danger": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "fill": {
           "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         }
       },
       "warning": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "fill": {
           "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         }
       },
       "safe": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "fill": {
           "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         }
       },
       "invalid": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "fill": {
           "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         }
       },
       "valid": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "fill": {
           "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         }
       },
       "error": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "fill": {
           "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         }
       },
       "success": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "fill": {
           "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         }
       },
       "inactive": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "fill": {
           "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         }
       },
       "active": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "fill": {
           "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         }

--- a/components/common/focus/tokens.json
+++ b/components/common/focus/tokens.json
@@ -2,39 +2,51 @@
   "utrecht": {
     "focus": {
       "background-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "outline-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "outline-offset": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "outline-style": {
-        "css": {
-          "syntax": "dotted | none | solid",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "dotted | none | solid",
+            "inherits": true
+          }
         }
       },
       "outline-width": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       }
     }

--- a/components/common/motion/tokens.json
+++ b/components/common/motion/tokens.json
@@ -2,9 +2,11 @@
   "utrecht": {
     "motion": {
       "max-animation-duration": {
-        "css": {
-          "syntax": "<time>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<time>",
+            "inherits": true
+          }
         }
       }
     }

--- a/components/common/space/tokens.json
+++ b/components/common/space/tokens.json
@@ -4,381 +4,487 @@
       "block": {
         "3xs": {
           "comment": "Extra Small 3",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "2xs": {
           "comment": "Extra Small 2",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "xs": {
           "comment": "Extra Small",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "sm": {
           "comment": "Small",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "md": {
           "comment": "Medium",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "lg": {
           "comment": "Large",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "xl": {
           "comment": "Extra Large",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "2xl": {
           "comment": "Extra Large 2",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "3xl": {
           "comment": "Extra Large 3",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "4xl": {
           "comment": "Extra Large 4",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       },
       "inline": {
         "3xs": {
           "comment": "Extra Small 3",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "2xs": {
           "comment": "Extra Small 2",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "xs": {
           "comment": "Extra Small",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "sm": {
           "comment": "Small",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "md": {
           "comment": "Medium",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "lg": {
           "comment": "Large",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "xl": {
           "comment": "Extra Large",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "2xl": {
           "comment": "Extra Large 2",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "3xl": {
           "comment": "Extra Large 3",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "4xl": {
           "comment": "Extra Large 4",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       },
       "text": {
         "3xs": {
           "comment": "Extra Small 3",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "2xs": {
           "comment": "Extra Small 2",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "xs": {
           "comment": "Extra Small",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "sm": {
           "comment": "Small",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "md": {
           "comment": "Medium",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "lg": {
           "comment": "Large",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "xl": {
           "comment": "Extra Large",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "2xl": {
           "comment": "Extra Large 2",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "3xl": {
           "comment": "Extra Large 3",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       },
       "row": {
         "4xs": {
           "comment": "Extra Small 4",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "3xs": {
           "comment": "Extra Small 3",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "2xs": {
           "comment": "Extra Small 2",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "xs": {
           "comment": "Extra Small",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "sm": {
           "comment": "Small",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "md": {
           "comment": "Medium",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "lg": {
           "comment": "Large",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "xl": {
           "comment": "Extra Large",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "2xl": {
           "comment": "Extra Large 2",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "3xl": {
           "comment": "Extra Large 3",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "4xl": {
           "comment": "Extra Large 4",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "5xl": {
           "comment": "Extra Large 5",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       },
       "column": {
         "4xs": {
           "comment": "Extra Small 4",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "3xs": {
           "comment": "Extra Small 3",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "2xs": {
           "comment": "Extra Small 2",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "xs": {
           "comment": "Extra Small",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "sm": {
           "comment": "Small",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "md": {
           "comment": "Medium",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "lg": {
           "comment": "Large",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "xl": {
           "comment": "Extra Large",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "2xl": {
           "comment": "Extra Large 2",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "3xl": {
           "comment": "Extra Large 3",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "4xl": {
           "comment": "Extra Large 4",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "5xl": {
           "comment": "Extra Large 5",
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       }

--- a/components/custom-checkbox/tokens.json
+++ b/components/custom-checkbox/tokens.json
@@ -2,210 +2,274 @@
   "utrecht": {
     "custom-checkbox": {
       "background-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "border-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "border-radius": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "border-width": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "icon": {
         "size": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       },
       "active": {
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-width": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "hover": {
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-width": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "focus": {
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-width": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "disabled": {
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-width": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "checked": {
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-width": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "indeterminate": {
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "invalid": {
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-width": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       }

--- a/components/data-list/tokens.json
+++ b/components/data-list/tokens.json
@@ -2,71 +2,91 @@
   "utrecht": {
     "data-list": {
       "margin-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "item-key": {
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "font-size": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "font-weight": {
-          "css": {
-            "syntax": "<number>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<number>",
+              "inherits": true
+            }
           }
         },
         "line-height": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       },
       "item-value": {
         "font-size": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "line-height": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       },
       "rows": {
         "item": {
           "margin-block-start": {
-            "css": {
-              "syntax": "<length>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<length>",
+                "inherits": true
+              }
             }
           }
         },
         "item-value": {
           "margin-block-start": {
-            "css": {
-              "syntax": "<length>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<length>",
+                "inherits": true
+              }
             }
           }
         }

--- a/components/digid-button/tokens.json
+++ b/components/digid-button/tokens.json
@@ -2,9 +2,11 @@
   "utrecht": {
     "digid-button": {
       "block-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       }
     }

--- a/components/document/tokens.json
+++ b/components/document/tokens.json
@@ -2,39 +2,51 @@
   "utrecht": {
     "document": {
       "background-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "font-family": {
-        "css": {
-          "syntax": "*",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "*",
+            "inherits": true
+          }
         }
       },
       "font-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "font-weight": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "line-height": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       }
     }

--- a/components/emphasis/tokens.json
+++ b/components/emphasis/tokens.json
@@ -3,17 +3,21 @@
     "emphasis": {
       "stressed": {
         "font-style": {
-          "css": {
-            "syntax": "inherit | italic | normal",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "inherit | italic | normal",
+              "inherits": true
+            }
           }
         }
       },
       "strong": {
         "font-weight": {
-          "css": {
-            "syntax": "<number>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<number>",
+              "inherits": true
+            }
           }
         }
       }

--- a/components/figure/tokens.json
+++ b/components/figure/tokens.json
@@ -2,34 +2,44 @@
   "utrecht": {
     "figure": {
       "margin-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "caption": {
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "font-size": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "line-height": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       }

--- a/components/form-field-description/tokens.json
+++ b/components/form-field-description/tokens.json
@@ -2,60 +2,78 @@
   "utrecht": {
     "form-field-description": {
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "font-family": {
-        "css": {
-          "syntax": "*",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "*",
+            "inherits": true
+          }
         }
       },
       "font-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "font-style": {
-        "css": {
-          "syntax": "italic",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "italic",
+            "inherits": true
+          }
         }
       },
       "margin-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "invalid": {
         "font-weight": {
-          "css": {
-            "syntax": "<number>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<number>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "valid": {
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       }

--- a/components/form-field/tokens.json
+++ b/components/form-field/tokens.json
@@ -2,50 +2,64 @@
   "utrecht": {
     "form-field": {
       "margin-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "max-inline-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "invalid": {
         "border-inline-start-color": {
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         },
         "border-inline-start-width": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "padding-inline-start": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       },
       "label": {
         "margin-block-end": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       }

--- a/components/form-fieldset/tokens.json
+++ b/components/form-fieldset/tokens.json
@@ -2,107 +2,139 @@
   "utrecht": {
     "form-fieldset": {
       "margin-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "invalid": {
         "border-inline-start-color": {
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         },
         "border-inline-start-width": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "padding-inline-start": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       },
       "section": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "legend": {
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "font-family": {
-          "css": {
-            "syntax": "*",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "*",
+              "inherits": true
+            }
           }
         },
         "font-size": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "font-weight": {
-          "css": {
-            "syntax": "<number>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<number>",
+              "inherits": true
+            }
           }
         },
         "line-height": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "margin-block-end": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "margin-block-start": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "text-transform": {
-          "css": {
-            "syntax": "inherit | none | uppercase",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "inherit | none | uppercase",
+              "inherits": true
+            }
           }
         },
         "disabled": {
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         }

--- a/components/form-input/tokens.json
+++ b/components/form-input/tokens.json
@@ -2,88 +2,116 @@
   "utrecht": {
     "form-input": {
       "background-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "border-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "border-radius": {
-        "css": {
-          "syntax": "<length-percentage>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length-percentage>",
+            "inherits": true
+          }
         }
       },
       "border-width": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "font-family": {
-        "css": {
-          "syntax": "*",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "*",
+            "inherits": true
+          }
         }
       },
       "font-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "font-style": {
-        "css": {
-          "syntax": "inherit | italic | normal",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "inherit | italic | normal",
+            "inherits": true
+          }
         }
       },
       "max-inline-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-inline-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-inline-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "placeholder": {
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "font-style": {
@@ -92,76 +120,98 @@
             "inherits": true
           }
         }
-      },
-      "disabled": {
-        "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
-          }
-        },
-        "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
-          }
-        },
-        "color": {
-          "css": {
+      }
+    },
+    "disabled": {
+      "background-color": {
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
             "syntax": "<color>",
             "inherits": true
           }
         }
       },
-      "focus": {
-        "background-color": {
-          "css": {
+      "border-color": {
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
             "syntax": "<color>",
             "inherits": true
           }
-        },
-        "border-color": {
-          "css": {
+        }
+      },
+      "color": {
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
             "syntax": "<color>",
             "inherits": true
           }
-        },
-        "border-width": {
-          "css": {
+        }
+      }
+    },
+    "focus": {
+      "background-color": {
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
+        }
+      },
+      "border-color": {
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
+        }
+      },
+      "border-width": {
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
             "inherits": true
           }
         }
-      },
-      "invalid": {
-        "background-color": {
-          "css": {
+      }
+    },
+    "invalid": {
+      "background-color": {
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
             "syntax": "<color>",
-            "inherits": true
-          }
-        },
-        "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
-          }
-        },
-        "border-width": {
-          "css": {
-            "syntax": "<length>",
             "inherits": true
           }
         }
       },
-      "read-only": {
-        "border-color": {
-          "css": {
+      "border-color": {
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
             "syntax": "<color>",
             "inherits": true
           }
-        },
-        "color": {
-          "css": {
+        }
+      },
+      "border-width": {
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
+        }
+      }
+    },
+    "read-only": {
+      "border-color": {
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
+        }
+      },
+      "color": {
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
             "syntax": "<color>",
             "inherits": true
           }

--- a/components/form-label/tokens.json
+++ b/components/form-label/tokens.json
@@ -2,64 +2,82 @@
   "utrecht": {
     "form-label": {
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "font-weight": {
-        "css": {
-          "syntax": "<number>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<number>",
+            "inherits": true
+          }
         }
       },
       "font-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "checkbox": {
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "font-weight": {
-          "css": {
-            "syntax": "<number>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<number>",
+              "inherits": true
+            }
           }
         }
       },
       "checked": {
         "font-weight": {
-          "css": {
-            "syntax": "<number>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<number>",
+              "inherits": true
+            }
           }
         }
       },
       "disabled": {
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "radio": {
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "font-weight": {
-          "css": {
-            "syntax": "<number>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<number>",
+              "inherits": true
+            }
           }
         }
       }

--- a/components/form-toggle/tokens.json
+++ b/components/form-toggle/tokens.json
@@ -2,122 +2,158 @@
   "utrecht": {
     "form-toggle": {
       "accent-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "background-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "border-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "border-radius": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "border-width": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "track": {
         "border-radius": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "disabled": {
           "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         }
       },
       "thumb": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "margin-inline-start": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "margin-inline-end": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "min-inline-size": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "disabled": {
           "box-shadow": {
-            "css": {
-              "syntax": "*",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "*",
+                "inherits": true
+              }
             }
           },
           "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         }
       },
       "checked": {
         "accent-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "focus": {
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-style": {
-          "css": {
-            "syntax": "*",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "*",
+              "inherits": true
+            }
           }
         },
         "border-width": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       }

--- a/components/form/tokens.json
+++ b/components/form/tokens.json
@@ -2,9 +2,11 @@
   "utrecht": {
     "form": {
       "max-inline-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       }
     }

--- a/components/heading-1/tokens.json
+++ b/components/heading-1/tokens.json
@@ -2,45 +2,59 @@
   "utrecht": {
     "heading-1": {
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "font-family": {
-        "css": {
-          "syntax": "*",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "*",
+            "inherits": true
+          }
         }
       },
       "font-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "font-weight": {
-        "css": {
-          "syntax": "<number>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<number>",
+            "inherits": true
+          }
         }
       },
       "line-height": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       }
     }

--- a/components/heading-2/tokens.json
+++ b/components/heading-2/tokens.json
@@ -2,45 +2,59 @@
   "utrecht": {
     "heading-2": {
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "font-family": {
-        "css": {
-          "syntax": "*",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "*",
+            "inherits": true
+          }
         }
       },
       "font-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "font-weight": {
-        "css": {
-          "syntax": "<number>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<number>",
+            "inherits": true
+          }
         }
       },
       "line-height": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       }
     }

--- a/components/heading-3/tokens.json
+++ b/components/heading-3/tokens.json
@@ -2,45 +2,59 @@
   "utrecht": {
     "heading-3": {
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "font-family": {
-        "css": {
-          "syntax": "*",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "*",
+            "inherits": true
+          }
         }
       },
       "font-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "font-weight": {
-        "css": {
-          "syntax": "<number>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<number>",
+            "inherits": true
+          }
         }
       },
       "line-height": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       }
     }

--- a/components/heading-4/tokens.json
+++ b/components/heading-4/tokens.json
@@ -2,45 +2,59 @@
   "utrecht": {
     "heading-4": {
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "font-family": {
-        "css": {
-          "syntax": "*",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "*",
+            "inherits": true
+          }
         }
       },
       "font-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "font-weight": {
-        "css": {
-          "syntax": "<number>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<number>",
+            "inherits": true
+          }
         }
       },
       "line-height": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       }
     }

--- a/components/heading-5/tokens.json
+++ b/components/heading-5/tokens.json
@@ -2,45 +2,59 @@
   "utrecht": {
     "heading-5": {
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "font-family": {
-        "css": {
-          "syntax": "*",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "*",
+            "inherits": true
+          }
         }
       },
       "font-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "font-weight": {
-        "css": {
-          "syntax": "<number>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<number>",
+            "inherits": true
+          }
         }
       },
       "line-height": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       }
     }

--- a/components/heading-6/tokens.json
+++ b/components/heading-6/tokens.json
@@ -2,45 +2,59 @@
   "utrecht": {
     "heading-6": {
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "font-family": {
-        "css": {
-          "syntax": "*",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "*",
+            "inherits": true
+          }
         }
       },
       "font-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "font-weight": {
-        "css": {
-          "syntax": "<number>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<number>",
+            "inherits": true
+          }
         }
       },
       "line-height": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       }
     }

--- a/components/heading-group/tokens.json
+++ b/components/heading-group/tokens.json
@@ -2,15 +2,19 @@
   "utrecht": {
     "heading-group": {
       "margin-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       }
     }

--- a/components/heading/tokens.json
+++ b/components/heading/tokens.json
@@ -2,21 +2,27 @@
   "utrecht": {
     "heading": {
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "font-family": {
-        "css": {
-          "syntax": "*",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "*",
+            "inherits": true
+          }
         }
       },
       "font-weight": {
-        "css": {
-          "syntax": "<number>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<number>",
+            "inherits": true
+          }
         }
       }
     }

--- a/components/icon/tokens.json
+++ b/components/icon/tokens.json
@@ -2,28 +2,36 @@
   "utrecht": {
     "icon": {
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "size": {
-        "css": {
-          "syntax": "<length-percentage>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length-percentage>",
+            "inherits": true
+          }
         }
       },
       "inset-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "baseline": {
         "inset-block-start": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       }

--- a/components/link-list/tokens.json
+++ b/components/link-list/tokens.json
@@ -2,22 +2,28 @@
   "utrecht": {
     "link-list": {
       "margin-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "item": {
         "margin-block-start": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       }

--- a/components/link-social/tokens.json
+++ b/components/link-social/tokens.json
@@ -2,58 +2,76 @@
   "utrecht": {
     "link-social": {
       "background-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "border-width": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "border-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-inline-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "hover": {
         "scale": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       }

--- a/components/link/tokens.json
+++ b/components/link/tokens.json
@@ -2,104 +2,134 @@
   "utrecht": {
     "link": {
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "text-decoration": {
-        "css": {
-          "syntax": "none | underline",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "none | underline",
+            "inherits": true
+          }
         }
       },
       "text-decoration-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "text-decoration-thickness": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "text-underline-offset": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "active": {
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "focus": {
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "text-decoration": {
-          "css": {
-            "syntax": "none | underline",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "none | underline",
+              "inherits": true
+            }
           }
         },
         "text-decoration-thickness": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       },
       "hover": {
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "text-decoration": {
-          "css": {
-            "syntax": "none | underline",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "none | underline",
+              "inherits": true
+            }
           }
         },
         "text-decoration-thickness": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       },
       "placeholder": {
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "visited": {
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "icon": {
         "size": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       }

--- a/components/list-social/tokens.json
+++ b/components/list-social/tokens.json
@@ -2,34 +2,44 @@
   "utrecht": {
     "list-social": {
       "margin-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-inline-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-inline-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "item": {
         "margin-inline-end": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       }

--- a/components/logo-button/tokens.json
+++ b/components/logo-button/tokens.json
@@ -2,9 +2,11 @@
   "utrecht": {
     "logo-button": {
       "block-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       }
     }

--- a/components/logo/tokens.json
+++ b/components/logo/tokens.json
@@ -2,50 +2,64 @@
   "utrecht": {
     "logo": {
       "max-block-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "max-inline-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "min-block-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "min-inline-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "decoration-1": {
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "decoration-2": {
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "decoration-3": {
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       }

--- a/components/map-marker/tokens.json
+++ b/components/map-marker/tokens.json
@@ -2,46 +2,60 @@
   "utrecht": {
     "map-marker": {
       "background-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "border-width": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "border-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "box-shadow-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "icon": {
         "size": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       }

--- a/components/mapcontrolbutton/tokens.json
+++ b/components/mapcontrolbutton/tokens.json
@@ -2,114 +2,150 @@
   "utrecht": {
     "mapcontrolbutton": {
       "border-width": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "focus-transform-scale": {
-        "css": {
-          "syntax": "<number>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<number>",
+            "inherits": true
+          }
         }
       },
       "font-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "min-block-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "min-inline-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-inline-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-inline-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-inline-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-inline-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "disabled": {
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "hover-background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "primary-action": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "hover-background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       }

--- a/components/mark/tokens.json
+++ b/components/mark/tokens.json
@@ -2,15 +2,19 @@
   "utrecht": {
     "mark": {
       "background-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       }
     }

--- a/components/ordered-list/tokens.json
+++ b/components/ordered-list/tokens.json
@@ -2,52 +2,68 @@
   "utrecht": {
     "ordered-list": {
       "font-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "line-height": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-inline-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "item": {
         "margin-block-start": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "margin-block-end": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "padding-inline-start": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       }

--- a/components/page-content/tokens.json
+++ b/components/page-content/tokens.json
@@ -2,15 +2,19 @@
   "utrecht": {
     "page-content": {
       "padding-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       }
     }

--- a/components/page-footer/tokens.json
+++ b/components/page-footer/tokens.json
@@ -2,45 +2,59 @@
   "utrecht": {
     "page-footer": {
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "background-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "background-image": {
-        "css": {
-          "syntax": "<url> | *",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<url> | *",
+            "inherits": true
+          }
         }
       },
       "padding-inline-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-inline-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       }
     }

--- a/components/page-header/tokens.json
+++ b/components/page-header/tokens.json
@@ -2,27 +2,35 @@
   "utrecht": {
     "page-header": {
       "background-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "padding-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       }
     }

--- a/components/page/tokens.json
+++ b/components/page/tokens.json
@@ -2,33 +2,43 @@
   "utrecht": {
     "page": {
       "background-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "margin-inline-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-inline-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "max-inline-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       }
     }

--- a/components/pagination/tokens.json
+++ b/components/pagination/tokens.json
@@ -2,237 +2,311 @@
   "utrecht": {
     "pagination": {
       "font-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "font-family": {
-        "css": {
-          "syntax": "*",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "*",
+            "inherits": true
+          }
         }
       },
       "margin-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "page-link": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-radius": {
-          "css": {
-            "syntax": "<length-percentage>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length-percentage>",
+              "inherits": true
+            }
           }
         },
         "border-width": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
-          }
-        },
-        "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
-          }
-        },
-        "font-weight": {
-          "css": {
-            "syntax": "<number>",
-            "inherits": true
-          }
-        },
-        "padding-inline-end": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
-          }
-        },
-        "padding-inline-start": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
-          }
-        },
-        "padding-block-end": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
-          }
-        },
-        "padding-block-start": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
-          }
-        },
-        "text-decoration": {
-          "css": {
-            "syntax": "none | underline",
-            "inherits": true
-          }
-        },
-        "current": {
-          "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
-            }
-          },
-          "border-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
-            }
-          },
-          "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
-            }
-          }
-        },
-        "distanced": {
-          "margin-inline-start": {
-            "css": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
               "syntax": "<length>",
               "inherits": true
             }
           }
         },
-        "hover": {
-          "background-color": {
-            "css": {
+        "color": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
               "syntax": "<color>",
               "inherits": true
+            }
+          }
+        },
+        "font-weight": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<number>",
+              "inherits": true
+            }
+          }
+        },
+        "padding-inline-end": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
+          }
+        },
+        "padding-inline-start": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
+          }
+        },
+        "padding-block-end": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
+          }
+        },
+        "padding-block-start": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
+          }
+        },
+        "text-decoration": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "none | underline",
+              "inherits": true
+            }
+          }
+        },
+        "current": {
+          "background-color": {
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "border-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
+            }
+          }
+        },
+        "distanced": {
+          "margin-inline-start": {
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<length>",
+                "inherits": true
+              }
+            }
+          }
+        },
+        "hover": {
+          "background-color": {
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
+            }
+          },
+          "border-color": {
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
+            }
+          },
+          "color": {
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         }
       },
       "relative-link": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-radius": {
-          "css": {
-            "syntax": "<length-percentage>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length-percentage>",
+              "inherits": true
+            }
           }
         },
         "border-width": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "font-weight": {
-          "css": {
-            "syntax": "<number>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<number>",
+              "inherits": true
+            }
           }
         },
         "padding-inline-end": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "padding-inline-start": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "padding-block-end": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "padding-block-start": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "text-decoration": {
-          "css": {
-            "syntax": "none | underline",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "none | underline",
+              "inherits": true
+            }
           }
         },
         "text-transform": {
-          "css": {
-            "syntax": "inherit | uppercase",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "inherit | uppercase",
+              "inherits": true
+            }
           }
         },
         "distanced": {
           "margin-inline-end": {
-            "css": {
-              "syntax": "<length>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<length>",
+                "inherits": true
+              }
             }
           },
           "margin-inline-start": {
-            "css": {
-              "syntax": "<length>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<length>",
+                "inherits": true
+              }
             }
           }
         },
         "hover": {
           "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "border-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         }

--- a/components/paragraph/tokens.json
+++ b/components/paragraph/tokens.json
@@ -2,70 +2,92 @@
   "utrecht": {
     "paragraph": {
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "font-family": {
-        "css": {
-          "syntax": "*",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "*",
+            "inherits": true
+          }
         }
       },
       "font-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "font-weight": {
-        "css": {
-          "syntax": "<number>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<number>",
+            "inherits": true
+          }
         }
       },
       "line-height": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "lead": {
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "font-size": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "font-weight": {
-          "css": {
-            "syntax": "<number>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<number>",
+              "inherits": true
+            }
           }
         },
         "line-height": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       }

--- a/components/pre-heading/tokens.json
+++ b/components/pre-heading/tokens.json
@@ -2,45 +2,59 @@
   "utrecht": {
     "pre-heading": {
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "font-family": {
-        "css": {
-          "syntax": "*",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "*",
+            "inherits": true
+          }
         }
       },
       "font-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "font-weight": {
-        "css": {
-          "syntax": "<number>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<number>",
+            "inherits": true
+          }
         }
       },
       "line-height": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       }
     }

--- a/components/process-steps/tokens.json
+++ b/components/process-steps/tokens.json
@@ -2,313 +2,403 @@
   "denhaag": {
     "process-steps": {
       "font-family": {
-        "css": {
-          "syntax": "*",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "*",
+            "inherits": true
+          }
         }
       },
       "font-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "line-height": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "step-heading": {
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "font-family": {
-          "css": {
-            "syntax": "*",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "*",
+              "inherits": true
+            }
           }
         },
         "font-size": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "font-weight": {
-          "css": {
-            "syntax": "<number>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<number>",
+              "inherits": true
+            }
           }
         },
         "current": {
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         },
         "checked": {
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         },
         "not-checked": {
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         },
         "warning": {
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         }
       },
       "step-marker": {
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-width": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "font-size": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "font-weight": {
-          "css": {
-            "syntax": "<number>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<number>",
+              "inherits": true
+            }
           }
         },
         "current": {
           "border-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "border-width": {
-            "css": {
-              "syntax": "<length>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<length>",
+                "inherits": true
+              }
             }
           },
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         },
         "checked": {
           "border-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "border-width": {
-            "css": {
-              "syntax": "<length>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<length>",
+                "inherits": true
+              }
             }
           },
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         },
         "warning": {
           "border-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         }
       },
       "sub-step-marker": {
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "current": {
           "border-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         },
         "checked": {
           "border-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         },
         "not-checked": {
           "border-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         },
         "warning": {
           "border-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         }
       },
       "step-line": {
         "stroke-width": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
-          }
-        },
-        "checked": {
-          "color": {
-            "css": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
               "syntax": "<color>",
               "inherits": true
             }
           }
         },
+        "checked": {
+          "color": {
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
+            }
+          }
+        },
         "warning": {
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         }
       },
       "step-metadata": {
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "font-size": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       },
       "step-description": {
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "font-size": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       },
       "sub-step": {},
       "sub-step-heading": {
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "font-family": {
-          "css": {
-            "syntax": "*",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "*",
+              "inherits": true
+            }
           }
         },
         "font-size": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "font-weight": {
-          "css": {
-            "syntax": "<number>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<number>",
+              "inherits": true
+            }
           }
         }
       }

--- a/components/radio-button/tokens.json
+++ b/components/radio-button/tokens.json
@@ -2,188 +2,246 @@
   "utrecht": {
     "radio-button": {
       "background-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "border-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "border-width": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "active": {
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-width": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "checked": {
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-width": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "hover": {
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-width": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "focus": {
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-width": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "disabled": {
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-width": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "invalid": {
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-width": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       }

--- a/components/search-bar/tokens.json
+++ b/components/search-bar/tokens.json
@@ -3,50 +3,64 @@
     "search-bar": {
       "button": {
         "border-color": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
-          }
-        },
-        "hover": {
-          "transform-scale": {
-            "css": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
               "syntax": "<length>",
               "inherits": true
             }
           }
         },
+        "hover": {
+          "transform-scale": {
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<length>",
+                "inherits": true
+              }
+            }
+          }
+        },
         "font-weight": {
-          "css": {
-            "syntax": "<number>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<number>",
+              "inherits": true
+            }
           }
         },
         "letter-spacing": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "text-transform": {},
         "primary-action": {
           "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "hover": {
             "background-color": {
-              "css": {
-                "syntax": "<color>",
-                "inherits": true
+              "$extensions": {
+                "nl.nldesignsystem.css.property": {
+                  "syntax": "<color>",
+                  "inherits": true
+                }
               }
             }
           }
@@ -54,47 +68,61 @@
       },
       "textbox": {
         "padding-inline-start": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "border-bottom-width": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       },
       "input": {
         "background-image": {
-          "css": {
-            "syntax": "<image>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<image>",
+              "inherits": true
+            }
           }
         },
         "background-position-x": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "background-position-y": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "background-repeat": {
-          "css": {
-            "syntax": "*",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "*",
+              "inherits": true
+            }
           }
         },
         "background-size": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       }

--- a/components/select/tokens.json
+++ b/components/select/tokens.json
@@ -2,140 +2,184 @@
   "utrecht": {
     "select": {
       "background-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "border-bottom-width": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "border-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "border-radius": {
-        "css": {
-          "syntax": "<length-percentage>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length-percentage>",
+            "inherits": true
+          }
         }
       },
       "border-width": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "font-family": {
-        "css": {
-          "syntax": "*",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "*",
+            "inherits": true
+          }
         }
       },
       "font-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "max-inline-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-inline-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-inline-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "disabled": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "focus": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "invalid": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-width": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       }

--- a/components/separator/tokens.json
+++ b/components/separator/tokens.json
@@ -2,27 +2,35 @@
   "utrecht": {
     "separator": {
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "block-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       }
     }

--- a/components/skip-link/tokens.json
+++ b/components/skip-link/tokens.json
@@ -2,70 +2,92 @@
   "utrecht": {
     "skip-link": {
       "background-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "min-block-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "min-inline-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-inline-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-inline-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "text-decoration": {
-        "css": {
-          "syntax": "none | underline",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "none | underline",
+            "inherits": true
+          }
         }
       },
       "z-index": {
-        "css": {
-          "syntax": "<number>",
-          "inherits": false
-        }
-      },
-      "focus": {
-        "text-decoration": {
-          "css": {
-            "syntax": "none | underline",
-            "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<number>",
+            "inherits": false
+          }
+        },
+        "focus": {
+          "text-decoration": {
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "none | underline",
+                "inherits": true
+              }
+            }
           }
         }
       }

--- a/components/spotlight-section/tokens.json
+++ b/components/spotlight-section/tokens.json
@@ -2,90 +2,118 @@
   "utrecht": {
     "spotlight-section": {
       "background-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "border-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "border-width": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "padding-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-inline-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-inline-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "info": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "warning": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       }

--- a/components/surface/css/stories/readme.stories.mdx
+++ b/components/surface/css/stories/readme.stories.mdx
@@ -17,7 +17,7 @@ To make the browser user interface match your websites surface background color,
 For projects that use JSX and React, the following code sample shows how to refer to the design token package to automatically use the most recent choice of color.
 
 ```jsx
-import { utrechtSurfaceBackgroundColor } from "@utrecht/design-tokens/dist/index";
+import { utrechtSurfaceBackgroundColor } from "@utrecht/design-tokens/dist/index.js";
 
 export const ThemeColor = () => <meta name="theme-color" content={utrechtSurfaceBackgroundColor} />;
 ```

--- a/components/surface/tokens.json
+++ b/components/surface/tokens.json
@@ -2,15 +2,19 @@
   "utrecht": {
     "surface": {
       "background-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       }
     }

--- a/components/table/tokens.json
+++ b/components/table/tokens.json
@@ -2,237 +2,311 @@
   "utrecht": {
     "table": {
       "border-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "border-width": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "font-family": {
-        "css": {
-          "syntax": "*",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "*",
+            "inherits": true
+          }
         }
       },
       "font-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "line-height": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "caption": {
         "font-weight": {
-          "css": {
-            "syntax": "<number>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<number>",
+              "inherits": true
+            }
           }
         },
         "font-family": {
-          "css": {
-            "syntax": "*",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "*",
+              "inherits": true
+            }
           }
         },
         "font-size": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "line-height": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "text-align": {
-          "css": {
-            "syntax": "left | right | start | end",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "left | right | start | end",
+              "inherits": true
+            }
           }
         },
         "margin-block-end": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       },
       "header": {
         "font-weight": {
-          "css": {
-            "syntax": "<number>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<number>",
+              "inherits": true
+            }
           }
         },
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "text-transform": {
-          "css": {
-            "syntax": "inherit | uppercase",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "inherit | uppercase",
+              "inherits": true
+            }
           }
         },
         "border-block-end-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-block-end-width": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       },
       "header-cell": {
         "font-size": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "font-weight": {
-          "css": {
-            "syntax": "<number>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<number>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "text-transform": {
-          "css": {
-            "syntax": "inherit | uppercase",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "inherit | uppercase",
+              "inherits": true
+            }
           }
         }
       },
       "cell": {
         "line-height": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "padding-block-end": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "padding-block-start": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "padding-inline-end": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "padding-inline-start": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       },
       "row": {
         "border-block-end-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-block-end-width": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "padding-inline-end": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "padding-inline-start": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "alternate-odd": {
           "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         },
         "alternate-even": {
           "background-color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           },
           "color": {
-            "css": {
-              "syntax": "<color>",
-              "inherits": true
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              }
             }
           }
         }

--- a/components/textarea/tokens.json
+++ b/components/textarea/tokens.json
@@ -2,174 +2,228 @@
   "utrecht": {
     "textarea": {
       "background-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "border-bottom-width": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "border-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "border-radius": {
-        "css": {
-          "syntax": "<length-percentage>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length-percentage>",
+            "inherits": true
+          }
         }
       },
       "border-width": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "font-family": {
-        "css": {
-          "syntax": "*",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "*",
+            "inherits": true
+          }
         }
       },
       "font-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "line-height": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "max-inline-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "min-block-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-inline-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-inline-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "placeholder": {
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "disabled": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "focus": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-width": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       },
       "invalid": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-width": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       },
       "read-only": {
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       }

--- a/components/textbox/tokens.json
+++ b/components/textbox/tokens.json
@@ -2,162 +2,212 @@
   "utrecht": {
     "textbox": {
       "background-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "border-bottom-width": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "border-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "border-radius": {
-        "css": {
-          "syntax": "<length-percentage>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length-percentage>",
+            "inherits": true
+          }
         }
       },
       "border-width": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "font-family": {
-        "css": {
-          "syntax": "*",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "*",
+            "inherits": true
+          }
         }
       },
       "font-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "max-inline-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-inline-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-inline-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "placeholder": {
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "disabled": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "focus": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-width": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       },
       "invalid": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "border-width": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       },
       "read-only": {
         "border-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       }

--- a/components/toptask-link/tokens.json
+++ b/components/toptask-link/tokens.json
@@ -2,104 +2,136 @@
   "utrecht": {
     "toptask-link": {
       "background-color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "color": {
-        "css": {
-          "syntax": "<color>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          }
         }
       },
       "font-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "line-height": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "min-block-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "min-inline-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-inline-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-inline-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "hover": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "transform-scale": {
-          "css": {
-            "syntax": "<number>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<number>",
+              "inherits": true
+            }
           }
         }
       },
       "focus": {
         "background-color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         },
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "icon": {
         "size": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       }

--- a/components/toptask-nav/tokens.json
+++ b/components/toptask-nav/tokens.json
@@ -2,9 +2,11 @@
   "utrecht": {
     "toptask-link-nav": {
       "gap": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "link": {

--- a/components/unordered-list/tokens.json
+++ b/components/unordered-list/tokens.json
@@ -2,60 +2,78 @@
   "utrecht": {
     "unordered-list": {
       "font-size": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "line-height": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "margin-block-end": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "padding-inline-start": {
-        "css": {
-          "syntax": "<length>",
-          "inherits": true
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
         }
       },
       "item": {
         "margin-block-start": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "margin-block-end": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         },
         "padding-inline-start": {
-          "css": {
-            "syntax": "<length>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       },
       "marker": {
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       }

--- a/components/value-number/tokens.json
+++ b/components/value-number/tokens.json
@@ -3,17 +3,21 @@
     "value-number": {
       "positive": {
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       },
       "negative": {
         "color": {
-          "css": {
-            "syntax": "<color>",
-            "inherits": true
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            }
           }
         }
       }

--- a/documentation/components/DesignTokensTable.jsx
+++ b/documentation/components/DesignTokensTable.jsx
@@ -4,7 +4,11 @@ export const path2css = (path) => `var(--${path.join('-')})`;
 import { ColorExample } from './ColorExample';
 
 const visualizeToken = (token) => {
-  if (token.css && token.css.syntax === '<color>') {
+  if (
+    token['$extensions'] &&
+    token['$extensions']['nl.nldesignsystem.css.property'] &&
+    token['$extensions']['nl.nldesignsystem.css.property'].syntax === '<color>'
+  ) {
     return <ColorExample color={token.value}></ColorExample>;
   } else {
     return '';

--- a/documentation/components/ExampleTokensCSS.jsx
+++ b/documentation/components/ExampleTokensCSS.jsx
@@ -27,7 +27,16 @@ const findDesignTokens = (tokens, callback) => traverseDeep(tokens, [], tokens, 
 const tokensToCSS = (tokens) => {
   const lines = [];
   findDesignTokens(tokens, (path, value) =>
-    lines.push(`  --${path.join('-')}: ${value && value.css && value.css.syntax ? value.css.syntax : '<value>'};`),
+    lines.push(
+      `  --${path.join('-')}: ${
+        value &&
+        value['$extensions'] &&
+        value['$extensions']['nl.nldesignsystem.css.property'] &&
+        value['$extensions']['nl.nldesignsystem.css.property'].syntax
+          ? '<value>'
+          : undefined
+      };`,
+    ),
   );
   return `.your-theme {\n  /* Comment out the custom properties you don't need */\n${lines.join('\n')}\n}`;
 };

--- a/documentation/components/ExampleTokensJSON.jsx
+++ b/documentation/components/ExampleTokensJSON.jsx
@@ -5,7 +5,9 @@ import React from 'react';
 import { CopyButton } from './CopyButton';
 
 export const ExampleTokensJSON = ({ definition }) => {
-  const x = cloneDeepWith(definition, (item) => (isPlainObject(item.css) ? {} : undefined));
+  const x = cloneDeepWith(definition, (item) =>
+    isPlainObject(item['$extensions']) || isPlainObject(item['$value']) ? {} : undefined,
+  );
 
   const code = JSON.stringify(x, null, '  ');
   return (

--- a/packages/storybook/config/manager.js
+++ b/packages/storybook/config/manager.js
@@ -1,6 +1,6 @@
 import { addons } from '@storybook/addons';
 import { create } from '@storybook/theming/create';
-import { utrechtTypographySansSerifFontFamily } from '@utrecht/design-tokens/dist/index';
+import { utrechtTypographySansSerifFontFamily } from '@utrecht/design-tokens/dist/index.js';
 import theme from '@utrecht/storybook-helpers/storybook-theme.json';
 
 addons.setConfig({

--- a/packages/storybook/stories/web-component/surface/readme.stories.mdx
+++ b/packages/storybook/stories/web-component/surface/readme.stories.mdx
@@ -17,7 +17,7 @@ To make the browser user interface match your websites surface background color,
 For projects that use JSX and React, the following code sample shows how to refer to the design token package to automatically use the most recent choice of color.
 
 ```jsx
-import { utrechtSurfaceBackgroundColor } from "@utrecht/design-tokens/dist/index";
+import { utrechtSurfaceBackgroundColor } from "@utrecht/design-tokens/dist/index.js";
 
 export const ThemeColor = () => <meta name="theme-color" content={utrechtSurfaceBackgroundColor} />;
 ```

--- a/proprietary/design-tokens/build-stylelint.mjs
+++ b/proprietary/design-tokens/build-stylelint.mjs
@@ -57,7 +57,7 @@ glob('../../components/**/tokens.json', function (err, paths) {
       tokens,
       [],
       tokens,
-      (value) => Object.prototype.hasOwnProperty.call(value, 'css'),
+      (value) => Object.prototype.hasOwnProperty.call(value, '$extensions'),
       (path, value) => cssVariables.push(path.join('-')),
     );
 


### PR DESCRIPTION
We want to use the new property because [`$extensions` it is part of the design tokens format specification](https://tr.designtokens.org/format/#extensions).