### PR TITLE
docs: fix hot module reloading (HMR) in React Storybook

### DIFF
--- a/packages/storybook-react/src/stories/Accordion.stories.tsx
+++ b/packages/storybook-react/src/stories/Accordion.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { AccordionProvider } from '@utrecht/component-library-react/dist/css-module';
+import { AccordionProvider } from '@utrecht/component-library-react/src/css-module';
 import readme from '@utrecht/components/accordion/README.md?raw';
 import tokensDefinition from '@utrecht/components/accordion/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/Alert.stories.tsx
+++ b/packages/storybook-react/src/stories/Alert.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/blocks';
 import type { Meta, StoryObj } from '@storybook/react';
-import { Alert, Heading1, Paragraph } from '@utrecht/component-library-react/dist/css-module/index';
+import { Alert, Heading1, Paragraph } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/alert/README.md?raw';
 import tokensDefinition from '@utrecht/components/alert/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/AlertDialog.stories.tsx
+++ b/packages/storybook-react/src/stories/AlertDialog.stories.tsx
@@ -1,13 +1,7 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { AlertDialogProps } from '@utrecht/component-library-react/dist/AlertDialog';
-import {
-  AlertDialog,
-  Button,
-  ButtonGroup,
-  Paragraph,
-  PrimaryActionButton,
-} from '@utrecht/component-library-react/dist/css-module';
+import { AlertDialog, Button, ButtonGroup, Paragraph, PrimaryActionButton } from '@utrecht/component-library-react/src';
+import { AlertDialogProps } from '@utrecht/component-library-react/src/css-module/AlertDialog';
 import readme from '@utrecht/components/alert-dialog/README.md?raw';
 import tokensDefinition from '@utrecht/components/alert-dialog/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/AlternateLangNav.stories.tsx
+++ b/packages/storybook-react/src/stories/AlternateLangNav.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { ButtonGroup, Heading, Link, LinkButton } from '@utrecht/component-library-react/dist/css-module/index';
+import { ButtonGroup, Heading, Link, LinkButton } from '@utrecht/component-library-react/src/css-module/index';
 import tokensDefinition from '@utrecht/components/alert-dialog/tokens.json';
 import readme from '@utrecht/components/alternate-lang-nav/README.md?raw';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/Article.stories.tsx
+++ b/packages/storybook-react/src/stories/Article.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/blocks';
 import { Meta, StoryObj } from '@storybook/react';
-import { Article, Heading1, Paragraph } from '@utrecht/component-library-react/dist/css-module/index';
+import { Article, Heading1, Paragraph } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/article/README.md?raw';
 import tokensDefinition from '@utrecht/components/article/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/Backdrop.stories.tsx
+++ b/packages/storybook-react/src/stories/Backdrop.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/blocks';
 import { Meta, StoryObj } from '@storybook/react';
-import { AlertDialog, Backdrop, Button, Paragraph } from '@utrecht/component-library-react/dist/css-module/index';
+import { AlertDialog, Backdrop, Button, Paragraph } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/backdrop/README.md?raw';
 import tokensDefinition from '@utrecht/components/backdrop/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/BadgeCounter.stories.tsx
+++ b/packages/storybook-react/src/stories/BadgeCounter.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { BadgeCounter, Paragraph } from '@utrecht/component-library-react/dist/css-module/index';
+import { BadgeCounter, Paragraph } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/badge-counter/README.md?raw';
 import tokensDefinition from '@utrecht/components/badge-counter/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/BadgeList.stories.tsx
+++ b/packages/storybook-react/src/stories/BadgeList.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { BadgeList, DataBadge } from '@utrecht/component-library-react/dist/css-module/index';
+import { BadgeList, DataBadge } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/badge-list/README.md?raw';
 import tokensDefinition from '@utrecht/components/badge-list/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/BreadcrumbNav.stories.tsx
+++ b/packages/storybook-react/src/stories/BreadcrumbNav.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { BreadcrumbLink, BreadcrumbNav } from '@utrecht/component-library-react/dist/css-module/index';
+import { BreadcrumbLink, BreadcrumbNav } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/breadcrumb/README.md?raw';
 import tokensDefinition from '@utrecht/components/breadcrumb/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/Button.stories.tsx
+++ b/packages/storybook-react/src/stories/Button.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { Button } from '@utrecht/component-library-react/dist/css-module/index';
+import { Button } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/button/README.md?raw';
 import tokensDefinition from '@utrecht/components/button/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/ButtonGroup.stories.tsx
+++ b/packages/storybook-react/src/stories/ButtonGroup.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/blocks';
 import { Meta, StoryObj } from '@storybook/react';
