### PR TITLE
fix: revert "support design tokens in `::selection`"

### DIFF
--- a/proprietary/design-tokens/src/background-image-icon.scss
+++ b/proprietary/design-tokens/src/background-image-icon.scss
@@ -5,8 +5,7 @@
  */
 
 .utrecht-theme,
-.utrecht-theme ::backdrop,
-.utrecht-theme ::selection {
+.utrecht-theme ::backdrop {
   --utrecht-menulijst-item-background-image: url("./pijltje.svg");
   --utrecht-link-icon-left-background-image: url("./pijltje.svg");
   --utrecht-search-bar-input-background-image: url("./icoon-zoek-rood.svg");

--- a/proprietary/design-tokens/src/dark/index.scss
+++ b/proprietary/design-tokens/src/dark/index.scss
@@ -8,7 +8,6 @@
 @import "../../dist/dark/mixin-theme";
 
 .utrecht-theme--color-scheme-dark,
-.utrecht-theme--color-scheme-dark ::backdrop,
-.utrecht-theme--color-scheme-dark ::selection {
+.utrecht-theme--color-scheme-dark ::backdrop {
   @include utrecht-theme--dark;
 }

--- a/proprietary/design-tokens/src/index.scss
+++ b/proprietary/design-tokens/src/index.scss
@@ -12,8 +12,7 @@
 @import "./responsive";
 
 .utrecht-theme,
-.utrecht-theme ::backdrop,
-.utrecht-theme ::selection {
+.utrecht-theme ::backdrop {
   @include utrecht-theme;
 
   utrecht-page-footer,
@@ -30,10 +29,8 @@
 @media (prefers-color-scheme: dark) {
   .utrecht-theme--media-query,
   .utrecht-theme--media-query ::backdrop,
-  .utrecht-theme--media-query ::selection,
   .utrecht-theme--media-query-color-scheme,
-  .utrecht-theme--media-query-color-scheme ::backdrop,
-  .utrecht-theme--media-query-color-scheme ::selection {
+  .utrecht-theme--media-query-color-scheme ::backdrop {
     @include utrecht-theme--dark;
   }
 }

--- a/proprietary/design-tokens/src/style-dictionary-config-dark.js
+++ b/proprietary/design-tokens/src/style-dictionary-config-dark.js
@@ -18,7 +18,7 @@ module.exports = {
           destination: 'root.css',
           format: 'css/variables',
           options: {
-            selector: ':root, ::backdrop, ::selection',
+            selector: ':root, ::backdrop',
             outputReferences: true,
           },
         },
@@ -32,7 +32,7 @@ module.exports = {
           destination: 'index.css',
           format: 'css/variables',
           options: {
-            selector: '.utrecht-theme--dark, .utrecht-theme--dark ::backdrop, .utrecht-theme--dark ::selection',
+            selector: '.utrecht-theme--dark, .utrecht-theme--dark ::backdrop',
             outputReferences: true,
           },
         },

--- a/proprietary/design-tokens/style-dictionary.config.json
+++ b/proprietary/design-tokens/style-dictionary.config.json
@@ -50,7 +50,7 @@
           "destination": "root.css",
           "format": "css/variables",
           "options": {
-            "selector": ":root, ::backdrop, ::selection",
+            "selector": ":root, ::backdrop",
             "outputReferences": true
           }
         }
@@ -64,7 +64,7 @@
           "destination": "theme.css",
           "format": "css/variables",
           "options": {
-            "selector": ".utrecht-theme, .utrecht-theme ::backdrop, .utrecht-theme ::selection",
+            "selector": ".utrecht-theme, .utrecht-theme ::backdrop",
             "outputReferences": true
           }
         }


### PR DESCRIPTION
This reverts commit fb62efec0a5681efdf8d142d25a6ecbdecb23cf8.

Unfortunately the following code makes the user selection invisible:

```
::selection {
    --color: red;
}
```

Somehow, only having a custom property, breaks `background-color` and `color`. This totally works:

```
::selection {
    --color: red;
    background-color: Highlight;
    color: HighlightText;
}
```

However, the following would not be our intention:

```
.utrecht-theme,
.utrecht-theme ::selection {
    --color: red;
    background-color: Highlight;
    color: HighlightText;
}
```

Perhaps we could do the following, but I doubt it would be worth the complexity.

```
.utrecht-theme,
.utrecht-theme ::selection {
    --color: red;
}

.utrecht-theme ::selection {
    background-color: Highlight;
    color: HighlightText;
}
```