### PR TITLE
docs: fix typescript errors in Storybook React stories

### DIFF
--- a/packages/component-library-react/src/FormLabel.tsx
+++ b/packages/component-library-react/src/FormLabel.tsx
@@ -2,7 +2,6 @@ import clsx from 'clsx';
 import { ForwardedRef, forwardRef, LabelHTMLAttributes, PropsWithChildren } from 'react';
 
 export interface FormLabelProps extends LabelHTMLAttributes<HTMLLabelElement> {
-  htmlFor: string;
   type?: 'checkbox' | 'radio';
   disabled?: boolean;
   checked?: boolean;

--- a/packages/storybook-react/src/stories/BadgeList.stories.tsx
+++ b/packages/storybook-react/src/stories/BadgeList.stories.tsx
@@ -14,13 +14,7 @@ const meta = {
   args: {
     children: [<DataBadge>Badge A</DataBadge>, <DataBadge>Badge B</DataBadge>, <DataBadge>Badge C</DataBadge>],
   },
-  argTypes: {
-    items: {
-      name: 'value',
-      type: { name: 'string', required: false },
-      table: { defaultValue: { summary: '' } },
-    },
-  },
+  argTypes: {},
   parameters: {
     tokensPrefix: 'utrecht-badge-list',
     tokens,

--- a/packages/storybook-react/src/stories/BreadcrumbNav.stories.tsx
+++ b/packages/storybook-react/src/stories/BreadcrumbNav.stories.tsx
@@ -27,13 +27,6 @@ const meta = {
     ],
   },
   argTypes: {
-    items: {
-      description: 'Links',
-      type: {
-        name: 'array',
-        required: true,
-      },
-    },
     appearance: {
       description: 'Appearance',
       control: { type: 'select' },

--- a/packages/storybook-react/src/stories/Button.stories.tsx
+++ b/packages/storybook-react/src/stories/Button.stories.tsx
@@ -31,11 +31,11 @@ const meta = {
   },
   argTypes: {
     appearance: {
-      type: 'select',
+      control: { type: 'select' },
       options: [undefined, 'primary-action-button', 'secondary-action-button', 'subtle-button'],
     },
     type: {
-      type: 'select',
+      control: { type: 'select' },
       options: [undefined, 'button', 'submit', 'reset'],
     },
   },

--- a/packages/storybook-react/src/stories/ColorSample.stories.tsx
+++ b/packages/storybook-react/src/stories/ColorSample.stories.tsx
@@ -20,7 +20,10 @@ const meta = {
       control: {
         type: 'color',
       },
-      type: { required: true },
+      type: {
+        name: 'string',
+        required: true,
+      },
       table: {
         category: 'API',
       },

--- a/packages/storybook-react/src/stories/FormField.stories.tsx
+++ b/packages/storybook-react/src/stories/FormField.stories.tsx
@@ -35,14 +35,6 @@ const meta = {
     Input: Textbox,
   },
   argTypes: {
-    disabled: {
-      description: 'Disabled',
-      control: 'boolean',
-      table: {
-        category: 'Component',
-        defaultValue: { summary: false },
-      },
-    },
     invalid: {
       name: 'invalid',
       type: { name: 'boolean', required: false },

--- a/packages/storybook-react/src/stories/FormLabel.stories.tsx
+++ b/packages/storybook-react/src/stories/FormLabel.stories.tsx
@@ -13,7 +13,7 @@ const meta = {
   component: FormLabel,
   argTypes: {
     type: {
-      type: 'select',
+      type: { name: 'string', required: false },
       options: [undefined, 'checkbox', 'radio'],
     },
     checked: {

--- a/packages/storybook-react/src/stories/OrderedListItem.stories.tsx
+++ b/packages/storybook-react/src/stories/OrderedListItem.stories.tsx
@@ -6,7 +6,6 @@ const meta = {
   title: 'React Component/Ordered List/Item',
   id: 'react-ordered-list--item',
   component: OrderedListItem,
-  name: OrderedListItem,
   decorators: [(Story) => <OrderedList>{Story()}</OrderedList>],
   args: {
     children: 'List item',

--- a/packages/storybook-react/src/stories/Select.stories.tsx
+++ b/packages/storybook-react/src/stories/Select.stories.tsx
@@ -81,7 +81,7 @@ const meta = {
       },
     },
   },
-  render: ({ ...args }) => (
+  render: ({ options, ...args }) => (
     <Select {...args}>
       {options &&
         options.length > 0 &&

--- a/packages/storybook-react/src/stories/UnorderedListItem.stories.tsx
+++ b/packages/storybook-react/src/stories/UnorderedListItem.stories.tsx
@@ -6,7 +6,6 @@ const meta = {
   title: 'React Component/Unordered List/Item',
   id: 'react-unordered-list--item',
   component: UnorderedListItem,
-  name: UnorderedListItem,
   decorators: [(Story) => <UnorderedList>{Story()}</UnorderedList>],
   args: {
     children: 'List item',

--- a/packages/storybook-react/src/stories/template/PageStep-1.stories.tsx
+++ b/packages/storybook-react/src/stories/template/PageStep-1.stories.tsx
@@ -33,131 +33,138 @@ const meta = {
   title: 'Template/Multistep form/Step 1',
   id: 'template-form-pages-step-1',
   component: Page,
-} as Meta<typeof Page>;
+} satisfies Meta<typeof Page>;
 
 export default meta;
 
-const Template: StoryObj<typeof Page> = (args) => (
-  <Page {...args}>
-    <PageHeader>
-      <Link href="/">
-        <UtrechtLogo />
-      </Link>
-    </PageHeader>
-    <PageContent style={{ '--utrecht-space-around': 1 } as any}>
-      <UtrechtBreadcrumb
-        json={JSON.stringify([
-          { href: 'https://example/', title: 'Home', current: false },
-          { href: 'https://example/', title: 'Online loket', current: true },
-        ])}
-        variant="arrows"
-      />
+type Story = StoryObj<typeof meta>;
 
-      <aside>
-        <Heading3>MIJN LOKET</Heading3>
-        <UtrechtDigidButton>
-          <ButtonLink appearance="primary-action-button">
-            Uitloggen
-            <UtrechtIconArrow />
-          </ButtonLink>
-        </UtrechtDigidButton>
-        <Paragraph>Mevrouw Cindy</Paragraph>
-        <br />
-        <br />
-      </aside>
-      <Heading1>
-        <Paragraph lead>ONLINE LOKET</Paragraph>
-        Een verhuizing doorgeven
-      </Heading1>
-      <section>
-        <Heading2>Uw gegevens</Heading2>
-        <Paragraph>
-          Hieronder ziet u de gegevens die wij van u weten. Kloppen uw gegevens niet? Dan kunt u deze laten aanpassen
-          via
-          <Link href="https://www.utrecht.nl/persoonsgegevenswijzigen"> www.utrecht.nl/persoonsgegevenswijzigen. </Link>
-          Uw e-mailadres en telefoonnummer vult u zelf in.
-        </Paragraph>
-      </section>
-      <section>
-        <Heading2>PERSOONSGEGEVENS</Heading2>
-        <DataList appearance="rows">
-          <DataListItem>
-            <DataListKey>Burgerservicenummer</DataListKey>
-            <DataListValue>298272921</DataListValue>
-          </DataListItem>
-          <DataListItem>
-            <DataListKey>Aanhef</DataListKey>
-            <DataListValue>Vrouw</DataListValue>
-          </DataListItem>
-          <DataListItem>
-            <DataListKey>Voorletter(s)</DataListKey>
-            <DataListValue notranslate>C.</DataListValue>
-          </DataListItem>
-          <DataListItem>
-            <DataListKey>Tussenvoegsel(s)</DataListKey>
-            <DataListValue notranslate></DataListValue>
-          </DataListItem>
-          <DataListItem>
-            <DataListKey>Achternaam</DataListKey>
-            <DataListValue notranslate>Verburg</DataListValue>
-          </DataListItem>
-        </DataList>
-      </section>
-      <Separator />
-      <section>
-        <Heading2>ADRESGEGEVENS</Heading2>
-        <DataList appearance="rows">
-          <DataListItem>
-            <DataListKey>Straatnaam</DataListKey>
-            <DataListValue notranslate>Stadsplateau</DataListValue>
-          </DataListItem>
-          <DataListItem>
-            <DataListKey>Huisnummer</DataListKey>
-            <DataListValue>1</DataListValue>
-          </DataListItem>
-          <DataListItem>
-            <DataListKey>Huisletter</DataListKey>
-            <DataListValue notranslate></DataListValue>
-          </DataListItem>
-          <DataListItem>
-            <DataListKey>Huisnummertoevoeging</DataListKey>
-            <DataListValue notranslate></DataListValue>
-          </DataListItem>
-          <DataListItem>
-            <DataListKey>Postcode</DataListKey>
-            <DataListValue notranslate>3521AZ</DataListValue>
-          </DataListItem>
-          <DataListItem>
-            <DataListKey>Woonplaats</DataListKey>
-            <DataListValue notranslate>Utrecht</DataListValue>
-          </DataListItem>
-        </DataList>
-      </section>
-      <Separator />
-      <section>
-        <Heading2>CONTACTGEGEVENS</Heading2>
-        <form>
-          <FormField>
-            <FormLabel htmlFor="telefoonnummer">Telefoonnummer</FormLabel>
-            <br />
-            <Textbox id="telefoonnummer" />
-          </FormField>
-          <FormField>
-            <FormLabel id="email-label" htmlFor="email">
-              E-mailadres *
-            </FormLabel>
-            <br />
-            <Textbox required id="email" aria-labelledby="email-label" aria-describedby="email-desc" />
-            <UtrechtFormFieldDescription id="email-desc">Vragen met een * zijn verplicht.</UtrechtFormFieldDescription>
-          </FormField>
-          <Button appearance="primary-action-button" type="submit">
-            VOLGENDE
-          </Button>
-        </form>
-      </section>
-    </PageContent>
-    <PageFooter />
-  </Page>
-);
+export const One: Story = {
+  render: (args) => (
+    <Page {...args}>
+      <PageHeader>
+        <Link href="/">
+          <UtrechtLogo />
+        </Link>
+      </PageHeader>
+      <PageContent style={{ '--utrecht-space-around': 1 } as any}>
+        <UtrechtBreadcrumb
+          json={JSON.stringify([
+            { href: 'https://example/', title: 'Home', current: false },
+            { href: 'https://example/', title: 'Online loket', current: true },
+          ])}
+          variant="arrows"
+        />
 
-export const One = Template.bind({});
+        <aside>
+          <Heading3>MIJN LOKET</Heading3>
+          <UtrechtDigidButton>
+            <ButtonLink appearance="primary-action-button">
+              Uitloggen
+              <UtrechtIconArrow />
+            </ButtonLink>
+          </UtrechtDigidButton>
+          <Paragraph>Mevrouw Cindy</Paragraph>
+          <br />
+          <br />
+        </aside>
+        <Heading1>
+          <Paragraph lead>ONLINE LOKET</Paragraph>
+          Een verhuizing doorgeven
+        </Heading1>
+        <section>
+          <Heading2>Uw gegevens</Heading2>
+          <Paragraph>
+            Hieronder ziet u de gegevens die wij van u weten. Kloppen uw gegevens niet? Dan kunt u deze laten aanpassen
+            via
+            <Link href="https://www.utrecht.nl/persoonsgegevenswijzigen">
+              {' '}
+              www.utrecht.nl/persoonsgegevenswijzigen.{' '}
+            </Link>
+            Uw e-mailadres en telefoonnummer vult u zelf in.
+          </Paragraph>
+        </section>
+        <section>
+          <Heading2>PERSOONSGEGEVENS</Heading2>
+          <DataList appearance="rows">
+            <DataListItem>
+              <DataListKey>Burgerservicenummer</DataListKey>
+              <DataListValue>298272921</DataListValue>
+            </DataListItem>
+            <DataListItem>
+              <DataListKey>Aanhef</DataListKey>
+              <DataListValue>Vrouw</DataListValue>
+            </DataListItem>
+            <DataListItem>
+              <DataListKey>Voorletter(s)</DataListKey>
+              <DataListValue notranslate>C.</DataListValue>
+            </DataListItem>
+            <DataListItem>
+              <DataListKey>Tussenvoegsel(s)</DataListKey>
+              <DataListValue notranslate></DataListValue>
+            </DataListItem>
+            <DataListItem>
+              <DataListKey>Achternaam</DataListKey>
+              <DataListValue notranslate>Verburg</DataListValue>
+            </DataListItem>
+          </DataList>
+        </section>
+        <Separator />
+        <section>
+          <Heading2>ADRESGEGEVENS</Heading2>
+          <DataList appearance="rows">
+            <DataListItem>
+              <DataListKey>Straatnaam</DataListKey>
+              <DataListValue notranslate>Stadsplateau</DataListValue>
+            </DataListItem>
+            <DataListItem>
+              <DataListKey>Huisnummer</DataListKey>
+              <DataListValue>1</DataListValue>
+            </DataListItem>
+            <DataListItem>
+              <DataListKey>Huisletter</DataListKey>
+              <DataListValue notranslate></DataListValue>
+            </DataListItem>
+            <DataListItem>
+              <DataListKey>Huisnummertoevoeging</DataListKey>
+              <DataListValue notranslate></DataListValue>
+            </DataListItem>
+            <DataListItem>
+              <DataListKey>Postcode</DataListKey>
+              <DataListValue notranslate>3521AZ</DataListValue>
+            </DataListItem>
+            <DataListItem>
+              <DataListKey>Woonplaats</DataListKey>
+              <DataListValue notranslate>Utrecht</DataListValue>
+            </DataListItem>
+          </DataList>
+        </section>
+        <Separator />
+        <section>
+          <Heading2>CONTACTGEGEVENS</Heading2>
+          <form>
+            <FormField>
+              <FormLabel htmlFor="telefoonnummer">Telefoonnummer</FormLabel>
+              <br />
+              <Textbox id="telefoonnummer" />
+            </FormField>
+            <FormField>
+              <FormLabel id="email-label" htmlFor="email">
+                E-mailadres *
+              </FormLabel>
+              <br />
+              <Textbox required id="email" aria-labelledby="email-label" aria-describedby="email-desc" />
+              <UtrechtFormFieldDescription id="email-desc">
+                Vragen met een * zijn verplicht.
+              </UtrechtFormFieldDescription>
+            </FormField>
+            <Button appearance="primary-action-button" type="submit">
+              VOLGENDE
+            </Button>
+          </form>
+        </section>
+      </PageContent>
+      <PageFooter />
+    </Page>
+  ),
+};

--- a/packages/storybook-react/src/stories/template/PageStep-2.stories.tsx
+++ b/packages/storybook-react/src/stories/template/PageStep-2.stories.tsx
@@ -33,88 +33,90 @@ const meta = {
   title: 'Template/Multistep form/Step 2',
   id: 'template-form-pages-step-2',
   component: Page,
-} as Meta<typeof Page>;
+} satisfies Meta<typeof Page>;
 
 export default meta;
 
-const Template: StoryObj<typeof Page> = (args) => (
-  <Page {...args}>
-    <PageHeader>
-      <Link href="/">
-        <UtrechtLogo />
-      </Link>
-    </PageHeader>
-    <PageContent style={{ '--utrecht-space-around': 1 } as any}>
-      <UtrechtBreadcrumb
-        json={JSON.stringify([
-          { href: 'https://example/', title: 'Home', current: false },
-          { href: 'https://example/', title: 'Online loket', current: true },
-        ])}
-        variant="arrows"
-      />
+type Story = StoryObj<typeof meta>;
 
-      <aside>
-        <Heading3>MIJN LOKET</Heading3>
-        <UtrechtDigidButton>
-          <ButtonLink appearance="primary-action-button">
-            Uitloggen
-            <UtrechtIconArrow />
-          </ButtonLink>
-        </UtrechtDigidButton>
-        <Paragraph>Mevrouw Cindy</Paragraph>
-        <br />
-        <br />
-      </aside>
-      <Heading1>
-        <Paragraph lead>ONLINE LOKET</Paragraph>
-        Een verhuizing doorgeven
-      </Heading1>
-      <Heading2>De Verhuizing</Heading2>
-      <Separator />
-      <section>
-        <form>
-          <FormField>
-            <FormLabel htmlFor="verhuisdatum">Verhuisdatum*</FormLabel>
-            <br />
-            <Textbox id="verhuisdatum" type="date" required />
-          </FormField>
-          <Fieldset>
-            <FieldsetLegend>NIEUWE ADRES</FieldsetLegend>
-            <div role="radiogroup" aria-labelledby="nieuwe-adres-label" data-rating-value="">
-              <Heading4 id="nieuwe-adres-label">Hoe wilt u zoeken *</Heading4>
+export const Two: Story = {
+  render: (args) => (
+    <Page {...args}>
+      <PageHeader>
+        <Link href="/">
+          <UtrechtLogo />
+        </Link>
+      </PageHeader>
+      <PageContent style={{ '--utrecht-space-around': 1 } as any}>
+        <UtrechtBreadcrumb
+          json={JSON.stringify([
+            { href: 'https://example/', title: 'Home', current: false },
+            { href: 'https://example/', title: 'Online loket', current: true },
+          ])}
+          variant="arrows"
+        />
+
+        <aside>
+          <Heading3>MIJN LOKET</Heading3>
+          <UtrechtDigidButton>
+            <ButtonLink appearance="primary-action-button">
+              Uitloggen
+              <UtrechtIconArrow />
+            </ButtonLink>
+          </UtrechtDigidButton>
+          <Paragraph>Mevrouw Cindy</Paragraph>
+          <br />
+          <br />
+        </aside>
+        <Heading1>
+          <Paragraph lead>ONLINE LOKET</Paragraph>
+          Een verhuizing doorgeven
+        </Heading1>
+        <Heading2>De Verhuizing</Heading2>
+        <Separator />
+        <section>
+          <form>
+            <FormField>
+              <FormLabel htmlFor="verhuisdatum">Verhuisdatum*</FormLabel>
+              <br />
+              <Textbox id="verhuisdatum" type="date" required />
+            </FormField>
+            <Fieldset>
+              <FieldsetLegend>NIEUWE ADRES</FieldsetLegend>
+              <div role="radiogroup" aria-labelledby="nieuwe-adres-label" data-rating-value="">
+                <Heading4 id="nieuwe-adres-label">Hoe wilt u zoeken *</Heading4>
+                <FormField>
+                  <RadioButton id="postcode" name="woonplaats-en-straat" />
+                  <FormLabel htmlFor="postcode">Postcode</FormLabel>
+                </FormField>
+                <FormField>
+                  <RadioButton id="woonplaats-en-straat" name="woonplaats-en-straat" />
+                  <FormLabel htmlFor="woonplaats-en-straat">Woonplaats en Straat</FormLabel>
+                </FormField>
+              </div>
               <FormField>
-                <RadioButton id="postcode" name="woonplaats-en-straat" />
-                <FormLabel htmlFor="postcode">Postcode</FormLabel>
+                <FormLabel htmlFor="postcode">Postcode *</FormLabel>
+                <br />
+                <Textbox id="postcode" required aria-invalid="true" aria-errormessage="err-postcode" />
+                <UtrechtFormFieldDescription id="err-postcode" status="invalid">
+                  U moet de postcode van het nieuwe adres invullen.
+                </UtrechtFormFieldDescription>
               </FormField>
               <FormField>
-                <RadioButton id="woonplaats-en-straat" name="woonplaats-en-straat" />
-                <FormLabel htmlFor="woonplaats-en-straat">Woonplaats en Straat</FormLabel>
+                <FormLabel htmlFor="huisnummer">Huisnummer *</FormLabel>
+                <br />
+                <Textbox id="huisnummer" required />
               </FormField>
-            </div>
-            <FormField>
-              <FormLabel htmlFor="postcode">Postcode *</FormLabel>
-              <br />
-              <Textbox id="postcode" required aria-invalid="true" aria-errormessage="err-postcode" />
-              <UtrechtFormFieldDescription id="err-postcode" status="invalid">
-                U moet de postcode van het nieuwe adres invullen.
-              </UtrechtFormFieldDescription>
-            </FormField>
-            <FormField>
-              <FormLabel htmlFor="huisnummer">Huisnummer *</FormLabel>
-              <br />
-              <Textbox id="huisnummer" required />
-            </FormField>
-            <UtrechtFormFieldDescription>Vragen met een * zijn verplicht.</UtrechtFormFieldDescription>
-          </Fieldset>
-          <Link href="/">VORIGE</Link>
-          <Button type="submit" appearance="primary-action-button">
-            VOLGENDE
-          </Button>
-        </form>
-      </section>
-    </PageContent>
-    <PageFooter />
-  </Page>
-);
-
-export const Two = Template.bind({});
+              <UtrechtFormFieldDescription>Vragen met een * zijn verplicht.</UtrechtFormFieldDescription>
+            </Fieldset>
+            <Link href="/">VORIGE</Link>
+            <Button type="submit" appearance="primary-action-button">
+              VOLGENDE
+            </Button>
+          </form>
+        </section>
+      </PageContent>
+      <PageFooter />
+    </Page>
+  ),
+};

--- a/packages/storybook-react/src/stories/template/PageStep-3.stories.tsx
+++ b/packages/storybook-react/src/stories/template/PageStep-3.stories.tsx
@@ -33,97 +33,99 @@ const meta = {
   title: 'Template/Multistep form/Step 3',
   id: 'template-form-pages-step-3',
   component: Page,
-} as Meta<typeof Page>;
+} satisfies Meta<typeof Page>;
 
 export default meta;
 
-const Template: StoryObj<typeof Page> = (args) => (
-  <Page {...args}>
-    <PageHeader>
-      <Link href="/">
-        <UtrechtLogo />
-      </Link>
-    </PageHeader>
-    <PageContent style={{ '--utrecht-space-around': 1 } as any}>
-      <UtrechtBreadcrumb
-        json={JSON.stringify([
-          { href: 'https://example/', title: 'Home', current: false },
-          { href: 'https://example/', title: 'Online loket', current: true },
-        ])}
-        variant="arrows"
-      />
+type Story = StoryObj<typeof meta>;
 
-      <aside>
-        <Heading3>MIJN LOKET</Heading3>
-        <UtrechtDigidButton>
-          <ButtonLink appearance="primary-action-button">
-            Uitloggen
-            <UtrechtIconArrow />
-          </ButtonLink>
-        </UtrechtDigidButton>
-        <Paragraph>Mevrouw Cindy</Paragraph>
-        <br />
-        <br />
-      </aside>
-      <Heading1>
-        <Paragraph lead>ONLINE LOKET</Paragraph>
-        Een verhuizing doorgeven
-      </Heading1>
-      <Heading2>Woonsituatie</Heading2>
-      <Separator />
-      <section>
-        <form>
-          <Fieldset>
-            <FieldsetLegend>MEDEVERHUIZERS</FieldsetLegend>
+export const Three: Story = {
+  render: (args) => (
+    <Page {...args}>
+      <PageHeader>
+        <Link href="/">
+          <UtrechtLogo />
+        </Link>
+      </PageHeader>
+      <PageContent style={{ '--utrecht-space-around': 1 } as any}>
+        <UtrechtBreadcrumb
+          json={JSON.stringify([
+            { href: 'https://example/', title: 'Home', current: false },
+            { href: 'https://example/', title: 'Online loket', current: true },
+          ])}
+          variant="arrows"
+        />
 
-            <div role="group" aria-labelledby="Medeverhuizers-label" data-rating-value="">
-              <Heading4 id="Medeverhuizers-label">Medeverhuizers</Heading4>
+        <aside>
+          <Heading3>MIJN LOKET</Heading3>
+          <UtrechtDigidButton>
+            <ButtonLink appearance="primary-action-button">
+              Uitloggen
+              <UtrechtIconArrow />
+            </ButtonLink>
+          </UtrechtDigidButton>
+          <Paragraph>Mevrouw Cindy</Paragraph>
+          <br />
+          <br />
+        </aside>
+        <Heading1>
+          <Paragraph lead>ONLINE LOKET</Paragraph>
+          Een verhuizing doorgeven
+        </Heading1>
+        <Heading2>Woonsituatie</Heading2>
+        <Separator />
+        <section>
+          <form>
+            <Fieldset>
+              <FieldsetLegend>MEDEVERHUIZERS</FieldsetLegend>
+
+              <div role="group" aria-labelledby="Medeverhuizers-label" data-rating-value="">
+                <Heading4 id="Medeverhuizers-label">Medeverhuizers</Heading4>
+                <FormField>
+                  <Checkbox id="medeverhuizers" />
+                  <FormLabel htmlFor="medeverhuizers">Bruce Verburg</FormLabel>
+                </FormField>
+              </div>
+              <Separator />
               <FormField>
-                <Checkbox id="medeverhuizers" />
-                <FormLabel htmlFor="medeverhuizers">Bruce Verburg</FormLabel>
-              </FormField>
-            </div>
-            <Separator />
-            <FormField>
-              <FormLabel htmlFor="hoeveel-personen">
-                Hoeveel personen - inclusief uzelf - wonen er na uw verhuizing op het nieuwe adres? *
-              </FormLabel>
-              <br />
-              <Textbox id="hoeveel-personen" required type="number" />
-            </FormField>
-            <div role="radiogroup" aria-labelledby="wat-is-uw-nieuwe-woonsituatie-label" data-rating-value="">
-              <Heading4 id="wat-is-uw-nieuwe-woonsituatie-label">Wat is uw nieuwe woonsituatie? *</Heading4>
-              <FormField>
-                <RadioButton id="1" name="wat-is-uw-nieuwe-woonsituatie" />
-                <FormLabel htmlFor="1">Ik ben (mede-)eigenaar van de woning/appartement/studio</FormLabel>
-              </FormField>
-              <FormField>
-                <RadioButton id="2" name="wat-is-uw-nieuwe-woonsituatie" />
-                <FormLabel htmlFor="2">
-                  Ik ben (mede-)huurder van de woning/appartement/studio en heb een huurcontract
+                <FormLabel htmlFor="hoeveel-personen">
+                  Hoeveel personen - inclusief uzelf - wonen er na uw verhuizing op het nieuwe adres? *
                 </FormLabel>
+                <br />
+                <Textbox id="hoeveel-personen" required type="number" />
               </FormField>
-              <FormField>
-                <RadioButton id="3" name="wat-is-uw-nieuwe-woonsituatie" />
-                <FormLabel htmlFor="3">
-                  Ik huur een deel van de woning (kamer/verdieping) en heb een huurcontact
-                </FormLabel>
-              </FormField>
-              <FormField>
-                <RadioButton id="4" name="wat-is-uw-nieuwe-woonsituatie" />
-                <FormLabel htmlFor="4">Ik ga bij iemand in huis wonen en heb geen huurcontract</FormLabel>
-              </FormField>
-            </div>
-          </Fieldset>
-          <Link href="/">VORIGE</Link>
-          <Button type="submit" appearance="primary-action-button">
-            VOLGENDE
-          </Button>
-        </form>
-      </section>
-    </PageContent>
-    <PageFooter />
-  </Page>
-);
-
-export const Three = Template.bind({});
+              <div role="radiogroup" aria-labelledby="wat-is-uw-nieuwe-woonsituatie-label" data-rating-value="">
+                <Heading4 id="wat-is-uw-nieuwe-woonsituatie-label">Wat is uw nieuwe woonsituatie? *</Heading4>
+                <FormField>
+                  <RadioButton id="1" name="wat-is-uw-nieuwe-woonsituatie" />
+                  <FormLabel htmlFor="1">Ik ben (mede-)eigenaar van de woning/appartement/studio</FormLabel>
+                </FormField>
+                <FormField>
+                  <RadioButton id="2" name="wat-is-uw-nieuwe-woonsituatie" />
+                  <FormLabel htmlFor="2">
+                    Ik ben (mede-)huurder van de woning/appartement/studio en heb een huurcontract
+                  </FormLabel>
+                </FormField>
+                <FormField>
+                  <RadioButton id="3" name="wat-is-uw-nieuwe-woonsituatie" />
+                  <FormLabel htmlFor="3">
+                    Ik huur een deel van de woning (kamer/verdieping) en heb een huurcontact
+                  </FormLabel>
+                </FormField>
+                <FormField>
+                  <RadioButton id="4" name="wat-is-uw-nieuwe-woonsituatie" />
+                  <FormLabel htmlFor="4">Ik ga bij iemand in huis wonen en heb geen huurcontract</FormLabel>
+                </FormField>
+              </div>
+            </Fieldset>
+            <Link href="/">VORIGE</Link>
+            <Button type="submit" appearance="primary-action-button">
+              VOLGENDE
+            </Button>
+          </form>
+        </section>
+      </PageContent>
+      <PageFooter />
+    </Page>
+  ),
+};

--- a/packages/storybook-react/src/stories/template/PageStep-4.stories.tsx
+++ b/packages/storybook-react/src/stories/template/PageStep-4.stories.tsx
@@ -35,171 +35,173 @@ const meta = {
   title: 'Template/Multistep form/Step 4',
   id: 'template-form-pages-step-4',
   component: Page,
-} as Meta<typeof Page>;
+} satisfies Meta<typeof Page>;
 
 export default meta;
 
-const Template: StoryObj<typeof Page> = (args) => (
-  <Page {...args}>
-    <PageHeader>
-      <Link href="/">
-        <UtrechtLogo />
-      </Link>
-    </PageHeader>
-    <PageContent style={{ '--utrecht-space-around': 1 } as any}>
-      <UtrechtBreadcrumb
-        json={JSON.stringify([
-          { href: 'https://example/', title: 'Home', current: false },
-          { href: 'https://example/', title: 'Online loket', current: true },
-        ])}
-        variant="arrows"
-      />
+type Story = StoryObj<typeof meta>;
 
-      <aside>
-        <Heading3>MIJN LOKET</Heading3>
-        <UtrechtDigidButton>
-          <ButtonLink appearance="primary-action-button">
-            Uitloggen
-            <UtrechtIconArrow />
-          </ButtonLink>
-        </UtrechtDigidButton>
-        <Paragraph>Mevrouw Cindy</Paragraph>
-        <br />
-        <br />
-      </aside>
-      <Heading1>
-        <Paragraph lead>ONLINE LOKET</Paragraph>
-        Een verhuizing doorgeven
-      </Heading1>
-      <Heading2>Controleren en versturen</Heading2>
-      <Paragraph>
-        Bijna klaar! Controleer hieronder of alle gegevens kloppen. Als alles is zoals het moet, zet dan onderaan een
-        vinkje en verstuur het formulier.
-      </Paragraph>
-      <section>
-        <Heading2>Uw gegevens</Heading2>
-        <Heading3>PERSOONSGEGEVENS</Heading3>
-        <DataList appearance="rows">
-          <DataListItem>
-            <DataListKey>Burgerservicenummer</DataListKey>
-            <DataListValue>298272921</DataListValue>
-          </DataListItem>
-          <DataListItem>
-            <DataListKey>Aanhef</DataListKey>
-            <DataListValue>Vrouw</DataListValue>
-          </DataListItem>
-          <DataListItem>
-            <DataListKey>Voorletter(s)</DataListKey>
-            <DataListValue notranslate>C.</DataListValue>
-          </DataListItem>
-          <DataListItem>
-            <DataListKey>Tussenvoegsel(s)</DataListKey>
-            <DataListValue notranslate></DataListValue>
-          </DataListItem>
-          <DataListItem>
-            <DataListKey>Achternaam</DataListKey>
-            <DataListValue notranslate>Verburg</DataListValue>
-          </DataListItem>
-        </DataList>
-        <Separator />
-        <Heading3>ADRESGEGEVENS</Heading3>
-        <DataList appearance="rows">
-          <DataListItem>
-            <DataListKey>Straatnaam</DataListKey>
-            <DataListValue notranslate>Stadskantoor</DataListValue>
-          </DataListItem>
-          <DataListItem>
-            <DataListKey>Huisnummer</DataListKey>
-            <DataListValue>1</DataListValue>
-          </DataListItem>
-          <DataListItem>
-            <DataListKey>Huisletter</DataListKey>
-            <DataListValue notranslate></DataListValue>
-          </DataListItem>
-          <DataListItem>
-            <DataListKey>Huisnummertoevoeging</DataListKey>
-            <DataListValue notranslate></DataListValue>
-          </DataListItem>
-          <DataListItem>
-            <DataListKey>Postcode</DataListKey>
-            <DataListValue notranslate>3521AZ</DataListValue>
-          </DataListItem>
-          <DataListItem>
-            <DataListKey>Woonplaats</DataListKey>
-            <DataListValue notranslate>Utrecht</DataListValue>
-          </DataListItem>
-        </DataList>
-        <Separator />
-        <Heading3>Contactgegevens</Heading3>
-        <DataList appearance="rows">
-          <DataListItem>
-            <DataListKey>Telefoonnummmer</DataListKey>
-            <DataListValue>0612345678</DataListValue>
-          </DataListItem>
-          <DataListItem>
-            <DataListKey>E-mailadres</DataListKey>
-            <DataListValue notranslate>
-              <URLValue>example@example.com</URLValue>
-            </DataListValue>
-          </DataListItem>
-        </DataList>
-        <Separator />
-        <Heading3>De verhuizing</Heading3>
-        <DataList appearance="rows">
-          <DataListItem>
-            <DataListKey>Verhuisdatum</DataListKey>
-            <DataListValue>11-08-2022</DataListValue>
-          </DataListItem>
-        </DataList>
-        <Separator />
-        <Heading3>Nieuwe Adres</Heading3>
-        <DataList appearance="rows">
-          <DataListItem>
-            <DataListKey>Postcode</DataListKey>
-            <DataListValue notranslate>3521AZ</DataListValue>
-          </DataListItem>
-          <DataListItem>
-            <DataListKey>Huisnummer</DataListKey>
-            <DataListValue>1</DataListValue>
-          </DataListItem>
-          <DataListItem>
-            <DataListKey>Selecteer uw nieuwe adres</DataListKey>
-            <DataListValue notranslate>Stadsplateau 1</DataListValue>
-          </DataListItem>
-        </DataList>
-        <Separator />
-        <Heading3>Woonsituatie</Heading3>
-        <DataList appearance="rows">
-          <DataListItem>
-            <DataListKey>
-              Hoeveel personen - inclusief uzelf - wonen er na uw verhuizing op het nieuwe adres?
-            </DataListKey>
-            <DataListValue>3</DataListValue>
-          </DataListItem>
-          <DataListItem>
-            <DataListKey>Wat is uw nieuwe woonsituatie?</DataListKey>
-            <DataListValue>Ik ben (mede-)eigenaar van de woning/appartement/studio</DataListValue>
-          </DataListItem>
-        </DataList>
-      </section>
-      <Separator />
-      <Fieldset>
-        <FieldsetLegend>AKKOORD EN VERSTUREN</FieldsetLegend>
-        <form>
-          <FormField>
-            <Checkbox id="akkoord" />
-            <FormLabel htmlFor="akkoord">Ja, ik heb alles juist ingevuld.</FormLabel>
-          </FormField>
-          <Button appearance="primary-action-button" disabled type="submit">
-            Versturen
-            <UtrechtIconArrow />
-          </Button>
-        </form>
-      </Fieldset>
-      <Link href="/">VORIGE</Link>
-    </PageContent>
-    <PageFooter />
-  </Page>
-);
+export const Four: Story = {
+  render: (args) => (
+    <Page {...args}>
+      <PageHeader>
+        <Link href="/">
+          <UtrechtLogo />
+        </Link>
+      </PageHeader>
+      <PageContent style={{ '--utrecht-space-around': 1 } as any}>
+        <UtrechtBreadcrumb
+          json={JSON.stringify([
+            { href: 'https://example/', title: 'Home', current: false },
+            { href: 'https://example/', title: 'Online loket', current: true },
+          ])}
+          variant="arrows"
+        />
 
-export const Four = Template.bind({});
+        <aside>
+          <Heading3>MIJN LOKET</Heading3>
+          <UtrechtDigidButton>
+            <ButtonLink appearance="primary-action-button">
+              Uitloggen
+              <UtrechtIconArrow />
+            </ButtonLink>
+          </UtrechtDigidButton>
+          <Paragraph>Mevrouw Cindy</Paragraph>
+          <br />
+          <br />
+        </aside>
+        <Heading1>
+          <Paragraph lead>ONLINE LOKET</Paragraph>
+          Een verhuizing doorgeven
+        </Heading1>
+        <Heading2>Controleren en versturen</Heading2>
+        <Paragraph>
+          Bijna klaar! Controleer hieronder of alle gegevens kloppen. Als alles is zoals het moet, zet dan onderaan een
+          vinkje en verstuur het formulier.
+        </Paragraph>
+        <section>
+          <Heading2>Uw gegevens</Heading2>
+          <Heading3>PERSOONSGEGEVENS</Heading3>
+          <DataList appearance="rows">
+            <DataListItem>
+              <DataListKey>Burgerservicenummer</DataListKey>
+              <DataListValue>298272921</DataListValue>
+            </DataListItem>
+            <DataListItem>
+              <DataListKey>Aanhef</DataListKey>
+              <DataListValue>Vrouw</DataListValue>
+            </DataListItem>
+            <DataListItem>
+              <DataListKey>Voorletter(s)</DataListKey>
+              <DataListValue notranslate>C.</DataListValue>
+            </DataListItem>
+            <DataListItem>
+              <DataListKey>Tussenvoegsel(s)</DataListKey>
+              <DataListValue notranslate></DataListValue>
+            </DataListItem>
+            <DataListItem>
+              <DataListKey>Achternaam</DataListKey>
+              <DataListValue notranslate>Verburg</DataListValue>
+            </DataListItem>
+          </DataList>
+          <Separator />
+          <Heading3>ADRESGEGEVENS</Heading3>
+          <DataList appearance="rows">
+            <DataListItem>
+              <DataListKey>Straatnaam</DataListKey>
+              <DataListValue notranslate>Stadskantoor</DataListValue>
+            </DataListItem>
+            <DataListItem>
+              <DataListKey>Huisnummer</DataListKey>
+              <DataListValue>1</DataListValue>
+            </DataListItem>
+            <DataListItem>
+              <DataListKey>Huisletter</DataListKey>
+              <DataListValue notranslate></DataListValue>
+            </DataListItem>
+            <DataListItem>
+              <DataListKey>Huisnummertoevoeging</DataListKey>
+              <DataListValue notranslate></DataListValue>
+            </DataListItem>
+            <DataListItem>
+              <DataListKey>Postcode</DataListKey>
+              <DataListValue notranslate>3521AZ</DataListValue>
+            </DataListItem>
+            <DataListItem>
+              <DataListKey>Woonplaats</DataListKey>
+              <DataListValue notranslate>Utrecht</DataListValue>
+            </DataListItem>
+          </DataList>
+          <Separator />
+          <Heading3>Contactgegevens</Heading3>
+          <DataList appearance="rows">
+            <DataListItem>
+              <DataListKey>Telefoonnummmer</DataListKey>
+              <DataListValue>0612345678</DataListValue>
+            </DataListItem>
+            <DataListItem>
+              <DataListKey>E-mailadres</DataListKey>
+              <DataListValue notranslate>
+                <URLValue>example@example.com</URLValue>
+              </DataListValue>
+            </DataListItem>
+          </DataList>
+          <Separator />
+          <Heading3>De verhuizing</Heading3>
+          <DataList appearance="rows">
+            <DataListItem>
+              <DataListKey>Verhuisdatum</DataListKey>
+              <DataListValue>11-08-2022</DataListValue>
+            </DataListItem>
+          </DataList>
+          <Separator />
+          <Heading3>Nieuwe Adres</Heading3>
+          <DataList appearance="rows">
+            <DataListItem>
+              <DataListKey>Postcode</DataListKey>
+              <DataListValue notranslate>3521AZ</DataListValue>
+            </DataListItem>
+            <DataListItem>
+              <DataListKey>Huisnummer</DataListKey>
+              <DataListValue>1</DataListValue>
+            </DataListItem>
+            <DataListItem>
+              <DataListKey>Selecteer uw nieuwe adres</DataListKey>
+              <DataListValue notranslate>Stadsplateau 1</DataListValue>
+            </DataListItem>
+          </DataList>
+          <Separator />
+          <Heading3>Woonsituatie</Heading3>
+          <DataList appearance="rows">
+            <DataListItem>
+              <DataListKey>
+                Hoeveel personen - inclusief uzelf - wonen er na uw verhuizing op het nieuwe adres?
+              </DataListKey>
+              <DataListValue>3</DataListValue>
+            </DataListItem>
+            <DataListItem>
+              <DataListKey>Wat is uw nieuwe woonsituatie?</DataListKey>
+              <DataListValue>Ik ben (mede-)eigenaar van de woning/appartement/studio</DataListValue>
+            </DataListItem>
+          </DataList>
+        </section>
+        <Separator />
+        <Fieldset>
+          <FieldsetLegend>AKKOORD EN VERSTUREN</FieldsetLegend>
+          <form>
+            <FormField>
+              <Checkbox id="akkoord" />
+              <FormLabel htmlFor="akkoord">Ja, ik heb alles juist ingevuld.</FormLabel>
+            </FormField>
+            <Button appearance="primary-action-button" disabled type="submit">
+              Versturen
+              <UtrechtIconArrow />
+            </Button>
+          </form>
+        </Fieldset>
+        <Link href="/">VORIGE</Link>
+      </PageContent>
+      <PageFooter />
+    </Page>
+  ),
+};

--- a/packages/storybook-react/src/stories/template/PageStepLogin.stories.tsx
+++ b/packages/storybook-react/src/stories/template/PageStepLogin.stories.tsx
@@ -23,47 +23,49 @@ const meta = {
   title: 'Template/DigiD login page',
   id: 'template-form-pages-step-login',
   component: Page,
-} as Meta<typeof Page>;
+} satisfies Meta<typeof Page>;
 
 export default meta;
 
-const Template: StoryObj<typeof Page> = () => (
-  <Page>
-    <PageHeader>
-      <Link href="/">
-        <UtrechtLogo />
-      </Link>
-    </PageHeader>
-    <PageContent style={{ '--utrecht-space-around': 1 } as any}>
-      <UtrechtBreadcrumb
-        json={JSON.stringify([
-          { href: 'https://example/', title: 'Home', current: false },
-          { href: 'https://example/', title: 'Online loket', current: true },
-        ])}
-        variant="arrows"
-      />
-      <Heading1>Inloggen</Heading1>
-      <Paragraph>Log in met uw DigiD om verder to gaan</Paragraph>
-      <UtrechtDigidButton>
-        <ButtonLink appearance="primary-action-button">
-          Inloggen met DigiD <UtrechtIconArrow />
-        </ButtonLink>
-      </UtrechtDigidButton>
-      <Separator />
-      <aside>
-        <Heading2>Uitleg over DigiD?</Heading2>
-        <Paragraph>
-          Vindt u DigiD ingewikkeld? Bekijk dan deze
-          <Link href="https://www.uabc.nl/?osc=uabc">uitleg over DigiD.</Link>
-        </Paragraph>
-      </aside>
-      <Separator />
-      <Link external href="https://www.kcmsurvey.com/qSwudd733b9c27c2e91ba8c7b598MaSd?webpagina=Inloggen">
-        <UtrechtIconArrow /> Wat vindt u van deze pagina?
-      </Link>
-    </PageContent>
-    <PageFooter />
-  </Page>
-);
+type Story = StoryObj<typeof meta>;
 
-export const Login = Template.bind({});
+export const Login: Story = {
+  render: () => (
+    <Page>
+      <PageHeader>
+        <Link href="/">
+          <UtrechtLogo />
+        </Link>
+      </PageHeader>
+      <PageContent style={{ '--utrecht-space-around': 1 } as any}>
+        <UtrechtBreadcrumb
+          json={JSON.stringify([
+            { href: 'https://example/', title: 'Home', current: false },
+            { href: 'https://example/', title: 'Online loket', current: true },
+          ])}
+          variant="arrows"
+        />
+        <Heading1>Inloggen</Heading1>
+        <Paragraph>Log in met uw DigiD om verder to gaan</Paragraph>
+        <UtrechtDigidButton>
+          <ButtonLink appearance="primary-action-button">
+            Inloggen met DigiD <UtrechtIconArrow />
+          </ButtonLink>
+        </UtrechtDigidButton>
+        <Separator />
+        <aside>
+          <Heading2>Uitleg over DigiD?</Heading2>
+          <Paragraph>
+            Vindt u DigiD ingewikkeld? Bekijk dan deze
+            <Link href="https://www.uabc.nl/?osc=uabc">uitleg over DigiD.</Link>
+          </Paragraph>
+        </aside>
+        <Separator />
+        <Link external href="https://www.kcmsurvey.com/qSwudd733b9c27c2e91ba8c7b598MaSd?webpagina=Inloggen">
+          <UtrechtIconArrow /> Wat vindt u van deze pagina?
+        </Link>
+      </PageContent>
+      <PageFooter />
+    </Page>
+  ),
+};

--- a/packages/storybook-react/src/stories/util.tsx
+++ b/packages/storybook-react/src/stories/util.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { StoryObj } from '@storybook/react';
 import { ComponentTokensSection } from '@utrecht/documentation/components/ComponentTokensSection.jsx';
 import React from 'react';
 
@@ -19,17 +19,13 @@ interface Props {
   tokens: DesignToken[];
 }
 
-interface DesignTokenStoryParameters {
+export interface DesignTokenStoryParameters {
   tokens: DesignToken[];
   tokensPrefix: string;
   definition: DesignTokenTree;
 }
 
-export const designTokenStory = <T,>(
-  meta: Meta<T> & {
-    parameters: DesignTokenStoryParameters;
-  },
-) => {
+export const designTokenStory = (meta: any): any => {
   const DesignTokensStory: StoryObj<Props> = {
     args: {
       tokens: meta.parameters['tokens'],

--- a/packages/storybook-react/src/utrecht-design-tokens.d.ts
+++ b/packages/storybook-react/src/utrecht-design-tokens.d.ts
@@ -1,0 +1,7 @@
+import 'react';
+
+declare module 'react' {
+  export interface CSSProperties {
+    [key: `--utrecht-${string}`]: string | number | undefined;
+  }
+}


### PR DESCRIPTION
Still some errors remaining, mostly to do with `subcomponents` and with `render: ...` typing:

```text
Found 89 errors in 13 files.

Errors  Files
     1  ../../node_modules/.pnpm/markdown-to-jsx@7.1.8_react@18.2.0/node_modules/markdown-to-jsx/dist/index.d.ts:53
     1  src/stories/AlternateLangNav.stories.tsx:16
     1  src/stories/ButtonGroup.stories.tsx:13
     3  src/stories/FormField.stories.tsx:22
    13  src/stories/FormFieldCheckbox.stories.tsx:85
    18  src/stories/FormFieldCheckboxGroup.stories.tsx:74
    15  src/stories/FormFieldRadioGroup.stories.tsx:74
    13  src/stories/FormFieldText.stories.tsx:78
     2  src/stories/Icon.stories.tsx:21
     6  src/stories/Page.stories.tsx:17
     2  src/stories/RadioButton.stories.tsx:14
    13  src/stories/Select.stories.tsx:84
     1  src/stories/util.tsx:2
```