### PR TITLE
ci: use frozen lockfile with new pnpm

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -23,7 +23,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 7
+          version: 8.3
           run_install: false
 
       - name: Get pnpm store directory
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pnpm install --no-frozen-lockfile
+          pnpm install --frozen-lockfile
           pnpm ls --recursive
 
   lint:
@@ -60,7 +60,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 7
+          version: 8.3
           run_install: false
 
       - name: Get pnpm store directory
@@ -77,7 +77,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pnpm install --no-frozen-lockfile
+          pnpm install --frozen-lockfile
 
       - name: "Continuous Integration: lint"
         run: |
@@ -100,7 +100,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 7
+          version: 8.3
           run_install: false
 
       - name: Get pnpm store directory
@@ -117,7 +117,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pnpm install --no-frozen-lockfile
+          pnpm install --frozen-lockfile
 
       - name: "Continuous Integration: build"
         env:
@@ -156,7 +156,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 7
+          version: 8.3
           run_install: false
 
       - name: Get pnpm store directory
@@ -173,7 +173,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pnpm install --no-frozen-lockfile
+          pnpm install --frozen-lockfile
 
       - name: "Continuous Integration: test"
         run: |
@@ -198,7 +198,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 7
+          version: 8.3
           run_install: false
 
       - name: Get pnpm store directory
@@ -215,7 +215,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pnpm install --no-frozen-lockfile
+          pnpm install --frozen-lockfile
 
       - name: "Continuous Integration: build Storybook with animation disabled"
         env:
@@ -280,7 +280,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 7
+          version: 8.3
           run_install: false
 
       - name: Get pnpm store directory
@@ -297,7 +297,7 @@ jobs:
 
       - name: "Continuous Deployment: install"
         run: |
-          pnpm install --no-frozen-lockfile
+          pnpm install --frozen-lockfile
           pnpm ls --recursive
 
       - name: "Continuous Deployment: build"


### PR DESCRIPTION
Currently the build fails:

```
lerna-lite notice cli v1.17.0
lerna-lite info versioning independent
lerna-lite info ci enabled
lerna-lite info Assuming all packages changed
lerna-lite ERR! EUNCOMMIT Working tree has uncommitted changes, please commit or remove the following changes before continuing:
lerna-lite ERR! EUNCOMMIT  M pnpm-lock.yaml
lerna-lite ERR! Working tree has uncommitted changes, please commit or remove the following changes before continuing:
lerna-lite ERR!  M pnpm-lock.yaml
 ELIFECYCLE  Command failed with exit code 1.
```