### PR TITLE
refactor: use CSF3 and Storybook 7 types for more react components

### DIFF
--- a/packages/storybook-react/src/stories/Alert.stories.tsx
+++ b/packages/storybook-react/src/stories/Alert.stories.tsx
@@ -1,3 +1,4 @@
+import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import type { Meta, StoryObj } from '@storybook/react';
 import { Alert, Heading1, Paragraph } from '@utrecht/component-library-react/dist/css-module/index';
 import readme from '@utrecht/components/alert/README.md?raw';
@@ -10,63 +11,66 @@ const meta = {
   title: 'React Component/Alert',
   id: 'react-alert',
   component: Alert,
-  tags: ['autodocs'],
+  args: {
+    children: [
+      <Heading1>Lorem ipsum</Heading1>,
+      <Paragraph>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+        magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+        pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
+        laborum.
+      </Paragraph>,
+    ],
+  },
   parameters: {
     tokensPrefix: 'utrecht-alert',
     tokens,
     tokensDefinition,
     docs: {
-      description: {
-        component: readme,
-      },
+      page: () => (
+        <>
+          <Description markdown={readme} />
+          <Primary />
+          <ArgsTable story={PRIMARY_STORY} />
+          <Stories />
+        </>
+      ),
     },
   },
-} as Meta<typeof Alert>;
+} satisfies Meta<typeof Alert>;
 
 export default meta;
 
-const Template: StoryObj<typeof meta> = (args) => <Alert {...args} />;
+type Story = StoryObj<typeof meta>;
+export const Default: Story = {};
 
