### PR TITLE
build: always specify rootDir when composite: true

### DIFF
--- a/packages/component-library-react/tsconfig.json
+++ b/packages/component-library-react/tsconfig.json
@@ -3,7 +3,7 @@
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "allowUnreachableCode": false,
-    "composite": false,
+    "composite": true,
     "declaration": true,
     "esModuleInterop": true,
     "experimentalDecorators": true,
@@ -18,6 +18,7 @@
     "noUnusedParameters": true,
     "outDir": "dist",
     "resolveJsonModule": true,
+    "rootDir": "./src/",
     "skipLibCheck": true,
     "strict": true,
     "target": "es2020"

--- a/packages/component-library-react/tsconfig.json
+++ b/packages/component-library-react/tsconfig.json
@@ -3,7 +3,7 @@
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "allowUnreachableCode": false,
-    "composite": true,
+    "composite": false,
     "declaration": true,
     "esModuleInterop": true,
     "experimentalDecorators": true,

--- a/packages/component-library-vue/tsconfig.jest.json
+++ b/packages/component-library-vue/tsconfig.jest.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "composite": true,
+    "rootDir": "./src/",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/packages/component-library-vue/tsconfig.lib.json
+++ b/packages/component-library-vue/tsconfig.lib.json
@@ -9,6 +9,7 @@
     "paths": {
       "@/*": ["./src/*"]
     },
+    "rootDir": "src/",
     "strict": true
   }
 }

--- a/packages/component-library-vue/tsconfig.vite-config.json
+++ b/packages/component-library-vue/tsconfig.vite-config.json
@@ -4,6 +4,7 @@
   "include": ["vite.config.*"],
   "compilerOptions": {
     "composite": true,
+    "rootDir": "./src/",
     "types": ["node"]
   }
 }

--- a/packages/storybook-helpers/tsconfig.json
+++ b/packages/storybook-helpers/tsconfig.json
@@ -4,7 +4,7 @@
     "composite": true,
     "esModuleInterop": true,
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "./src/"
   },
   "extends": "../../tsconfig.json",
   "include": ["src/**/*.ts"],

--- a/packages/storybook-react/tsconfig.node.json
+++ b/packages/storybook-react/tsconfig.node.json
@@ -3,6 +3,7 @@
     "composite": true,
     "module": "ESNext",
     "moduleResolution": "Node",
+    "rootDir": "./",
     "allowSyntheticDefaultImports": true
   },
   "include": ["vite.config.ts"],

--- a/packages/storybook-vue/tsconfig.node.json
+++ b/packages/storybook-vue/tsconfig.node.json
@@ -3,6 +3,7 @@
     "composite": true,
     "module": "ESNext",
     "moduleResolution": "Node",
+    "rootDir": "./",
     "allowSyntheticDefaultImports": true
   },
   "include": ["vite.config.ts"],

--- a/packages/web-component-library-vue/tsconfig.app.json
+++ b/packages/web-component-library-vue/tsconfig.app.json
@@ -7,6 +7,7 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "rootDir": "./src/"
   }
 }

--- a/packages/web-component-library-vue/tsconfig.vite-config.json
+++ b/packages/web-component-library-vue/tsconfig.vite-config.json
@@ -4,6 +4,7 @@
   "include": ["vite.config.*"],
   "compilerOptions": {
     "composite": true,
+    "rootDir": "./src/",
     "types": ["node"]
   }
 }


### PR DESCRIPTION
Bug report via Slack:

> In de laatste versies van  @utrecht/component-library-react krijg ik de volgende foutmelding wanneer ik (voor de PRA) mijn component-library-react probeer te "builden":
> `Could not find a declaration file for module '@utrecht/component-library-react/dist/css-module'.`
> In de node_modules/@utrecht/component-library-react/dist folder zie ik de componenten van Utrecht niet meer en ook zie ik het index.d.ts bestand niet.
> Klopt het dat de componenten het index.d.ts bestand in deze folder ontbreken?
> (Het lijkt te komen door de `"composite": true` in `tsconfig.json`)

Conclusie: `composite: true` stelt de `rootDir` aan in op de locatie van `tsconfig.json`, dus de file is onbedoeld verplaatst van `dist/css-module/index.d.ts` naar `dist/src/css-module/index.d.ts`.

De PR gaat expliciet de `rootDir` goed instellen voor alle TypeScript configuraties met `composite: true`.
