### PR TITLE
fix: allow selecting dates from previous and next month

### DIFF
--- a/packages/component-library-react/src/Calendar/index.tsx
+++ b/packages/component-library-react/src/Calendar/index.tsx
@@ -13,7 +13,6 @@ import {
   isSameMonth,
   Locale,
   parseISO,
-  setDate as setDateFns,
   setMonth,
   setYear,
   startOfMonth,
@@ -165,10 +164,9 @@ export const Calendar: FC<CalendarProps> = ({
                       isToday={isSameDay(date, day.date)}
                       dayOutOfTheMonth={!isSameMonth(day.date, date)}
                       key={index}
-                      onClick={(event) => {
-                        const selectedDay = setDateFns(date, Number((event.target as HTMLButtonElement).textContent));
-                        setDate(selectedDay);
-                        onCalendarClick(formatISO(selectedDay));
+                      onClick={() => {
+                        setDate(day.date);
+                        onCalendarClick(formatISO(day.date));
                       }}
                       aria-label={format(day.date, 'eeee dd LLLL Y', { locale })}
                       day={day.date.getDate().toString()}


### PR DESCRIPTION
Solves https://github.com/frameless/utrecht-huwelijksplanner/issues/265

Clicking a date from a previous month would select that same day in the current month. This change correctly changes the current day to the selected day. This also fixes a bug where selecting 31st March when April is the active month would change the calendar to May. It now correctly switches to 31st March. 