-export const Default = Template.bind({});
-
-Default.args = {
-  children: [
-    <Heading1>Lorem ipsum</Heading1>,
-    <Paragraph>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
-      magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-      consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-      Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-    </Paragraph>,
-  ],
+export const Info: Story = {
+  args: {
+    ...Default.args,
+    type: 'info',
+  },
 };
 
-export const Info = Template.bind({});
-
-Info.args = {
-  ...Default.args,
-  type: 'info',
+export const OK: Story = {
+  args: {
+    ...Default.args,
+    type: 'ok',
+  },
 };
 
-export const OK = Template.bind({});
-
-OK.args = {
-  ...Default.args,
-  type: 'ok',
+export const Warning: Story = {
+  args: {
+    ...Default.args,
+    type: 'warning',
+  },
 };
 
-export const Warning = Template.bind({});
-
-Warning.args = {
-  ...Default.args,
-  type: 'warning',
-};
-
-export const Error = Template.bind({});
-
-Error.args = {
-  ...Default.args,
-  type: 'error',
+export const Error: Story = {
+  args: {
+    ...Default.args,
+    type: 'error',
+  },
 };
 
 export const DesignTokens = designTokenStory(meta);

--- a/packages/storybook-react/src/stories/Article.stories.tsx
+++ b/packages/storybook-react/src/stories/Article.stories.tsx
@@ -1,3 +1,4 @@
+import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
 import { Article, Heading1, Paragraph } from '@utrecht/component-library-react/dist/css-module/index';
 import readme from '@utrecht/components/article/README.md?raw';
@@ -10,35 +11,38 @@ const meta = {
   title: 'React Component/Article',
   id: 'react-article',
   component: Article,
-  tags: ['autodocs'],
+  args: {
+    children: [
+      <Heading1>Lorem ipsum</Heading1>,
+      <Paragraph>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+        magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+        pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
+        laborum.
+      </Paragraph>,
+    ],
+  },
   parameters: {
     tokensPrefix: 'utrecht-article',
     tokens,
     tokensDefinition,
     docs: {
-      description: {
-        component: readme,
-      },
+      page: () => (
+        <>
+          <Description markdown={readme} />
+          <Primary />
+          <ArgsTable story={PRIMARY_STORY} />
+          <Stories />
+        </>
+      ),
     },
   },
-} as Meta<typeof Article>;
+} satisfies Meta<typeof Article>;
 
 export default meta;
 
-const Template: StoryObj<typeof Article> = (args) => <Article {...args} />;
-
-export const Default = Template.bind({});
-
-Default.args = {
-  children: [
-    <Heading1>Lorem ipsum</Heading1>,
-    <Paragraph>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
-      magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-      consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-      Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-    </Paragraph>,
-  ],
-};
+type Story = StoryObj<typeof meta>;
+export const Default: Story = {};
 
 export const DesignTokens = designTokenStory(meta);

--- a/packages/storybook-react/src/stories/Backdrop.stories.tsx
+++ b/packages/storybook-react/src/stories/Backdrop.stories.tsx
@@ -1,3 +1,4 @@
+import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
 import { AlertDialog, Backdrop, Button, Paragraph } from '@utrecht/component-library-react/dist/css-module/index';
 import readme from '@utrecht/components/backdrop/README.md?raw';
@@ -10,36 +11,38 @@ const meta = {
   title: 'React Component/Backdrop',
   id: 'react-backdrop',
   component: Backdrop,
-  tags: ['autodocs'],
+  args: {
+    children: (
+      <AlertDialog open>
+        <Paragraph>Greetings, one and all!</Paragraph>
+        <form method="dialog">
+          <Button type="submit" appearance="primary-action-button">
+            OK
+          </Button>
+        </form>
+      </AlertDialog>
+    ),
+  },
   parameters: {
     tokensPrefix: 'utrecht-backdrop',
     tokens,
     tokensDefinition,
     docs: {
-      description: {
-        component: readme,
-      },
+      page: () => (
+        <>
+          <Description markdown={readme} />
+          <Primary />
+          <ArgsTable story={PRIMARY_STORY} />
+          <Stories />
+        </>
+      ),
     },
   },
-} as Meta<typeof Backdrop>;
+} satisfies Meta<typeof Backdrop>;
 
 export default meta;
 
-const Template: StoryObj<typeof Backdrop> = (args) => <Backdrop {...args} />;
-
-export const Default = Template.bind({});
-
-Default.args = {
-  children: (
-    <AlertDialog open>
-      <Paragraph>Greetings, one and all!</Paragraph>
-      <form method="dialog">
-        <Button type="submit" appearance="primary-action-button">
-          OK
-        </Button>
-      </form>
-    </AlertDialog>
-  ),
-};
+type Story = StoryObj<typeof meta>;
+export const Default: Story = {};
 
 export const DesignTokens = designTokenStory(meta);

--- a/packages/storybook-react/src/stories/ButtonGroup.stories.tsx
+++ b/packages/storybook-react/src/stories/ButtonGroup.stories.tsx
@@ -1,3 +1,4 @@
+import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
 import { Button, ButtonGroup } from '@utrecht/component-library-react/dist/css-module/index';
 import readme from '@utrecht/components/button-group/README.md?raw';
@@ -10,33 +11,35 @@ const meta = {
   title: 'React Component/Button group',
   id: 'react-button-group',
   component: ButtonGroup,
+  args: {
+    children: (
+      <>
+        <Button appearance="primary-action-button">Save and continue</Button>
+        <Button appearance="secondary-action-button">Back</Button>
+      </>
+    ),
+  },
   argTypes: {},
-  tags: ['autodocs'],
   parameters: {
     tokensPrefix: 'utrecht-button-group',
     tokens,
     tokensDefinition,
     docs: {
-      description: {
-        component: readme,
-      },
+      page: () => (
+        <>
+          <Description markdown={readme} />
+          <Primary />
+          <ArgsTable story={PRIMARY_STORY} />
+          <Stories />
+        </>
+      ),
     },
   },
-} as Meta<typeof Button>;
+} satisfies Meta<typeof Button>;
 
 export default meta;
 
-const Template: StoryObj<typeof Button> = (args) => <ButtonGroup {...args} />;
-
-export const Default = Template.bind({});
-
-Default.args = {
-  children: (
-    <>
-      <Button appearance="primary-action-button">Save and continue</Button>
-      <Button appearance="secondary-action-button">Back</Button>
-    </>
-  ),
-};
+type Story = StoryObj<typeof meta>;
+export const Default: Story = {};
 
 export const DesignTokens = designTokenStory(meta);

--- a/packages/storybook-react/src/stories/Code.stories.tsx
+++ b/packages/storybook-react/src/stories/Code.stories.tsx
@@ -1,3 +1,4 @@
+import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
 import { Code } from '@utrecht/component-library-react/dist/css-module/index';
 import readme from '@utrecht/components/code/README.md?raw';
@@ -10,27 +11,37 @@ const meta = {
   title: 'React Component/Code',
   id: 'react-code',
   component: Code,
-  tags: ['autodocs'],
+  args: {
+    children: '<input type="url" value="https://example.fi/">',
+  },
+  argTypes: {
+    children: {
+      name: 'Text content',
+      type: { name: 'string', required: true },
+      table: {
+        category: 'API',
+      },
+    },
+  },
   parameters: {
     tokensPrefix: 'utrecht-code',
     tokens,
     tokensDefinition,
     docs: {
-      description: {
-        component: readme,
-      },
+      page: () => (
+        <>
+          <Description markdown={readme} />
+          <Primary />
+          <ArgsTable story={PRIMARY_STORY} />
+          <Stories />
+        </>
+      ),
     },
   },
-} as Meta<typeof Code>;
+} satisfies Meta<typeof Code>;
 
 export default meta;
 
