### PR TITLE
style: remove `letter-spacing` tokens (except for badge)

### DIFF
--- a/components/button/css/_mixin.scss
+++ b/components/button/css/_mixin.scss
@@ -226,7 +226,6 @@
   gap: var(--utrecht-button-icon-gap);
   inline-size: var(--utrecht-button-inline-size, auto);
   justify-content: center;
-  letter-spacing: var(--utrecht-button-letter-spacing);
   line-height: var(--utrecht-button-line-height);
   min-block-size: var(--utrecht-button-min-block-size, 44px);
   min-inline-size: var(--utrecht-button-min-inline-size, 44px);

--- a/components/button/tokens.json
+++ b/components/button/tokens.json
@@ -81,14 +81,6 @@
           }
         }
       },
-      "letter-spacing": {
-        "$extensions": {
-          "nl.nldesignsystem.css.property": {
-            "syntax": "<length>",
-            "inherits": true
-          }
-        }
-      },
       "line-height": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {

--- a/components/heading-1/css/_mixin.scss
+++ b/components/heading-1/css/_mixin.scss
@@ -17,7 +17,6 @@
   );
   font-size: var(--utrecht-heading-1-font-size, revert);
   font-weight: var(--utrecht-heading-1-font-weight, var(--utrecht-heading-font-weight, bold));
-  letter-spacing: var(--utrecht-heading-1-letter-spacing);
   line-height: var(--utrecht-heading-1-line-height);
   margin-block-end: calc(var(--utrecht-space-around, 0) * var(--utrecht-heading-1-margin-block-end, 0));
   margin-block-start: calc(var(--utrecht-space-around, 0) * var(--utrecht-heading-1-margin-block-start, 0));

--- a/components/heading-2/css/_mixin.scss
+++ b/components/heading-2/css/_mixin.scss
@@ -17,7 +17,6 @@
   );
   font-size: var(--utrecht-heading-2-font-size, revert);
   font-weight: var(--utrecht-heading-2-font-weight, var(--utrecht-heading-font-weight, bold));
-  letter-spacing: var(--utrecht-heading-2-letter-spacing);
   line-height: var(--utrecht-heading-2-line-height);
   margin-block-end: calc(var(--utrecht-space-around, 0) * var(--utrecht-heading-2-margin-block-end, 0));
   margin-block-start: calc(var(--utrecht-space-around, 0) * var(--utrecht-heading-2-margin-block-start, 0));

--- a/components/heading-3/css/_mixin.scss
+++ b/components/heading-3/css/_mixin.scss
@@ -17,7 +17,6 @@
   );
   font-size: var(--utrecht-heading-3-font-size, revert);
   font-weight: var(--utrecht-heading-3-font-weight, var(--utrecht-heading-font-weight, bold));
-  letter-spacing: var(--utrecht-heading-3-letter-spacing);
   line-height: var(--utrecht-heading-3-line-height);
   margin-block-end: calc(var(--utrecht-space-around, 0) * var(--utrecht-heading-3-margin-block-end, 0));
   margin-block-start: calc(var(--utrecht-space-around, 0) * var(--utrecht-heading-3-margin-block-start, 0));

--- a/components/heading-4/css/_mixin.scss
+++ b/components/heading-4/css/_mixin.scss
@@ -17,7 +17,6 @@
   );
   font-size: var(--utrecht-heading-4-font-size, revert);
   font-weight: var(--utrecht-heading-4-font-weight, var(--utrecht-heading-font-weight, bold));
-  letter-spacing: var(--utrecht-heading-4-letter-spacing);
   line-height: var(--utrecht-heading-4-line-height);
   margin-block-end: calc(var(--utrecht-space-around, 0) * var(--utrecht-heading-4-margin-block-end, 0));
   margin-block-start: calc(var(--utrecht-space-around, 0) * var(--utrecht-heading-4-margin-block-start, 0));

--- a/components/heading-5/css/_mixin.scss
+++ b/components/heading-5/css/_mixin.scss
@@ -17,7 +17,6 @@
   );
   font-size: var(--utrecht-heading-5-font-size, revert);
   font-weight: var(--utrecht-heading-5-font-weight, var(--utrecht-heading-font-weight, bold));
-  letter-spacing: var(--utrecht-heading-5-letter-spacing);
   line-height: var(--utrecht-heading-5-line-height);
   margin-block-end: calc(var(--utrecht-space-around, 0) * var(--utrecht-heading-5-margin-block-end, 0));
   margin-block-start: calc(var(--utrecht-space-around, 0) * var(--utrecht-heading-5-margin-block-start, 0));