-import { Button, ButtonGroup } from '@utrecht/component-library-react/dist/css-module/index';
+import { Button, ButtonGroup } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/button-group/README.md?raw';
 import tokensDefinition from '@utrecht/components/button-group/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/ButtonLink.stories.tsx
+++ b/packages/storybook-react/src/stories/ButtonLink.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { ButtonLink } from '@utrecht/component-library-react/dist/css-module/index';
+import { ButtonLink } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/button-link/README.md?raw';
 import tokensDefinition from '@utrecht/components/button-link/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/Calendar.stories.tsx
+++ b/packages/storybook-react/src/stories/Calendar.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { Calendar } from '@utrecht/component-library-react/dist/css-module';
+import { Calendar } from '@utrecht/component-library-react/src';
 import tokensDefinition from '@utrecht/components/calendar/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
 import { addDays, addWeeks, addYears } from 'date-fns';

--- a/packages/storybook-react/src/stories/Checkbox.stories.tsx
+++ b/packages/storybook-react/src/stories/Checkbox.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { Checkbox } from '@utrecht/component-library-react/dist/css-module/index';
+import { Checkbox } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/checkbox/README.md?raw';
 import tokensDefinition from '@utrecht/components/checkbox/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/Code.stories.tsx
+++ b/packages/storybook-react/src/stories/Code.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/blocks';
 import { Meta, StoryObj } from '@storybook/react';
-import { Code } from '@utrecht/component-library-react/dist/css-module/index';
+import { Code } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/code/README.md?raw';
 import tokensDefinition from '@utrecht/components/code/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/CodeBlock.stories.tsx
+++ b/packages/storybook-react/src/stories/CodeBlock.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/blocks';
 import { Meta, StoryObj } from '@storybook/react';
-import { CodeBlock } from '@utrecht/component-library-react/dist/css-module/index';
+import { CodeBlock } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/code-block/README.md?raw';
 import tokensDefinition from '@utrecht/components/code-block/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/ColorSample.stories.tsx
+++ b/packages/storybook-react/src/stories/ColorSample.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { ColorSample } from '@utrecht/component-library-react/dist/css-module/index';
+import { ColorSample } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/color-sample/README.md?raw';
 import tokensDefinition from '@utrecht/components/color-sample/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/DataBadge.stories.tsx
+++ b/packages/storybook-react/src/stories/DataBadge.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { DataBadge, Paragraph } from '@utrecht/component-library-react/dist/css-module/index';
+import { DataBadge, Paragraph } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/badge-data/README.md?raw';
 import tokensDefinition from '@utrecht/components/badge-data/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/DataList.stories.tsx
+++ b/packages/storybook-react/src/stories/DataList.stories.tsx
@@ -5,7 +5,7 @@ import {
   DataListItem,
   DataListKey,
   DataListValue,
-} from '@utrecht/component-library-react/dist/css-module/index';
+} from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/data-list/README.md?raw';
 import tokensDefinition from '@utrecht/components/data-list/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/DataListValue.stories.tsx
+++ b/packages/storybook-react/src/stories/DataListValue.stories.tsx
@@ -1,10 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
-import {
-  DataList,
-  DataListItem,
-  DataListValue,
-  URLValue,
-} from '@utrecht/component-library-react/dist/css-module/index';
+import { DataList, DataListItem, DataListValue, URLValue } from '@utrecht/component-library-react/src/css-module/index';
 import React from 'react';
 
 const meta = {

--- a/packages/storybook-react/src/stories/Document.stories.tsx
+++ b/packages/storybook-react/src/stories/Document.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { Article, Document, Heading1, Paragraph } from '@utrecht/component-library-react/dist/css-module/index';
+import { Article, Document, Heading1, Paragraph } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/document/README.md?raw';
 import tokensDefinition from '@utrecht/components/document/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/Emphasis.stories.tsx
+++ b/packages/storybook-react/src/stories/Emphasis.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { Emphasis, Paragraph } from '@utrecht/component-library-react/dist/css-module/index';
+import { Emphasis, Paragraph } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/emphasis/README.md?raw';
 import tokensDefinition from '@utrecht/components/emphasis/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/Figure.stories.tsx
+++ b/packages/storybook-react/src/stories/Figure.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Args, Meta, StoryObj } from '@storybook/react';
-import { Figure, FigureCaption, Image, Link } from '@utrecht/component-library-react/dist/css-module/index';
+import { Figure, FigureCaption, Image, Link } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/figure/README.md?raw';
 import tokensDefinition from '@utrecht/components/figure/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/FormField.stories.tsx
