### PR TITLE
style: avoid unreadable overlapping skip links

### DIFF
--- a/components/skip-link/css/_mixin.scss
+++ b/components/skip-link/css/_mixin.scss
@@ -7,10 +7,17 @@
 @import "../../common/focus/mixin";
 
 @mixin utrecht-skip-link {
+  /* Use `ButtonFace` as default `background-color`
+   * to ensure the skip link is not transparent and unreadable
+   * when CSS variables are not defined.
+   * 
+   * My only concern with this is that it makes it look like a button,
+   * and it implies the `Space` button should work, but it won't work.
+   */
   align-items: center;
-  background-color: var(--utrecht-skip-link-background-color);
+  background-color: var(--utrecht-skip-link-background-color, ButtonFace);
   box-sizing: border-box;
-  color: var(--utrecht-skip-link-color);
+  color: var(--utrecht-skip-link-color, ButtonText);
   display: inline-flex;
   justify-content: center;
   min-block-size: var(--utrecht-skip-link-min-block-size, 44px);


### PR DESCRIPTION
Use `ButtonFace` as default `background-color` to ensure the skip link is not transparent and unreadable when CSS variables are not defined.

My only concern with this is that it makes it look like a button, and it implies the `Space` button should work, but it won't work. But I consider this a smaller usability issue than no background.