-const Template: StoryObj<typeof Code> = (args) => <Code {...args} />;
-
-export const Default = Template.bind({});
-
-Default.args = {
-  children: '<input type="url" value="https://example.fi/">',
-};
-
+type Story = StoryObj<typeof meta>;
+export const Default: Story = {};
 export const DesignTokens = designTokenStory(meta);

--- a/packages/storybook-react/src/stories/CodeBlock.stories.tsx
+++ b/packages/storybook-react/src/stories/CodeBlock.stories.tsx
@@ -1,3 +1,4 @@
+import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
 import { CodeBlock } from '@utrecht/component-library-react/dist/css-module/index';
 import readme from '@utrecht/components/code-block/README.md?raw';
@@ -10,37 +11,39 @@ const meta = {
   title: 'React Component/Code block',
   id: 'react-code-block',
   component: CodeBlock,
-  tags: ['autodocs'],
+  args: {
+    children: `<!DOCTYPE html>
+      <html lang="nl" dir="ltr">
+        <head>
+          <title>NL Design System</title>
+          <meta charset="utf-8"/>
+        </head>
+        <body>
+          <h1>NL Design System</h1>
+        </body>
+      </html>
+  `,
+  },
   parameters: {
     tokensPrefix: 'utrecht-code-block',
     tokens,
     tokensDefinition,
     docs: {
-      description: {
-        component: readme,
-      },
+      page: () => (
+        <>
+          <Description markdown={readme} />
+          <Primary />
+          <ArgsTable story={PRIMARY_STORY} />
+          <Stories />
+        </>
+      ),
     },
   },
-} as Meta<typeof CodeBlock>;
+} satisfies Meta<typeof CodeBlock>;
 
 export default meta;
 
-const Template: StoryObj<typeof CodeBlock> = (args) => <CodeBlock {...args} />;
-
-export const Default = Template.bind({});
-
-Default.args = {
-  children: `<!DOCTYPE html>
-  <html lang="nl" dir="ltr">
-    <head>
-      <title>NL Design System</title>
-      <meta charset="utf-8"/>
-    </head>
-    <body>
-      <h1>NL Design System</h1>
-    </body>
-  </html>
-  `,
-};
+type Story = StoryObj<typeof meta>;
+export const Default: Story = {};
 
 export const DesignTokens = designTokenStory(meta);

--- a/packages/storybook-react/src/stories/Mark.stories.tsx
+++ b/packages/storybook-react/src/stories/Mark.stories.tsx
@@ -1,3 +1,4 @@
+import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
 import { Mark } from '@utrecht/component-library-react/dist/css-module/index';
 import readme from '@utrecht/components/mark/README.md?raw';
@@ -14,29 +15,33 @@ const meta = {
     children: {
       name: 'Text content',
       type: { name: 'string', required: true },
+      table: {
+        category: 'API',
+      },
     },
   },
-  tags: ['autodocs'],
+  args: {
+    children: 'The Quick Brown Fox Jumps Over The Lazy Dog',
+  },
   parameters: {
     tokensPrefix: 'utrecht-mark',
     tokens,
     tokensDefinition,
     docs: {
-      description: {
-        component: readme,
-      },
+      page: () => (
+        <>
+          <Description markdown={readme} />
+          <Primary />
+          <ArgsTable story={PRIMARY_STORY} />
+          <Stories />
+        </>
+      ),
     },
   },
-} as Meta<typeof Mark>;
+} satisfies Meta<typeof Mark>;
 
 export default meta;
 
-const Template: StoryObj<typeof Mark> = (args) => <Mark {...args} />;
-
-export const Default = Template.bind({});
-
-Default.args = {
-  children: 'The Quick Brown Fox Jumps Over The Lazy Dog',
-};
-
+type Story = StoryObj<typeof meta>;
+export const Default: Story = {};
 export const DesignTokens = designTokenStory(meta);