--- a/components/heading-6/css/_mixin.scss
+++ b/components/heading-6/css/_mixin.scss
@@ -17,7 +17,6 @@
   );
   font-size: var(--utrecht-heading-6-font-size, revert);
   font-weight: var(--utrecht-heading-6-font-weight, var(--utrecht-heading-font-weight, bold));
-  letter-spacing: var(--utrecht-heading-6-letter-spacing);
   line-height: var(--utrecht-heading-6-line-height);
   margin-block-end: calc(var(--utrecht-space-around, 0) * var(--utrecht-heading-6-margin-block-end, 0));
   margin-block-start: calc(var(--utrecht-space-around, 0) * var(--utrecht-heading-6-margin-block-start, 0));

--- a/components/link-button/css/_mixin.scss
+++ b/components/link-button/css/_mixin.scss
@@ -20,7 +20,6 @@
   gap: var(--utrecht-button-icon-gap);
   inline-size: var(--utrecht-button-inline-size, auto);
   justify-content: center;
-  letter-spacing: var(--utrecht-button-letter-spacing);
   line-height: inherit;
   min-block-size: var(--utrecht-button-min-block-size, 44px);
   min-inline-size: var(--utrecht-button-min-inline-size, 44px);

--- a/components/pre-heading/css/_mixin.scss
+++ b/components/pre-heading/css/_mixin.scss
@@ -12,7 +12,6 @@
   );
   font-size: var(--utrecht-pre-heading-font-size);
   font-weight: var(--utrecht-pre-heading-font-weight, var(--utrecht-heading-font-weight, bold));
-  letter-spacing: var(--utrecht-pre-heading-letter-spacing);
   line-height: var(--utrecht-pre-heading-line-height);
   margin-block-end: calc(var(--utrecht-space-around, 0) * var(--utrecht-pre-heading-margin-block-end, 0));
   margin-block-start: calc(var(--utrecht-space-around, 0) * var(--utrecht-pre-heading-margin-block-start, 0));

--- a/components/search-bar/css/_mixin.scss
+++ b/components/search-bar/css/_mixin.scss
@@ -10,7 +10,6 @@
   --utrecht-button-hover-scale: var(--utrecht-search-bar-hover-transform);
   --utrecht-button-font-size: var(--utrecht-search-bar-button-font-size);
   --utrecht-button-font-weight: var(--utrecht-search-bar-button-font-weight);
-  --utrecht-button-letter-spacing: var(--utrecht-search-bar-button-letter-spacing);
   --utrecht-button-primary-action-background-color: var(--utrecht-search-bar-button-background-color);
   --utrecht-button-primary-action-color: var(--utrecht-search-bar-button-color);
   --utrecht-button-primary-action-hover-background-color: var(--utrecht-search-bar-button-hover-background-color);

--- a/components/search-bar/tokens.json
+++ b/components/search-bar/tokens.json
@@ -42,14 +42,6 @@
             }
           }
         },