+++ b/packages/storybook-react/src/stories/FormField.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { FormField, Paragraph, Textbox } from '@utrecht/component-library-react/dist/css-module/index';
+import { FormField, Paragraph, Textbox } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/form-field/README.md?raw';
 import tokensDefinition from '@utrecht/components/form-field/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/FormFieldCheckbox.stories.tsx
+++ b/packages/storybook-react/src/stories/FormFieldCheckbox.stories.tsx
@@ -5,7 +5,7 @@ import {
   FormFieldDescription,
   FormLabel,
   Paragraph,
-} from '@utrecht/component-library-react/dist/css-module/index';
+} from '@utrecht/component-library-react/src/css-module/index';
 import React from 'react';
 import FormFieldMeta from './FormField.stories';
 

--- a/packages/storybook-react/src/stories/FormLabel.stories.tsx
+++ b/packages/storybook-react/src/stories/FormLabel.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { FormLabel } from '@utrecht/component-library-react/dist/css-module/index';
+import { FormLabel } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/form-label/README.md?raw';
 import tokensDefinition from '@utrecht/components/form-label/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/HTMLContent.stories.tsx
+++ b/packages/storybook-react/src/stories/HTMLContent.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { HTMLContent } from '@utrecht/component-library-react/dist/css-module/index';
+import { HTMLContent } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/html-content/README.md?raw';
 import React from 'react';
 

--- a/packages/storybook-react/src/stories/Heading.stories.tsx
+++ b/packages/storybook-react/src/stories/Heading.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { Heading } from '@utrecht/component-library-react/dist/css-module/index';
+import { Heading } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/heading/README.md?raw';
 import tokensDefinition from '@utrecht/components/heading/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/Heading1.stories.tsx
+++ b/packages/storybook-react/src/stories/Heading1.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { Heading1 } from '@utrecht/component-library-react/dist/css-module/index';
+import { Heading1 } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/heading-1/README.md?raw';
 import tokensDefinition from '@utrecht/components/heading-1/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/Heading2.stories.tsx
+++ b/packages/storybook-react/src/stories/Heading2.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { Heading2 } from '@utrecht/component-library-react/dist/css-module/index';
+import { Heading2 } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/heading-2/README.md?raw';
 import tokensDefinition from '@utrecht/components/heading-2/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/Heading3.stories.tsx
+++ b/packages/storybook-react/src/stories/Heading3.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { Heading3 } from '@utrecht/component-library-react/dist/css-module/index';
+import { Heading3 } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/heading-3/README.md?raw';
 import tokensDefinition from '@utrecht/components/heading-3/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/Heading4.stories.tsx
+++ b/packages/storybook-react/src/stories/Heading4.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { Heading4 } from '@utrecht/component-library-react/dist/css-module/index';
+import { Heading4 } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/heading-4/README.md?raw';
 import tokensDefinition from '@utrecht/components/heading-4/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/Heading5.stories.tsx
+++ b/packages/storybook-react/src/stories/Heading5.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { Heading5 } from '@utrecht/component-library-react/dist/css-module/index';
+import { Heading5 } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/heading-5/README.md?raw';
 import tokensDefinition from '@utrecht/components/heading-5/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/Heading6.stories.tsx
+++ b/packages/storybook-react/src/stories/Heading6.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { Heading6 } from '@utrecht/component-library-react/dist/css-module/index';
+import { Heading6 } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/heading-6/README.md?raw';
 import tokensDefinition from '@utrecht/components/heading-6/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/HeadingGroup.stories.tsx
+++ b/packages/storybook-react/src/stories/HeadingGroup.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { Heading1, HeadingGroup, Paragraph, PreHeading } from '@utrecht/component-library-react/dist/css-module/index';
+import { Heading1, HeadingGroup, Paragraph, PreHeading } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/heading-group/README.md?raw';
 import tokensDefinition from '@utrecht/components/heading-group/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/Icon.stories.tsx
+++ b/packages/storybook-react/src/stories/Icon.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { Icon } from '@utrecht/component-library-react/dist/css-module/index';
+import { Icon } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/icon/README.md?raw';
 import tokensDefinition from '@utrecht/components/icon/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/Image.stories.tsx
+++ b/packages/storybook-react/src/stories/Image.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { Image } from '@utrecht/component-library-react/dist/css-module/index';
+import { Image } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/img/README.md?raw';
 import tokensDefinition from '@utrecht/components/img/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/Link.stories.tsx
+++ b/packages/storybook-react/src/stories/Link.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { Link } from '@utrecht/component-library-react/dist/css-module/index';
+import { Link } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/link/README.md?raw';
 import tokensDefinition from '@utrecht/components/link/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/LinkSocial.stories.tsx
