### PR TITLE
fix: open forms background-color

### DIFF
--- a/proprietary/design-tokens/src/component/of/layout.tokens.json
+++ b/proprietary/design-tokens/src/component/of/layout.tokens.json
@@ -1,7 +1,7 @@
 {
   "of": {
     "layout": {
-      "background": { "value": "{utrecht.document.color}" },
+      "background": { "value": "{utrecht.document.background-color}" },
       "bg": { "value": "{of.layout.background}" }
     }
   }


### PR DESCRIPTION
Oeps, dit moest niet `document.color` maar `document.background-color` zijn
<img width="1192" alt="Screenshot 2023-03-29 at 13 31 26" src="https://user-images.githubusercontent.com/877246/228523429-99b8f56e-d9ee-4eed-a7bd-cd8638b7d37c.png">