-        "letter-spacing": {
-          "$extensions": {
-            "nl.nldesignsystem.css.property": {
-              "syntax": "<length>",
-              "inherits": true
-            }
-          }
-        },
         "hover": {
           "background-color": {
             "$extensions": {

--- a/documentation/website/huisstijl/typography.md
+++ b/documentation/website/huisstijl/typography.md
@@ -64,17 +64,6 @@ De inherit font stijl is om het overerven van een font stijl mogelijk te maken, 
 | Font style: Normal  | `--utrecht-typography-font-style-normal`  | De standaard font stijl.                               |
 | Font style: Inherit | `--utrecht-typography-font-style-inherit` | Erft de font stijl over van het bovenliggende element. |
 
-## Letter spacing
-
-We hebben een aantal letter spacings die we gebruiken om tekst leesbaarder te maken.
-
-| Beschrijving              | Design Token                                 | Opmerking                                                       |
-| ------------------------- | -------------------------------------------- | --------------------------------------------------------------- |
-| Normal                    | `--utrecht-typography-letter-spacing-normal` | Standaard gebruiken we bij alle teksten normale letter spacing. |
-| Small (0.8px of 0.05rem)  | `--utrecht-typography-letter-spacing-sm`     |                                                                 |
-| Medium (1px of 0.0625rem) | `--utrecht-typography-letter-spacing-md`     |                                                                 |
-| Large (3px of 0.1875rem)  | `--utrecht-typography-letter-spacing-lg`     |                                                                 |
-
 ## Line height
 
 We gebruiken de volgende line heights voor onze typografie:

--- a/proprietary/design-tokens/src/brand/utrecht/typography.tokens.json
+++ b/proprietary/design-tokens/src/brand/utrecht/typography.tokens.json
@@ -23,12 +23,6 @@
         "normal": { "value": "normal" },
         "inherit": { "value": "inherit" }
       },
-      "letter-spacing": {
-        "normal": { "value": "normal" },
-        "sm": { "value": "0.8px" },
-        "md": { "value": "1px" },
-        "lg": { "value": "3px" }
-      },
       "line-height": {
         "xs": { "value": "1" },
         "sm": { "value": "1.25" },

--- a/proprietary/design-tokens/src/component/utrecht/heading-1.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/heading-1.tokens.json
@@ -8,7 +8,6 @@
       "line-height": { "value": "{utrecht.typography.line-height.sm}" },
       "margin-block-end": { "value": "0.67rem" },
       "margin-block-start": { "value": "0.67rem" },
-      "letter-spacing": { "value": "{utrecht.typography.letter-spacing.normal}" },
       "text-transform": {}
     }
   }

--- a/proprietary/design-tokens/src/component/utrecht/heading-2.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/heading-2.tokens.json
@@ -8,7 +8,6 @@
       "line-height": { "value": "{utrecht.typography.line-height.sm}" },
       "margin-block-end": { "value": "0.3rem" },
       "margin-block-start": { "value": "1.5rem" },
-      "letter-spacing": { "value": "{utrecht.typography.letter-spacing.normal}" },
       "text-transform": {}
     }
   }

--- a/proprietary/design-tokens/src/component/utrecht/heading-3.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/heading-3.tokens.json
@@ -8,7 +8,6 @@
       "line-height": { "value": "{utrecht.typography.line-height.sm}" },
       "margin-block-end": { "value": "0.2rem" },
       "margin-block-start": { "value": "1rem" },
-      "letter-spacing": { "value": "{utrecht.typography.letter-spacing.normal}" },
       "text-transform": {}
     }
   }

--- a/proprietary/design-tokens/src/component/utrecht/heading-4.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/heading-4.tokens.json
@@ -8,7 +8,6 @@
       "line-height": { "value": "{utrecht.typography.line-height.md}" },
       "margin-block-end": { "value": "0.3rem" },
       "margin-block-start": { "value": "1.2rem" },
-      "letter-spacing": { "value": "{utrecht.typography.letter-spacing.normal}" },
       "text-transform": {}
     }
   }

--- a/proprietary/design-tokens/src/component/utrecht/heading-5.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/heading-5.tokens.json
@@ -7,8 +7,7 @@
       "font-weight": { "value": "{utrecht.typography.weight-scale.normal.font-weight}" },
       "line-height": { "value": "{utrecht.typography.line-height.md}" },
       "margin-block-end": { "value": "0.2rem" },
-      "margin-block-start": { "value": "1rem" },
-      "letter-spacing": { "value": "{utrecht.typography.letter-spacing.sm}" }
+      "margin-block-start": { "value": "1rem" }
     }
   }
 }

--- a/proprietary/design-tokens/src/component/utrecht/heading-6.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/heading-6.tokens.json
@@ -7,8 +7,7 @@
       "font-weight": { "value": "{utrecht.typography.weight-scale.normal.font-weight}" },
       "line-height": { "value": "{utrecht.typography.line-height.md}" },
       "margin-block-end": {},
-      "margin-block-start": {},
-      "letter-spacing": { "value": "{utrecht.typography.letter-spacing.sm}" }
+      "margin-block-start": {}
     }
   }
 }

--- a/proprietary/design-tokens/src/component/utrecht/search-bar.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/search-bar.tokens.json
@@ -17,7 +17,6 @@
         "color": { "value": "{utrecht.color.white}" },
         "font-size": { "value": "{utrecht.typography.scale.sm.font-size}" },
         "font-weight": { "value": "{utrecht.typography.weight-scale.bold.font-weight}" },
-        "letter-spacing": { "value": ".05em" },
         "hover": {
           "background-color": { "value": "hsl(359 65% 58%)" },
           "scale": { "value": "1" }


### PR DESCRIPTION
The `letter-spacing` were only used with `text-transform: uppercase`, without they should be discouraged.