+++ b/packages/storybook-react/src/stories/LinkSocial.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { LinkSocial } from '@utrecht/component-library-react/dist/css-module/index';
+import { LinkSocial } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/link-social/README.md?raw';
 import tokensDefinition from '@utrecht/components/link-social/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/ListSocial.stories.tsx
+++ b/packages/storybook-react/src/stories/ListSocial.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { LinkSocial, ListSocial, ListSocialItem } from '@utrecht/component-library-react/dist/css-module/index';
+import { LinkSocial, ListSocial, ListSocialItem } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/list-social/README.md?raw';
 import tokensDefinition from '@utrecht/components/list-social/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/Mark.stories.tsx
+++ b/packages/storybook-react/src/stories/Mark.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/blocks';
 import { Meta, StoryObj } from '@storybook/react';
-import { Mark } from '@utrecht/component-library-react/dist/css-module/index';
+import { Mark } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/mark/README.md?raw';
 import tokensDefinition from '@utrecht/components/mark/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/NumberValue.stories.tsx
+++ b/packages/storybook-react/src/stories/NumberValue.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { NumberValue } from '@utrecht/component-library-react/dist/css-module/index';
+import { NumberValue } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/value-number/README.md?raw';
 import React from 'react';
 

--- a/packages/storybook-react/src/stories/OrderedList.stories.tsx
+++ b/packages/storybook-react/src/stories/OrderedList.stories.tsx
@@ -1,7 +1,7 @@
 // performance optimizations are not relevant for story rendering, ignore ESLint
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { OrderedList, OrderedListItem } from '@utrecht/component-library-react/dist/css-module/index';
+import { OrderedList, OrderedListItem } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/ordered-list/README.md?raw';
 import tokensDefinition from '@utrecht/components/ordered-list/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/OrderedListItem.stories.tsx
