### PR TITLE
feat: datepicker table body styling

### DIFF
--- a/components/calendar/css/_mixin.scss
+++ b/components/calendar/css/_mixin.scss
@@ -91,7 +91,7 @@
 
 @mixin utrecht-calendar__navigation-label {
   color: var(--utrecht-calendar-navigation-label-color);
-  font-size: var(--utrecht-calendar-navigation-label-min-font-size);
+  font-size: var(--utrecht-calendar-navigation-label-font-size);
   text-align: center;
 }
 

--- a/packages/component-library-react/src/Calendar/index.tsx
+++ b/packages/component-library-react/src/Calendar/index.tsx
@@ -163,7 +163,7 @@ export const Calendar: FC<CalendarProps> = ({
                 {week.map((day, index) => {
                   return (
                     <CalendarTableDaysItemDay
-                      isToday={isSameDay(date, day.date)}
+                      isToday={isSameDay(day.date, Date.now())}
                       dayOutOfTheMonth={!isSameMonth(day.date, date)}
                       key={index}
                       onClick={() => {
@@ -173,7 +173,7 @@ export const Calendar: FC<CalendarProps> = ({
                       aria-label={format(day.date, 'eeee dd LLLL Y', { locale })}
                       day={day.date.getDate().toString()}
                       emphasis={day.emphasis}
-                      selected={day.selected}
+                      selected={day.selected || isSameDay(day.date, date)}
                       disabled={day.disabled}
                     />
                   );

--- a/proprietary/design-tokens/src/component/utrecht/calendar.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/calendar.tokens.json
@@ -26,7 +26,9 @@
           "color": {
             "value": "{utrecht.color.black}"
           },
-          "border-width": {},
+          "border-width": {
+            "value": "2px"
+          },
           "border-color": {
             "value": "transparent"
           },
@@ -36,7 +38,7 @@
               "value": "{utrecht.color.blue.40}"
             },
             "border-color": {
-              "value": "transparent"
+              "value": "{utrecht.color.black}"
             }
           },
           "focus": {
@@ -83,12 +85,16 @@
             "background-color": {}
           },
           "selected": {
-            "color": {},
+            "color": {
+              "value": "{utrecht.color.white}"
+            },
             "font-weight": {},
             "border-color": {
               "value": "transparent"
             },
-            "background-color": {}
+            "background-color": {
+              "value": "{utrecht.color.blue.30}"
+            }
           },
           "disabled": {
             "color": {},

--- a/proprietary/design-tokens/src/component/utrecht/calendar.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/calendar.tokens.json
@@ -66,15 +66,17 @@
           },
           "is-today": {
             "color": {
-              "value": "{utrecht.color.blue.40}"
+              "value": "{utrecht.color.blue.30}"
             },
             "font-weight": {
               "value": "700"
             },
             "border-color": {
-              "value": "transparent"
+              "value": "{utrecht.color.blue.35}"
             },
-            "background-color": {}
+            "background-color": {
+              "value": "{utrecht.color.blue.90}"
+            }
           },
           "emphasis": {
             "color": {},
@@ -97,7 +99,9 @@
             }
           },
           "disabled": {
-            "color": {},
+            "color": {
+              "value": "{utrecht.color.grey.40}"
+            },
             "border-color": {
               "value": "transparent"
             },
@@ -123,7 +127,7 @@
           "color": {
             "value": "{utrecht.color.black}"
           },
-          "min-font-size": {
+          "font-size": {
             "value": "{utrecht.typography.scale.lg.font-size}"
           }
         }


### PR DESCRIPTION
Based on https://github.com/nl-design-system/utrecht/pull/1699

This change adds styling to the calendar days for the following states
- Is today
- Is selected
- Is disabled

<img width="360" alt="image" src="https://user-images.githubusercontent.com/24610692/233039742-ffa59e0d-2767-4ee0-9436-e41541abf286.png">

[Figma design](https://www.figma.com/file/msb3CfQBefPoruqNQ968Zh/Utrecht-Design-System?node-id=2903-6360&t=VAIWYtcANbzpWIkn-0)