### PR TITLE
feat: allow unselected date and keep date when navigating months

### DIFF
--- a/packages/component-library-react/src/Calendar/index.tsx
+++ b/packages/component-library-react/src/Calendar/index.tsx
@@ -94,10 +94,11 @@ export const Calendar: FC<CalendarProps> = ({
   previousMonthButtonTitle = 'Previous month',
   nextMonthButtonTitle = 'Next month',
 }) => {
-  const [date, setDate] = useState(currentDate || new Date());
-  const calendar = createCalendar(date);
-  const start = startOfWeek(date, { weekStartsOn: 1 });
-  const end = endOfWeek(date, { weekStartsOn: 1 });
+  const [visibleMonth, setVisibleMonth] = useState(currentDate || new Date());
+  const [selectedDate, setSelectedDate] = useState(currentDate);
+  const calendar = createCalendar(visibleMonth);
+  const start = startOfWeek(visibleMonth, { weekStartsOn: 1 });
+  const end = endOfWeek(visibleMonth, { weekStartsOn: 1 });
 
   const currentWeek = eachDayOfInterval({ start, end }).map((day) => day);
   const chunksWeeks = chunk(calendar, calendar.length / 6);
@@ -130,17 +131,17 @@ export const Calendar: FC<CalendarProps> = ({
         <CalendarNavigationButtons
           previousIcon={<IconArrowLeftDouble title={previousYearButtonTitle} />}
           nextIcon={<IconArrowRightDouble title={nextYearButtonTitle} />}
-          onPreviousClick={() => setDate(setYear(date, getYear(date) - 1))}
-          onNextClick={() => setDate(addYears(date, 1))}
+          onPreviousClick={() => setVisibleMonth(setYear(visibleMonth, getYear(visibleMonth) - 1))}
+          onNextClick={() => setVisibleMonth(addYears(visibleMonth, 1))}
         >
           <CalendarNavigationButtons
             previousIcon={<IconArrowLeft title={previousMonthButtonTitle} />}
             nextIcon={<IconArrowRight title={nextMonthButtonTitle} />}
-            onPreviousClick={() => setDate(setMonth(date, date.getMonth() - 1))}
-            onNextClick={() => setDate(addMonths(date, 1))}
+            onPreviousClick={() => setVisibleMonth(setMonth(visibleMonth, visibleMonth.getMonth() - 1))}
+            onNextClick={() => setVisibleMonth(addMonths(visibleMonth, 1))}
           >
-            <CalendarNavigationLabel dateTime={format(date, 'yyyy-mm')}>
-              {format(date, 'LLLL Y', { locale })}
+            <CalendarNavigationLabel dateTime={format(visibleMonth, 'yyyy-mm')}>
+              {format(visibleMonth, 'LLLL Y', { locale })}
             </CalendarNavigationLabel>
           </CalendarNavigationButtons>
         </CalendarNavigationButtons>
@@ -164,16 +165,19 @@ export const Calendar: FC<CalendarProps> = ({
                   return (
                     <CalendarTableDaysItemDay
                       isToday={isSameDay(day.date, Date.now())}
-                      dayOutOfTheMonth={!isSameMonth(day.date, date)}
+                      dayOutOfTheMonth={!isSameMonth(day.date, visibleMonth)}
                       key={index}
                       onClick={() => {
-                        setDate(day.date);
-                        onCalendarClick(formatISO(day.date));
+                        setVisibleMonth(day.date);
+                        if (isSameMonth(day.date, visibleMonth)) {
+                          setSelectedDate(day.date);
+                          onCalendarClick(formatISO(day.date));
+                        }
                       }}
                       aria-label={format(day.date, 'eeee dd LLLL Y', { locale })}
                       day={day.date.getDate().toString()}
                       emphasis={day.emphasis}
-                      selected={day.selected || isSameDay(day.date, date)}
+                      selected={day.selected || (selectedDate && isSameDay(day.date, selectedDate))}
                       disabled={day.disabled}
                     />
                   );

--- a/packages/storybook-react/src/stories/Calendar.stories.tsx
+++ b/packages/storybook-react/src/stories/Calendar.stories.tsx
@@ -2,6 +2,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import { Calendar } from '@utrecht/component-library-react/dist/css-module';
 import tokensDefinition from '@utrecht/components/calendar/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
+import { addDays } from 'date-fns';
 import { enUS, nl } from 'date-fns/locale';
 import { designTokenStory } from './util';
 
@@ -24,7 +25,7 @@ const meta = {
     onCalendarClick: (date) => {
       console.log(date);
     },
-    currentDate: new Date(),
+    currentDate: addDays(new Date(), 3),
     events,
     locale: nl,
     previousYearButtonTitle: 'Vorig jaar',


### PR DESCRIPTION
### Summary
- Adds default no selection to datepicker
- Allows navigating to different month / year without losing day selection
- Removes onCalendarClick callback trigger when navigating