+++ b/packages/storybook-react/src/stories/OrderedListItem.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { OrderedList, OrderedListItem } from '@utrecht/component-library-react/dist/css-module/index';
+import { OrderedList, OrderedListItem } from '@utrecht/component-library-react/src/css-module/index';
 import React from 'react';
 
 const meta = {

--- a/packages/storybook-react/src/stories/Page.stories.tsx
+++ b/packages/storybook-react/src/stories/Page.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { Page } from '@utrecht/component-library-react/dist/css-module/index';
+import { Page } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/page/README.md?raw';
 import tokensDefinition from '@utrecht/components/page/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/PageContent.stories.tsx
+++ b/packages/storybook-react/src/stories/PageContent.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { PageContent, Paragraph } from '@utrecht/component-library-react/dist/css-module/index';
+import { PageContent, Paragraph } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/page-content/README.md?raw';
 import tokensDefinition from '@utrecht/components/page-content/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/PageFooter.stories.tsx
+++ b/packages/storybook-react/src/stories/PageFooter.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { PageFooter, Paragraph } from '@utrecht/component-library-react/dist/css-module/index';
+import { PageFooter, Paragraph } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/page-footer/README.md?raw';
 import tokensDefinition from '@utrecht/components/page-footer/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/PageHeader.stories.tsx
+++ b/packages/storybook-react/src/stories/PageHeader.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { Heading1, PageHeader } from '@utrecht/component-library-react/dist/css-module/index';
+import { Heading1, PageHeader } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/page-header/README.md?raw';
 import tokensDefinition from '@utrecht/components/page-header/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/Paragraph.stories.tsx
+++ b/packages/storybook-react/src/stories/Paragraph.stories.tsx
@@ -1,7 +1,7 @@
 import readme from '@nl-design-system-unstable/documentation/componenten/_paragraph.md?raw';
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/blocks';
 import { Meta, StoryObj } from '@storybook/react';
-import { Paragraph } from '@utrecht/component-library-react/dist/css-module/index';
+import { Paragraph } from '@utrecht/component-library-react/src/css-module/index';
 import tokensDefinition from '@utrecht/components/paragraph/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
 import React from 'react';

--- a/packages/storybook-react/src/stories/PreHeading.stories.tsx
+++ b/packages/storybook-react/src/stories/PreHeading.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { PreHeading } from '@utrecht/component-library-react/dist/css-module/index';
+import { PreHeading } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/pre-heading/README.md?raw';
 import tokensDefinition from '@utrecht/components/pre-heading/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/RadioButton.stories.tsx
+++ b/packages/storybook-react/src/stories/RadioButton.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { FormField, FormLabel, RadioButton } from '@utrecht/component-library-react/dist/css-module/index';
+import { FormField, FormLabel, RadioButton } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/radio-button/README.md?raw';
 import tokensDefinition from '@utrecht/components/radio-button/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/Select.stories.tsx
+++ b/packages/storybook-react/src/stories/Select.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { Select, SelectOption } from '@utrecht/component-library-react/dist/css-module/index';
+import { Select, SelectOption } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/select/README.md?raw';
 import tokensDefinition from '@utrecht/components/select/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/Separator.stories.tsx
+++ b/packages/storybook-react/src/stories/Separator.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { Separator } from '@utrecht/component-library-react/dist/css-module/index';
+import { Separator } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/separator/README.md?raw';
 import tokensDefinition from '@utrecht/components/separator/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/SkipLink.stories.tsx
+++ b/packages/storybook-react/src/stories/SkipLink.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { SkipLink } from '@utrecht/component-library-react/dist/css-module/index';
+import { SkipLink } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/skip-link/README.md?raw';
 import tokensDefinition from '@utrecht/components/skip-link/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/SpotlightSection.stories.tsx
+++ b/packages/storybook-react/src/stories/SpotlightSection.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { Heading1, Paragraph, SpotlightSection } from '@utrecht/component-library-react/dist/css-module/index';
+import { Heading1, Paragraph, SpotlightSection } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/spotlight-section/README.md?raw';
 import tokensDefinition from '@utrecht/components/spotlight-section/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/StatusBadge.stories.tsx
+++ b/packages/storybook-react/src/stories/StatusBadge.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { Paragraph, StatusBadge } from '@utrecht/component-library-react/dist/css-module/index';
+import { Paragraph, StatusBadge } from '@utrecht/component-library-react/src/css-module/index';
 import tokensDefinition from '@utrecht/components/badge-data/tokens.json';
 import readme from '@utrecht/components/badge-status/README.md?raw';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/Strong.stories.tsx
+++ b/packages/storybook-react/src/stories/Strong.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { Paragraph, Strong } from '@utrecht/component-library-react/dist/css-module/index';
+import { Paragraph, Strong } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/emphasis/README.md?raw';
 import tokensDefinition from '@utrecht/components/emphasis/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/Surface.stories.tsx
+++ b/packages/storybook-react/src/stories/Surface.stories.tsx
@@ -1,6 +1,6 @@
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { Surface } from '@utrecht/component-library-react/dist/css-module/index';
+import { Surface } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/surface/README.md?raw';
 import tokensDefinition from '@utrecht/components/surface/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/Table.stories.tsx
+++ b/packages/storybook-react/src/stories/Table.stories.tsx
@@ -8,7 +8,7 @@ import {
   TableHeader,
   TableHeaderCell,
   TableRow,
-} from '@utrecht/component-library-react/src/css-module';
+} from '@utrecht/component-library-react/src';
 import readme from '@utrecht/components/table/README.md?raw';
 import tokensDefinition from '@utrecht/components/table/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/UnorderedList.stories.tsx
+++ b/packages/storybook-react/src/stories/UnorderedList.stories.tsx
@@ -1,7 +1,7 @@
 // performance optimizations are not relevant for story rendering, ignore ESLint
 import { ArgsTable, Description, Primary, PRIMARY_STORY, Stories } from '@storybook/addon-docs';
 import { Meta, StoryObj } from '@storybook/react';
-import { UnorderedList, UnorderedListItem } from '@utrecht/component-library-react/dist/css-module/index';
+import { UnorderedList, UnorderedListItem } from '@utrecht/component-library-react/src/css-module/index';
 import readme from '@utrecht/components/unordered-list/README.md?raw';
 import tokensDefinition from '@utrecht/components/unordered-list/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';

--- a/packages/storybook-react/src/stories/UnorderedListItem.stories.tsx
+++ b/packages/storybook-react/src/stories/UnorderedListItem.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { UnorderedList, UnorderedListItem } from '@utrecht/component-library-react/dist/css-module/index';
+import { UnorderedList, UnorderedListItem } from '@utrecht/component-library-react/src/css-module/index';
 import React from 'react';
 
 const meta = {

--- a/packages/storybook-react/src/stories/template/PageStep-1.stories.tsx
+++ b/packages/storybook-react/src/stories/template/PageStep-1.stories.tsx
@@ -19,7 +19,7 @@ import {
   Paragraph,
   Separator,
   Textbox,
-} from '@utrecht/component-library-react/dist/css-module';
+} from '@utrecht/component-library-react/src';
 import {
   UtrechtBreadcrumb,
   UtrechtDigidButton,


### PR DESCRIPTION
When editing the React or CSS component the story should reload automatically