--- a/packages/storybook-react/src/stories/NumberValue.stories.tsx
+++ b/packages/storybook-react/src/stories/NumberValue.stories.tsx
@@ -33,7 +33,7 @@ const meta = {
       ),
     },
   },
-} as Meta<typeof NumberValue>;
+} satisfies Meta<typeof NumberValue>;
 
 export default meta;
 

--- a/packages/storybook-react/src/stories/PreHeading.stories.tsx
+++ b/packages/storybook-react/src/stories/PreHeading.stories.tsx
@@ -1,3 +1,4 @@
+import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
 import { PreHeading } from '@utrecht/component-library-react/dist/css-module/index';
 import readme from '@utrecht/components/pre-heading/README.md?raw';
@@ -13,23 +14,26 @@ const meta = {
   args: {
     children: 'Lorem ipsum dolor sit amet',
   },
-  tags: ['autodocs'],
   parameters: {
     tokensPrefix: 'utrecht-pre-heading',
     tokens,
     tokensDefinition,
     docs: {
-      description: {
-        component: readme,
-      },
+      page: () => (
+        <>
+          <Description markdown={readme} />
+          <Primary />
+          <ArgsTable story={PRIMARY_STORY} />
+          <Stories />
+        </>
+      ),
     },
   },
-} as Meta<typeof PreHeading>;
+} satisfies Meta<typeof PreHeading>;
 
 export default meta;
 
-const Template: StoryObj<typeof PreHeading> = (args) => <PreHeading {...args} />;
-
-export const Default = Template.bind({});
+type Story = StoryObj<typeof meta>;
+export const Default: Story = {};
 
 export const DesignTokens = designTokenStory(meta);

--- a/packages/storybook-react/src/stories/Separator.stories.tsx
+++ b/packages/storybook-react/src/stories/Separator.stories.tsx
@@ -1,3 +1,4 @@
+import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
 import { Separator } from '@utrecht/component-library-react/dist/css-module/index';
 import readme from '@utrecht/components/separator/README.md?raw';
@@ -10,23 +11,26 @@ const meta = {
   title: 'React Component/Separator',
   id: 'react-separator',
   component: Separator,
-  tags: ['autodocs'],
   parameters: {
     tokensPrefix: 'utrecht-separator',
     tokens,
     tokensDefinition,
     docs: {
-      description: {
-        component: readme,
-      },
+      page: () => (
+        <>
+          <Description markdown={readme} />
+          <Primary />
+          <ArgsTable story={PRIMARY_STORY} />
+          <Stories />
+        </>
+      ),
     },
   },
-} as Meta<typeof Separator>;
+} satisfies Meta<typeof Separator>;
 
 export default meta;
 
-const Template: StoryObj<typeof Separator> = (args) => <Separator {...args} />;
-
-export const Default = Template.bind({});
+type Story = StoryObj<typeof meta>;
+export const Default: Story = {};
 
 export const DesignTokens = designTokenStory(meta);

--- a/packages/storybook-react/src/stories/Strong.stories.tsx
+++ b/packages/storybook-react/src/stories/Strong.stories.tsx
@@ -1,3 +1,4 @@
+import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
 import { Paragraph, Strong } from '@utrecht/component-library-react/dist/css-module/index';
 import readme from '@utrecht/components/emphasis/README.md?raw';
@@ -11,27 +12,29 @@ const meta = {
   id: 'react-strong',
   component: Strong,
   decorators: [(Story) => <Paragraph>{Story()}</Paragraph>],
-  tags: ['autodocs'],
+  args: {
+    children: 'Hello, World!',
+  },
   parameters: {
     tokensPrefix: 'utrecht-emphasis',
     tokens,
     tokensDefinition,
     docs: {
-      description: {
-        component: readme,
-      },
+      page: () => (
+        <>
+          <Description markdown={readme} />
+          <Primary />
+          <ArgsTable story={PRIMARY_STORY} />
+          <Stories />
+        </>
+      ),
     },
   },
-} as Meta<typeof Strong>;
+} satisfies Meta<typeof Strong>;
 
 export default meta;
 
-const Template: StoryObj<typeof Strong> = (args) => <Strong {...args} />;
-
-export const Default = Template.bind({});
-
-Default.args = {
-  children: 'Hello, World!',
-};
+type Story = StoryObj<typeof meta>;
+export const Default: Story = {};
 
 export const DesignTokens = designTokenStory(meta);


### PR DESCRIPTION
Duplicate of #1638 but rebased onto main, to see if it fixes non locally reproducible lint errors.