### PR TITLE
fix: ensure hidden attribute still works for every HTML component

### DIFF
--- a/components/button/html/_mixin.scss
+++ b/components/button/html/_mixin.scss
@@ -14,6 +14,10 @@
     @include utrecht-button--distanced;
   }
 
+  button[hidden] {
+    display: none;
+  }
+
   button[type="submit" i],
   input[type="submit" i] {
     @include utrecht-button--submit;

--- a/components/code-block/html/_mixin.scss
+++ b/components/code-block/html/_mixin.scss
@@ -11,6 +11,10 @@
     @include utrecht-code-block;
   }
 
+  pre[hidden]:has(> code:only-child) {
+    display: none;
+  }
+
   pre:has(> code:only-child) > code {
     display: contents;
   }

--- a/components/form-fieldset/css/_reset.scss
+++ b/components/form-fieldset/css/_reset.scss
@@ -4,6 +4,7 @@
  */
 
 @mixin reset-fieldset {
+  /* `all: revert` unfortunately has as side-effect that the `hidde` attribute has no effect */
   all: revert;
   border: 0;
   margin-inline-end: 0;

--- a/components/form-fieldset/html/_mixin.scss
+++ b/components/form-fieldset/html/_mixin.scss
@@ -11,6 +11,10 @@
     @include utrecht-form-fieldset--html-fieldset;
     @include utrecht-form-fieldset--distanced;
   }
+
+  fieldset[hidden] {
+    display: none;
+  }
 }
 
 @mixin utrecht-html-legend {
@@ -18,6 +22,10 @@
     @include utrecht-form-fieldset__legend;
     @include utrecht-form-fieldset__legend--html-legend;
     @include utrecht-form-fieldset__legend--distanced;
+  }
+
+  legend[hidden] {
+    display: none;
   }
 
   fieldset:disabled > legend {

--- a/documentation/css.md
+++ b/documentation/css.md
@@ -2,6 +2,38 @@
 
 # Design system ten op zichte van CSS
 
+## `all`
+
+`all: revert` kan de `display` property aanpassen, waardoor het `hidden` HTML attribute niet werkt. Lees onder onder `display` wat een oplossing is.
+
+## `display`
+
+Het `display` attribuut overschrijft de browser stylesheet voor het `hidden` attribuut, waardoor je onverwacht gedrag hebt wanneer je `hidden` gebruikt op componenten.
+
+Wanneer je `display` gebruikt, zorg dat het `hidden` HTML attribuut nog steeds werkt. Bijvoorbeeld:
+
+```css
+.my-selector {
+  display: flex;
+}
+
+.my-selector[hidden] {
+  display: none;
+}
+```
+
+Bij web components kun je het zo doen:
+
+```css
+:host {
+  display: contents;
+}
+
+:host[hidden] {
+  display: none;
+}
+```
+
 ## `font-size`
 
 - Gebruik geen `font-size` kleiner dan `16px`.

--- a/packages/storybook-html/src/Article.stories.tsx
+++ b/packages/storybook-html/src/Article.stories.tsx
@@ -4,11 +4,15 @@ import type { Meta, StoryObj } from '@storybook/react';
 import readme from '@utrecht/components/article/README.md?raw';
 import tokensDefinition from '@utrecht/components/article/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
-import React from 'react';
+import React, { HTMLAttributes, PropsWithChildren } from 'react';
+import hiddenDocs from './_hidden.md?raw';
 import { htmlContentDecorator } from './decorator';
 import { designTokenStory } from './design-token-story';
+import { hidden } from './util/htmlArgTypes';
 
-const Article = ({ children }) => <article>{children}</article>;
+const Article = ({ children, ...restProps }: PropsWithChildren<HTMLAttributes<HTMLElement>>) => (
+  <article {...restProps}>{children}</article>
+);
 
 const meta = {
   title: 'HTML Component/Article',
@@ -19,18 +23,11 @@ const meta = {
     children: {
       description: 'Content of the article',
     },
+    hidden,
   },
   args: {
-    children: [
-      <h1>Lorem ipsum</h1>,
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
-        magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-        pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
-        laborum.
-      </p>,
-    ],
+    children: '',
+    hidden: false,
   },
   tags: ['autodocs'],
   parameters: {
@@ -53,10 +50,36 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
+  args: {
+    children: [
+      <h1>Lorem ipsum</h1>,
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+        magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+        pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
+        laborum.
+      </p>,
+    ],
+  },
   parameters: {
     docs: {
       description: {
         story: 'Markup using the `<article>` element.',
+      },
+    },
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    ...Default.args,
+    hidden: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: hiddenDocs,
       },
     },
   },

--- a/packages/storybook-html/src/Blockquote.stories.tsx
+++ b/packages/storybook-html/src/Blockquote.stories.tsx
@@ -4,11 +4,13 @@ import type { Meta, StoryObj } from '@storybook/react';
 import readme from '@utrecht/components/blockquote/README.md?raw';
 import tokensDefinition from '@utrecht/components/blockquote/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
-import React from 'react';
+import React, { HTMLAttributes, PropsWithChildren } from 'react';
+import hiddenDocs from './_hidden.md?raw';
 import { htmlContentDecorator } from './decorator';
 import { designTokenStory } from './design-token-story';
+import { hidden } from './util/htmlArgTypes';
 
-const Blockquote = ({ children }) => <blockquote>{children}</blockquote>;
+const Blockquote = ({ ...restProps }: PropsWithChildren<HTMLAttributes<HTMLElement>>) => <blockquote {...restProps} />;
 
 const meta = {
   title: 'HTML Component/Blockquote',
@@ -19,9 +21,11 @@ const meta = {
     children: {
       description: 'Content of the quote',
     },
+    hidden,
   },
   args: {
     children: [],
+    hidden: false,
   },
   tags: ['autodocs'],
   parameters: {
@@ -59,6 +63,20 @@ export const Default: Story = {
     docs: {
       description: {
         story: 'Markup using the `<blockquote>` element.',
+      },
+    },
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    ...Default.args,
+    hidden: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: hiddenDocs,
       },
     },
   },

--- a/packages/storybook-html/src/Button.stories.tsx
+++ b/packages/storybook-html/src/Button.stories.tsx
@@ -4,12 +4,14 @@ import type { Meta, StoryObj } from '@storybook/react';
 import readme from '@utrecht/components/button/README.md?raw';
 import tokensDefinition from '@utrecht/components/button/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
-import React from 'react';
+import React, { HTMLAttributes, PropsWithChildren } from 'react';
 import buttonDisabledTabindexMarkdown from './_button-disabled-tabindex.md?raw';
+import hiddenDocs from './_hidden.md?raw';
 import { htmlContentDecorator } from './decorator';
 import { designTokenStory } from './design-token-story';
+import { hidden } from './util/htmlArgTypes';
 
-const Button = ({ children, ...attributes }) => <button {...attributes}>{children}</button>;
+const Button = ({ ...attributes }: PropsWithChildren<HTMLAttributes<HTMLButtonElement>>) => <button {...attributes} />;
 
 const meta = {
   title: 'HTML Component/Button',
@@ -28,6 +30,7 @@ const meta = {
       description: 'Disabled',
       control: 'boolean',
     },
+    hidden,
     tabindex: {
       description: 'Tabindex',
       control: 'boolean',
@@ -40,6 +43,7 @@ const meta = {
   },
   args: {
     disabled: false,
+    hidden: false,
     type: 'button',
   },
   tags: ['autodocs'],
@@ -157,6 +161,20 @@ export const Submit: Story = {
     docs: {
       description: {
         story: 'Button with `type="submit"` attribute.',
+      },
+    },
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    ...Default.args,
+    hidden: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: hiddenDocs,
       },
     },
   },

--- a/packages/storybook-html/src/Checkbox.stories.tsx
+++ b/packages/storybook-html/src/Checkbox.stories.tsx
@@ -4,11 +4,27 @@ import type { Meta, StoryObj } from '@storybook/react';
 import readme from '@utrecht/components/checkbox/README.md?raw';
 import tokensDefinition from '@utrecht/components/checkbox/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
-import React from 'react';
+import React, { InputHTMLAttributes } from 'react';
+import hiddenDocs from './_hidden.md?raw';
 import { htmlContentDecorator } from './decorator';
 import { designTokenStory } from './design-token-story';
+import { hidden } from './util/htmlArgTypes';
 
-const Checkbox = ({ checked, disabled, indeterminate, invalid, name, required, value, ...attributes }) => (
+interface CheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
+  indeterminate?: boolean;
+  invalid?: boolean;
+}
+
+const Checkbox = ({
+  checked,
+  disabled,
+  indeterminate,
+  invalid,
+  name,
+  required,
+  value,
+  ...attributes
+}: CheckboxProps) => (
   <input
     name={name}
     type="checkbox"
@@ -36,6 +52,7 @@ const meta = {
       description: 'Disabled',
       control: 'boolean',
     },
+    hidden,
     invalid: {
       description: 'Invalid',
       control: 'boolean',
@@ -60,6 +77,7 @@ const meta = {
   args: {
     checked: false,
     disabled: false,
+    hidden: false,
     invalid: false,
     required: false,
     name: 'i-agree',
@@ -122,6 +140,20 @@ export const Indeterminate: Story = {
     indeterminate: true,
   },
   name: 'Indeterminate',
+};
+
+export const Hidden: Story = {
+  args: {
+    ...Default.args,
+    hidden: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: hiddenDocs,
+      },
+    },
+  },
 };
 
 export const DesignTokens = designTokenStory(meta);

--- a/packages/storybook-html/src/Code.stories.tsx
+++ b/packages/storybook-html/src/Code.stories.tsx
@@ -4,11 +4,13 @@ import type { Meta, StoryObj } from '@storybook/react';
 import readme from '@utrecht/components/code/README.md?raw';
 import tokensDefinition from '@utrecht/components/code/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
-import React from 'react';
+import React, { HTMLAttributes, PropsWithChildren } from 'react';
+import hiddenDocs from './_hidden.md?raw';
 import { htmlContentDecorator } from './decorator';
 import { designTokenStory } from './design-token-story';
+import { hidden } from './util/htmlArgTypes';
 
-const Code = ({ children }) => <code>{children}</code>;
+const Code = ({ ...restProps }: PropsWithChildren<HTMLAttributes<HTMLElement>>) => <code {...restProps} />;
 
 const meta = {
   title: 'HTML Component/Code',
@@ -20,9 +22,11 @@ const meta = {
       description: 'Code',
       control: 'text',
     },
+    hidden,
   },
   args: {
     children: '<input type="url" value="https://example.fi/">',
+    hidden: false,
   },
   tags: ['autodocs'],
   parameters: {
@@ -49,6 +53,20 @@ export const Default: Story = {
     docs: {
       description: {
         story: 'Markup using the `<code>` element.',
+      },
+    },
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    ...Default.args,
+    hidden: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: hiddenDocs,
       },
     },
   },

--- a/packages/storybook-html/src/CodeBlock.stories.tsx
+++ b/packages/storybook-html/src/CodeBlock.stories.tsx
@@ -4,12 +4,14 @@ import type { Meta, StoryObj } from '@storybook/react';
 import readme from '@utrecht/components/code-block/README.md?raw';
 import tokensDefinition from '@utrecht/components/code-block/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
-import React from 'react';
+import React, { HTMLAttributes, PropsWithChildren } from 'react';
+import hiddenDocs from './_hidden.md?raw';
 import { htmlContentDecorator } from './decorator';
 import { designTokenStory } from './design-token-story';
+import { hidden } from './util/htmlArgTypes';
 
-const CodeBlock = ({ children }) => (
-  <pre>
+const CodeBlock = ({ children, ...restProps }: PropsWithChildren<HTMLAttributes<HTMLPreElement>>) => (
+  <pre {...restProps}>
     <code>{children}</code>
   </pre>
 );
@@ -24,6 +26,7 @@ const meta = {
       description: 'Code',
       control: 'text',
     },
+    hidden,
   },
   args: {
     children: `<!DOCTYPE html>
@@ -37,6 +40,7 @@ const meta = {
   </body>
 </html>
 `,
+    hidden: false,
   },
   tags: ['autodocs'],
   parameters: {
@@ -63,6 +67,20 @@ export const Default: Story = {
     docs: {
       description: {
         story: 'Markup using the `<pre>` and `<code>` elements.',
+      },
+    },
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    ...Default.args,
+    hidden: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: hiddenDocs,
       },
     },
   },

--- a/packages/storybook-html/src/Document.stories.tsx
+++ b/packages/storybook-html/src/Document.stories.tsx
@@ -4,17 +4,23 @@ import type { Meta, StoryObj } from '@storybook/react';
 import readme from '@utrecht/components/document/README.md?raw';
 import tokensDefinition from '@utrecht/components/document/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
-import React from 'react';
+import React, { HTMLAttributes, PropsWithChildren } from 'react';
+import hiddenDocs from './_hidden.md?raw';
 import { htmlContentDecorator } from './decorator';
 import { designTokenStory } from './design-token-story';
+import { hidden } from './util/htmlArgTypes';
 
-const Document = ({ children, lang, dir, pageTitle }) => (
+interface DocumentStoryProps extends HTMLAttributes<HTMLHtmlElement> {
+  pageTitle?: string;
+}
+
+const Document = ({ children, hidden, lang, dir, pageTitle }: PropsWithChildren<DocumentStoryProps>) => (
   <html lang={lang} dir={dir}>
     <head>
       <meta charSet="utf-8" />
-      <title>{pageTitle}</title>
+      {pageTitle && <title>{pageTitle}</title>}
     </head>
-    <body>{children}</body>
+    <body hidden={hidden}>{children}</body>
   </html>
 );
 
@@ -32,6 +38,7 @@ const meta = {
       control: { type: 'select' },
       options: ['', 'ltr', 'auto', 'rtl'],
     },
+    hidden,
     lang: {
       description: 'Language',
       control: 'text',
@@ -43,6 +50,8 @@ const meta = {
   },
   args: {
     children: [],
+    hidden: false,
+    pageTitle: '',
   },
   tags: ['autodocs'],
   parameters: {
@@ -84,6 +93,20 @@ export const Default: Story = {
     docs: {
       description: {
         story: 'Markup using the `<body>` element.',
+      },
+    },
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    ...Default.args,
+    hidden: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: hiddenDocs,
       },
     },
   },

--- a/packages/storybook-html/src/Emphasis.stories.tsx
+++ b/packages/storybook-html/src/Emphasis.stories.tsx
@@ -4,11 +4,13 @@ import type { Meta, StoryObj } from '@storybook/react';
 import readme from '@utrecht/components/emphasis/README.md?raw';
 import tokensDefinition from '@utrecht/components/emphasis/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
-import React from 'react';
+import React, { HTMLAttributes, PropsWithChildren } from 'react';
+import hiddenDocs from './_hidden.md?raw';
 import { htmlContentDecorator } from './decorator';
 import { designTokenStory } from './design-token-story';
+import { hidden } from './util/htmlArgTypes';
 
-const Emphasis = ({ children }) => <em>{children}</em>;
+const Emphasis = ({ ...restProps }: PropsWithChildren<HTMLAttributes<HTMLElement>>) => <em {...restProps} />;
 
 const meta = {
   title: 'HTML Component/Emphasis',
@@ -19,9 +21,11 @@ const meta = {
     children: {
       description: 'Content of the emphasis',
     },
+    hidden,
   },
   args: {
     children: '',
+    hidden: false,
   },
   tags: ['autodocs'],
   parameters: {
@@ -51,6 +55,20 @@ export const Default: Story = {
     docs: {
       description: {
         story: 'Markup using the `<em>` element.',
+      },
+    },
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    ...Default.args,
+    hidden: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: hiddenDocs,
       },
     },
   },

--- a/packages/storybook-html/src/FormFieldset.stories.tsx
+++ b/packages/storybook-html/src/FormFieldset.stories.tsx
@@ -4,12 +4,17 @@ import type { Meta, StoryObj } from '@storybook/react';
 import readme from '@utrecht/components/form-fieldset/README.md?raw';
 import tokensDefinition from '@utrecht/components/form-fieldset/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
-import React from 'react';
+import React, { FieldsetHTMLAttributes, PropsWithChildren, ReactNode } from 'react';
+import hiddenDocs from './_hidden.md?raw';
 import { htmlContentDecorator } from './decorator';
 import { designTokenStory } from './design-token-story';
+import { hidden } from './util/htmlArgTypes';
 
-const Fieldset = ({ disabled, children, legend }) => (
-  <fieldset disabled={disabled || undefined}>
+interface FieldsetStory extends FieldsetHTMLAttributes<HTMLFieldSetElement> {
+  legend?: ReactNode;
+}
+const Fieldset = ({ disabled, children, legend, ...restProps }: PropsWithChildren<FieldsetStory>) => (
+  <fieldset disabled={disabled || undefined} {...restProps}>
     {legend ? <legend>{legend}</legend> : null}
     {children}
   </fieldset>
@@ -28,6 +33,7 @@ const meta = {
       description: 'Disabled',
       control: 'boolean',
     },
+    hidden,
     legend: {
       description: 'Set the content of the legend',
       control: 'text',
@@ -44,6 +50,7 @@ const meta = {
         laborum.
       </p>,
     ],
+    hidden: false,
   },
   tags: ['autodocs'],
   parameters: {
@@ -90,6 +97,20 @@ export const Disabled: Story = {
     docs: {
       description: {
         story: 'Markup using the `disabled` attribute.',
+      },
+    },
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    ...Default.args,
+    hidden: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: hiddenDocs,
       },
     },
   },

--- a/packages/storybook-html/src/FormLabel.stories.tsx
+++ b/packages/storybook-html/src/FormLabel.stories.tsx
@@ -4,14 +4,22 @@ import type { Meta, StoryObj } from '@storybook/react';
 import readme from '@utrecht/components/form-label/README.md?raw';
 import tokensDefinition from '@utrecht/components/form-label/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
-import React from 'react';
+import React, { LabelHTMLAttributes, PropsWithChildren } from 'react';
+import hiddenDocs from './_hidden.md?raw';
 import { htmlContentDecorator } from './decorator';
 import { designTokenStory } from './design-token-story';
+import { hidden } from './util/htmlArgTypes';
 
-const FormLabelStory = ({ id, children, type }) => (
+interface FormLabelStoryProps extends LabelHTMLAttributes<HTMLLabelElement> {
+  type?: string;
+}
+
+const FormLabelStory = ({ id, children, type, ...restProps }: PropsWithChildren<FormLabelStoryProps>) => (
   <p>
     <input type={type} id={id} />
-    <label htmlFor={id}>{children}</label>
+    <label htmlFor={id} {...restProps}>
+      {children}
+    </label>
   </p>
 );
 
@@ -25,6 +33,7 @@ const meta = {
       description: 'Set the content of the label',
       control: 'text',
     },
+    hidden,
     type: {
       description: 'Set the type of the form control',
       options: ['hidden', 'checkbox', 'radio'],
@@ -42,6 +51,7 @@ const meta = {
         laborum.
       </p>,
     ],
+    hidden: false,
   },
   tags: ['autodocs'],
   parameters: {
@@ -72,6 +82,20 @@ export const Default: Story = {
     docs: {
       description: {
         story: 'Markup using the `<label>` element.',
+      },
+    },
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    ...Default.args,
+    hidden: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: hiddenDocs,
       },
     },
   },

--- a/packages/storybook-html/src/Heading1.stories.tsx
+++ b/packages/storybook-html/src/Heading1.stories.tsx
@@ -4,11 +4,13 @@ import type { Meta, StoryObj } from '@storybook/react';
 import readme from '@utrecht/components/heading-1/README.md?raw';
 import tokensDefinition from '@utrecht/components/heading-1/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
-import React from 'react';
+import React, { HTMLAttributes, PropsWithChildren } from 'react';
+import hiddenDocs from './_hidden.md?raw';
 import { htmlContentDecorator } from './decorator';
 import { designTokenStory } from './design-token-story';
+import { hidden } from './util/htmlArgTypes';
 
-const Heading1 = ({ children }) => <h1>{children}</h1>;
+const Heading1 = ({ ...restProps }: PropsWithChildren<HTMLAttributes<HTMLElement>>) => <h1 {...restProps} />;
 
 const meta = {
   title: 'HTML Component/Heading/Heading 1',
@@ -19,9 +21,11 @@ const meta = {
     children: {
       description: 'Content of the heading',
     },
+    hidden,
   },
   args: {
     children: '',
+    hidden: false,
   },
   tags: ['autodocs'],
   parameters: {
@@ -51,6 +55,20 @@ export const Default: Story = {
     docs: {
       description: {
         story: 'Markup using the `<h1>` element.',
+      },
+    },
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    ...Default.args,
+    hidden: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: hiddenDocs,
       },
     },
   },

--- a/packages/storybook-html/src/Heading2.stories.tsx
+++ b/packages/storybook-html/src/Heading2.stories.tsx
@@ -4,11 +4,13 @@ import type { Meta, StoryObj } from '@storybook/react';
 import readme from '@utrecht/components/heading-2/README.md?raw';
 import tokensDefinition from '@utrecht/components/heading-2/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
-import React from 'react';
+import React, { HTMLAttributes, PropsWithChildren } from 'react';
+import hiddenDocs from './_hidden.md?raw';
 import { htmlContentDecorator } from './decorator';
 import { designTokenStory } from './design-token-story';
+import { hidden } from './util/htmlArgTypes';
 
-const Heading2 = ({ children }) => <h2>{children}</h2>;
+const Heading2 = ({ ...restProps }: PropsWithChildren<HTMLAttributes<HTMLElement>>) => <h2 {...restProps} />;
 
 const meta = {
   title: 'HTML Component/Heading/Heading 2',
@@ -19,9 +21,11 @@ const meta = {
     children: {
       description: 'Content of the heading',
     },
+    hidden,
   },
   args: {
     children: '',
+    hidden: false,
   },
   tags: ['autodocs'],
   parameters: {
@@ -51,6 +55,20 @@ export const Default: Story = {
     docs: {
       description: {
         story: 'Markup using the `<h2>` element.',
+      },
+    },
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    ...Default.args,
+    hidden: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: hiddenDocs,
       },
     },
   },

--- a/packages/storybook-html/src/Heading3.stories.tsx
+++ b/packages/storybook-html/src/Heading3.stories.tsx
@@ -4,11 +4,13 @@ import type { Meta, StoryObj } from '@storybook/react';
 import readme from '@utrecht/components/heading-3/README.md?raw';
 import tokensDefinition from '@utrecht/components/heading-3/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
-import React from 'react';
+import React, { HTMLAttributes, PropsWithChildren } from 'react';
+import hiddenDocs from './_hidden.md?raw';
 import { htmlContentDecorator } from './decorator';
 import { designTokenStory } from './design-token-story';
+import { hidden } from './util/htmlArgTypes';
 
-const Heading3 = ({ children }) => <h3>{children}</h3>;
+const Heading3 = ({ ...restProps }: PropsWithChildren<HTMLAttributes<HTMLElement>>) => <h3 {...restProps} />;
 
 const meta = {
   title: 'HTML Component/Heading/Heading 3',
@@ -19,9 +21,11 @@ const meta = {
     children: {
       description: 'Content of the heading',
     },
+    hidden,
   },
   args: {
     children: '',
+    hidden: false,
   },
   tags: ['autodocs'],
   parameters: {
@@ -51,6 +55,20 @@ export const Default: Story = {
     docs: {
       description: {
         story: 'Markup using the `<h3>` element.',
+      },
+    },
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    ...Default.args,
+    hidden: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: hiddenDocs,
       },
     },
   },

--- a/packages/storybook-html/src/Heading4.stories.tsx
+++ b/packages/storybook-html/src/Heading4.stories.tsx
@@ -4,11 +4,13 @@ import type { Meta, StoryObj } from '@storybook/react';
 import readme from '@utrecht/components/heading-4/README.md?raw';
 import tokensDefinition from '@utrecht/components/heading-4/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
-import React from 'react';
+import React, { HTMLAttributes, PropsWithChildren } from 'react';
+import hiddenDocs from './_hidden.md?raw';
 import { htmlContentDecorator } from './decorator';
 import { designTokenStory } from './design-token-story';
+import { hidden } from './util/htmlArgTypes';
 
-const Heading4 = ({ children }) => <h4>{children}</h4>;
+const Heading4 = ({ ...restProps }: PropsWithChildren<HTMLAttributes<HTMLElement>>) => <h4 {...restProps} />;
 
 const meta = {
   title: 'HTML Component/Heading/Heading 4',
@@ -19,9 +21,11 @@ const meta = {
     children: {
       description: 'Content of the heading',
     },
+    hidden,
   },
   args: {
     children: '',
+    hidden: false,
   },
   tags: ['autodocs'],
   parameters: {
@@ -51,6 +55,20 @@ export const Default: Story = {
     docs: {
       description: {
         story: 'Markup using the `<h4>` element.',
+      },
+    },
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    ...Default.args,
+    hidden: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: hiddenDocs,
       },
     },
   },

--- a/packages/storybook-html/src/Heading5.stories.tsx
+++ b/packages/storybook-html/src/Heading5.stories.tsx
@@ -4,11 +4,13 @@ import type { Meta, StoryObj } from '@storybook/react';
 import readme from '@utrecht/components/heading-5/README.md?raw';
 import tokensDefinition from '@utrecht/components/heading-5/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
-import React from 'react';
+import React, { HTMLAttributes, PropsWithChildren } from 'react';
+import hiddenDocs from './_hidden.md?raw';
 import { htmlContentDecorator } from './decorator';
 import { designTokenStory } from './design-token-story';
+import { hidden } from './util/htmlArgTypes';
 
-const Heading5 = ({ children }) => <h5>{children}</h5>;
+const Heading5 = ({ ...restProps }: PropsWithChildren<HTMLAttributes<HTMLElement>>) => <h5 {...restProps} />;
 
 const meta = {
   title: 'HTML Component/Heading/Heading 5',
@@ -19,9 +21,11 @@ const meta = {
     children: {
       description: 'Content of the heading',
     },
+    hidden,
   },
   args: {
     children: '',
+    hidden: false,
   },
   tags: ['autodocs'],
   parameters: {
@@ -51,6 +55,20 @@ export const Default: Story = {
     docs: {
       description: {
         story: 'Markup using the `<h5>` element.',
+      },
+    },
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    ...Default.args,
+    hidden: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: hiddenDocs,
       },
     },
   },

--- a/packages/storybook-html/src/Heading6.stories.tsx
+++ b/packages/storybook-html/src/Heading6.stories.tsx
@@ -4,11 +4,13 @@ import type { Meta, StoryObj } from '@storybook/react';
 import readme from '@utrecht/components/heading-6/README.md?raw';
 import tokensDefinition from '@utrecht/components/heading-6/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
-import React from 'react';
+import React, { HTMLAttributes, PropsWithChildren } from 'react';
+import hiddenDocs from './_hidden.md?raw';
 import { htmlContentDecorator } from './decorator';
 import { designTokenStory } from './design-token-story';
+import { hidden } from './util/htmlArgTypes';
 
-const Heading6 = ({ children }) => <h6>{children}</h6>;
+const Heading6 = ({ ...restProps }: PropsWithChildren<HTMLAttributes<HTMLElement>>) => <h6 {...restProps} />;
 
 const meta = {
   title: 'HTML Component/Heading/Heading 6',
@@ -19,9 +21,11 @@ const meta = {
     children: {
       description: 'Content of the heading',
     },
+    hidden,
   },
   args: {
     children: '',
+    hidden: false,
   },
   tags: ['autodocs'],
   parameters: {
@@ -51,6 +55,20 @@ export const Default: Story = {
     docs: {
       description: {
         story: 'Markup using the `<h6>` element.',
+      },
+    },
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    ...Default.args,
+    hidden: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: hiddenDocs,
       },
     },
   },

--- a/packages/storybook-html/src/Link.stories.tsx
+++ b/packages/storybook-html/src/Link.stories.tsx
@@ -4,11 +4,19 @@ import type { Meta, StoryObj } from '@storybook/react';
 import readme from '@utrecht/components/link/README.md?raw';
 import tokensDefinition from '@utrecht/components/link/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
-import React from 'react';
+import React, { AnchorHTMLAttributes, PropsWithChildren } from 'react';
+import hiddenDocs from './_hidden.md?raw';
 import { htmlContentDecorator } from './decorator';
 import { designTokenStory } from './design-token-story';
+import { hidden } from './util/htmlArgTypes';
 
 const normalizeTokenList = (str: string): string => str.replace(/\s+/g, ' ').trim();
+
+interface LinkStoryProps extends PropsWithChildren<AnchorHTMLAttributes<HTMLAnchorElement>> {
+  alternate?: boolean;
+  current?: boolean;
+  external?: boolean;
+}
 
 const Link = ({
   children,
@@ -18,7 +26,8 @@ const Link = ({
   hrefLang = undefined,
   alternate = false,
   external = false,
-}) => (
+  ...restProps
+}: LinkStoryProps) => (
   <a
     href={href === null ? '#' : href}
     aria-current={current || undefined}
@@ -28,6 +37,7 @@ const Link = ({
       normalizeTokenList(`${alternate ? 'alternate' : ''} ${external ? 'external noopener noreferrer' : ''}`) ||
       undefined
     }
+    {...restProps}
   >
     {children}
   </a>
@@ -56,6 +66,7 @@ const meta = {
       description: 'Link is external link',
       type: 'boolean',
     },
+    hidden,
     href: {
       description: 'Link href',
       control: 'text',
@@ -73,6 +84,7 @@ const meta = {
     alternate: false,
     children: [],
     external: false,
+    hidden: false,
     hrefLang: '',
     lang: '',
   },
@@ -178,6 +190,20 @@ export const CurrentLang: Story = {
     ariaLabel: 'This page in English',
   },
   name: 'Current language',
+};
+
+export const Hidden: Story = {
+  args: {
+    ...Default.args,
+    hidden: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: hiddenDocs,
+      },
+    },
+  },
 };
 
 export const DesignTokens = designTokenStory(meta);

--- a/packages/storybook-html/src/Mark.stories.tsx
+++ b/packages/storybook-html/src/Mark.stories.tsx
@@ -4,11 +4,13 @@ import type { Meta, StoryObj } from '@storybook/react';
 import readme from '@utrecht/components/mark/README.md?raw';
 import tokensDefinition from '@utrecht/components/mark/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
-import React from 'react';
+import React, { HTMLAttributes, PropsWithChildren } from 'react';
+import hiddenDocs from './_hidden.md?raw';
 import { htmlContentDecorator } from './decorator';
 import { designTokenStory } from './design-token-story';
+import { hidden } from './util/htmlArgTypes';
 
-const Mark = ({ children }) => <mark>{children}</mark>;
+const Mark = ({ ...restProps }: PropsWithChildren<HTMLAttributes<HTMLElement>>) => <mark {...restProps} />;
 
 const meta = {
   title: 'HTML Component/Mark',
@@ -19,9 +21,11 @@ const meta = {
     children: {
       description: 'Content of the marked text',
     },
+    hidden,
   },
   args: {
     children: '',
+    hidden: false,
   },
   tags: ['autodocs'],
   parameters: {
@@ -51,6 +55,20 @@ export const Default: Story = {
     docs: {
       description: {
         story: 'Markup using the `<mark>` element.',
+      },
+    },
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    ...Default.args,
+    hidden: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: hiddenDocs,
       },
     },
   },

--- a/packages/storybook-html/src/OrderedList.stories.tsx
+++ b/packages/storybook-html/src/OrderedList.stories.tsx
@@ -4,16 +4,20 @@ import type { Meta, StoryObj } from '@storybook/react';
 import readme from '@utrecht/components/ordered-list/README.md?raw';
 import tokensDefinition from '@utrecht/components/ordered-list/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
-import React from 'react';
+import React, { LiHTMLAttributes, OlHTMLAttributes, PropsWithChildren } from 'react';
+import hiddenDocs from './_hidden.md?raw';
 import { htmlContentDecorator } from './decorator';
 import { designTokenStory } from './design-token-story';
+import { hidden } from './util/htmlArgTypes';
 
-const OrderedList = ({ children, ...attributes }) => <ol {...attributes}>{children}</ol>;
+const OrderedList = ({ ...restProps }: PropsWithChildren<OlHTMLAttributes<HTMLOListElement>>) => <ol {...restProps} />;
 
-const OrderedListItem = ({ children, ...attributes }) => <li {...attributes}>{children}</li>;
+type OrderedListItemProps = PropsWithChildren<LiHTMLAttributes<HTMLLIElement>>;
 
-const OrderedListStory = ({ items }) => (
-  <OrderedList>
+const OrderedListItem = ({ ...restProps }: OrderedListItemProps) => <li {...restProps} />;
+
+const OrderedListStory = ({ items, ...restProps }: { items: OrderedListItemProps[] }) => (
+  <OrderedList {...restProps}>
     {items.map(({ children }) => (
       <OrderedListItem>{children}</OrderedListItem>
     ))}
@@ -34,12 +38,14 @@ const meta = {
       description: 'Text direction',
       control: 'text',
     },
+    hidden,
     lang: {
       description: 'Lang',
       control: 'text',
     },
   },
   args: {
+    hidden: false,
     items: [],
   },
   tags: ['autodocs'],
@@ -108,6 +114,20 @@ export const Arabic: Story = {
         story: `Right-to-left text should have list item markers before the text, on the right.
 
 With CSS you can use Arabic script digits for list item numbers, instead of the default latin numbers.`,
+      },
+    },
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    ...Default.args,
+    hidden: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: hiddenDocs,
       },
     },
   },

--- a/packages/storybook-html/src/Paragraph.stories.tsx
+++ b/packages/storybook-html/src/Paragraph.stories.tsx
@@ -4,12 +4,21 @@ import type { Meta, StoryObj } from '@storybook/react';
 import readme from '@utrecht/components/paragraph/README.md?raw';
 import tokensDefinition from '@utrecht/components/paragraph/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
-import React from 'react';
+import React, { HTMLAttributes, PropsWithChildren } from 'react';
+import hiddenDocs from './_hidden.md?raw';
 import { htmlContentDecorator } from './decorator';
 import { designTokenStory } from './design-token-story';
+import { hidden } from './util/htmlArgTypes';
 
-const Paragraph = ({ children, lead, small }) => (
-  <p className={lead ? 'lead' : null}>{small ? <small>{children}</small> : children}</p>
+interface ParagraphStoryProps extends HTMLAttributes<HTMLParagraphElement> {
+  lead?: boolean;
+  small?: boolean;
+}
+
+const Paragraph = ({ children, lead, small, ...restProps }: PropsWithChildren<ParagraphStoryProps>) => (
+  <p className={lead ? 'lead' : undefined} {...restProps}>
+    {small ? <small>{children}</small> : children}
+  </p>
 );
 
 const meta = {
@@ -21,6 +30,7 @@ const meta = {
     children: {
       description: 'Content of the paragraph',
     },
+    hidden,
     lead: {
       description: 'Lead paragraph',
       control: 'boolean',
@@ -32,6 +42,7 @@ const meta = {
   },
   args: {
     children: '',
+    hidden: false,
   },
   tags: ['autodocs'],
   parameters: {
@@ -92,6 +103,20 @@ export const Small: Story = {
   parameters: {
     status: {
       type: 'WORK IN PROGRESS',
+    },
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    ...Default.args,
+    hidden: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: hiddenDocs,
+      },
     },
   },
 };

--- a/packages/storybook-html/src/RadioButton.stories.tsx
+++ b/packages/storybook-html/src/RadioButton.stories.tsx
@@ -4,17 +4,23 @@ import type { Meta, StoryObj } from '@storybook/react';
 import readme from '@utrecht/components/radio-button/README.md?raw';
 import tokensDefinition from '@utrecht/components/radio-button/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
-import React from 'react';
+import React, { InputHTMLAttributes } from 'react';
+import hiddenDocs from './_hidden.md?raw';
 import { htmlContentDecorator } from './decorator';
 import { designTokenStory } from './design-token-story';
+import { hidden } from './util/htmlArgTypes';
 
-const RadioButton = ({ checked, disabled, invalid, required, value, ...attributes }) => (
+interface RadioButtonProps extends InputHTMLAttributes<HTMLInputElement> {
+  invalid?: boolean;
+}
+
+const RadioButton = ({ checked, disabled, invalid, required, value, ...attributes }: RadioButtonProps) => (
   <input
     type="radio"
-    defaultChecked={checked || null}
-    aria-invalid={invalid || null}
-    disabled={disabled || null}
-    required={required || null}
+    defaultChecked={checked || undefined}
+    aria-invalid={invalid || undefined}
+    disabled={disabled || undefined}
+    required={required || undefined}
     value={value}
     {...attributes}
   />
@@ -34,6 +40,7 @@ const meta = {
       description: 'Disabled',
       control: 'boolean',
     },
+    hidden,
     invalid: {
       description: 'Invalid',
       control: 'boolean',
@@ -50,6 +57,7 @@ const meta = {
   args: {
     checked: false,
     disabled: false,
+    hidden: false,
     invalid: false,
     required: false,
     value: '',
@@ -148,6 +156,20 @@ export const Invalid: Story = {
     docs: {
       description: {
         story: 'Markup using the `aria-invalid="true"` attribute.',
+      },
+    },
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    ...Default.args,
+    hidden: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: hiddenDocs,
       },
     },
   },

--- a/packages/storybook-html/src/Select.stories.tsx
+++ b/packages/storybook-html/src/Select.stories.tsx
@@ -4,14 +4,32 @@ import type { Meta, StoryObj } from '@storybook/react';
 import readme from '@utrecht/components/select/README.md?raw';
 import tokensDefinition from '@utrecht/components/select/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
-import React from 'react';
+import React, { SelectHTMLAttributes } from 'react';
+import hiddenDocs from './_hidden.md?raw';
 import { htmlContentDecorator } from './decorator';
 import { designTokenStory } from './design-token-story';
+import { hidden } from './util/htmlArgTypes';
 
-const Select = ({ disabled, invalid, options, required, value }) => (
-  <select aria-invalid={invalid || null} disabled={disabled || null} required={required || null} defaultValue={value}>
-    {options.map(({ label, selected, value }) => (
-      <option selected={selected || null} value={value || null}>
+interface OptionProps {
+  label: string;
+  selected?: boolean;
+  value: string;
+}
+interface SelectStoryProps extends SelectHTMLAttributes<HTMLSelectElement> {
+  invalid?: boolean;
+  options: OptionProps[];
+}
+
+const Select = ({ disabled, invalid, options, required, value, ...restProps }: SelectStoryProps) => (
+  <select
+    aria-invalid={invalid || undefined}
+    disabled={disabled || undefined}
+    required={required || undefined}
+    defaultValue={value}
+    {...restProps}
+  >
+    {options.map(({ label, selected, value }: OptionProps) => (
+      <option selected={selected || undefined} value={value || undefined}>
         {label}
       </option>
     ))}
@@ -28,6 +46,7 @@ const meta = {
       description: 'Disabled',
       control: 'boolean',
     },
+    hidden,
     invalid: {
       description: 'Invalid',
       control: 'boolean',
@@ -50,6 +69,7 @@ const meta = {
   },
   args: {
     disabled: false,
+    hidden: false,
     invalid: false,
     options: [],
     required: false,
@@ -132,6 +152,20 @@ export const Required: Story = {
     docs: {
       description: {
         story: 'Markup using the `required` or `aria-required="true"` attribute.',
+      },
+    },
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    ...Default.args,
+    hidden: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: hiddenDocs,
       },
     },
   },

--- a/packages/storybook-html/src/Separator.stories.tsx
+++ b/packages/storybook-html/src/Separator.stories.tsx
@@ -4,19 +4,25 @@ import type { Meta, StoryObj } from '@storybook/react';
 import readme from '@utrecht/components/separator/README.md?raw';
 import tokensDefinition from '@utrecht/components/separator/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
-import React from 'react';
+import React, { HTMLAttributes } from 'react';
+import hiddenDocs from './_hidden.md?raw';
 import { htmlContentDecorator } from './decorator';
 import { designTokenStory } from './design-token-story';
+import { hidden } from './util/htmlArgTypes';
 
-const Separator = () => <hr />;
+const Separator = ({ ...restProps }: HTMLAttributes<HTMLHRElement>) => <hr {...restProps} />;
 
 const meta = {
   title: 'HTML Component/Separator',
   id: 'html-separator',
   component: Separator,
   decorators: [htmlContentDecorator],
-  argTypes: {},
-  args: {},
+  argTypes: {
+    hidden,
+  },
+  args: {
+    hidden: false,
+  },
   tags: ['autodocs'],
   parameters: {
     status: {
@@ -42,6 +48,20 @@ export const Default: Story = {
     docs: {
       description: {
         story: 'Markup using the `<hr>` element.',
+      },
+    },
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    ...Default.args,
+    hidden: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: hiddenDocs,
       },
     },
   },

--- a/packages/storybook-html/src/Strong.stories.tsx
+++ b/packages/storybook-html/src/Strong.stories.tsx
@@ -4,11 +4,13 @@ import type { Meta, StoryObj } from '@storybook/react';
 import readme from '@utrecht/components/emphasis/README.md?raw';
 import tokensDefinition from '@utrecht/components/emphasis/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
-import React from 'react';
+import React, { HTMLAttributes, PropsWithChildren } from 'react';
+import hiddenDocs from './_hidden.md?raw';
 import { htmlContentDecorator } from './decorator';
 import { designTokenStory } from './design-token-story';
+import { hidden } from './util/htmlArgTypes';
 
-const Strong = ({ children }) => <strong>{children}</strong>;
+const Strong = ({ ...restProps }: PropsWithChildren<HTMLAttributes<HTMLElement>>) => <strong {...restProps} />;
 
 const meta = {
   title: 'HTML Component/Strong',
@@ -19,9 +21,11 @@ const meta = {
     children: {
       description: 'Content of the strong emphasis',
     },
+    hidden,
   },
   args: {
     children: '',
+    hidden: false,
   },
   tags: ['autodocs'],
   parameters: {
@@ -53,6 +57,20 @@ export const Default: Story = {
         story: `Markup using the \`<strong>\` element.
 
 Strong emphasis: very important or urgent content`,
+      },
+    },
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    ...Default.args,
+    hidden: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: hiddenDocs,
       },
     },
   },

--- a/packages/storybook-html/src/Table.stories.tsx
+++ b/packages/storybook-html/src/Table.stories.tsx
@@ -4,11 +4,13 @@ import type { Meta, StoryObj } from '@storybook/react';
 import readme from '@utrecht/components/table/README.md?raw';
 import tokensDefinition from '@utrecht/components/table/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
-import React from 'react';
+import React, { PropsWithChildren, TableHTMLAttributes } from 'react';
+import hiddenDocs from './_hidden.md?raw';
 import { htmlContentDecorator } from './decorator';
 import { designTokenStory } from './design-token-story';
+import { hidden } from './util/htmlArgTypes';
 
-const Table = ({ children, ...attributes }) => <table {...attributes}>{children}</table>;
+const Table = ({ ...restProps }: PropsWithChildren<TableHTMLAttributes<HTMLTableElement>>) => <table {...restProps} />;
 
 const meta = {
   title: 'HTML Component/Table',
@@ -19,6 +21,7 @@ const meta = {
     children: {
       description: 'Content of the table',
     },
+    hidden,
     summary: {
       description: 'Summary of the table contents',
       control: 'text',
@@ -26,6 +29,7 @@ const meta = {
   },
   args: {
     children: [],
+    hidden: false,
   },
   tags: ['autodocs'],
   parameters: {
@@ -86,6 +90,20 @@ export const Default: Story = {
     docs: {
       description: {
         story: 'Markup using the `<table>` element.',
+      },
+    },
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    ...Default.args,
+    hidden: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: hiddenDocs,
       },
     },
   },

--- a/packages/storybook-html/src/Textarea.stories.tsx
+++ b/packages/storybook-html/src/Textarea.stories.tsx
@@ -4,18 +4,33 @@ import type { Meta, StoryObj } from '@storybook/react';
 import readme from '@utrecht/components/textarea/README.md?raw';
 import tokensDefinition from '@utrecht/components/textarea/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
-import React from 'react';
+import React, { PropsWithChildren, TextareaHTMLAttributes } from 'react';
+import hiddenDocs from './_hidden.md?raw';
 import { htmlContentDecorator } from './decorator';
 import { designTokenStory } from './design-token-story';
+import { hidden } from './util/htmlArgTypes';
 
-const Textarea = ({ disabled, invalid, placeholder, readOnly, required, value }) => (
+interface TextareaStory extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  invalid?: boolean;
+}
+
+const Textarea = ({
+  disabled,
+  invalid,
+  placeholder,
+  readOnly,
+  required,
+  value,
+  ...restProps
+}: PropsWithChildren<TextareaStory>) => (
   <textarea
-    disabled={disabled || null}
-    aria-invalid={invalid || null}
-    placeholder={placeholder || null}
-    readOnly={readOnly || null}
-    required={required || null}
+    disabled={disabled || undefined}
+    aria-invalid={invalid || undefined}
+    placeholder={placeholder || undefined}
+    readOnly={readOnly || undefined}
+    required={required || undefined}
     defaultValue={value}
+    {...restProps}
   ></textarea>
 );
 
@@ -37,6 +52,7 @@ const meta = {
       description: 'Disabled',
       control: 'boolean',
     },
+    hidden,
     placeholder: {
       description: 'Placeholder',
       control: 'text',
@@ -52,6 +68,7 @@ const meta = {
   },
   args: {
     disabled: false,
+    hidden: false,
     invalid: false,
     placeholder: '',
     readOnly: false,
@@ -161,6 +178,20 @@ export const Required: Story = {
     docs: {
       description: {
         story: 'Markup using the `required` or `aria-required="true"` attribute.',
+      },
+    },
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    ...Default.args,
+    hidden: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: hiddenDocs,
       },
     },
   },

--- a/packages/storybook-html/src/Textbox.stories.tsx
+++ b/packages/storybook-html/src/Textbox.stories.tsx
@@ -4,10 +4,15 @@ import type { Meta, StoryObj } from '@storybook/react';
 import readme from '@utrecht/components/textbox/README.md?raw';
 import tokensDefinition from '@utrecht/components/textbox/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
-import React from 'react';
+import React, { InputHTMLAttributes } from 'react';
+import hiddenDocs from './_hidden.md?raw';
 import { htmlContentDecorator } from './decorator';
 import { designTokenStory } from './design-token-story';
+import { hidden } from './util/htmlArgTypes';
 
+interface TextboxStoryProps extends InputHTMLAttributes<HTMLInputElement> {
+  invalid?: boolean;
+}
 const Textbox = ({
   autoComplete,
   disabled,
@@ -20,19 +25,21 @@ const Textbox = ({
   required,
   type,
   value,
-}) => (
+  ...restProps
+}: TextboxStoryProps) => (
   <input
     type={type}
-    aria-invalid={invalid || null}
-    disabled={disabled || null}
-    min={min || null}
-    max={max || null}
-    pattern={pattern || null}
-    placeholder={placeholder || null}
-    required={required || null}
-    readOnly={readOnly || null}
+    aria-invalid={invalid || undefined}
+    disabled={disabled || undefined}
+    min={min || undefined}
+    max={max || undefined}
+    pattern={pattern || undefined}
+    placeholder={placeholder || undefined}
+    required={required || undefined}
+    readOnly={readOnly || undefined}
     defaultValue={value}
-    autoComplete={autoComplete || null}
+    autoComplete={autoComplete || undefined}
+    {...restProps}
   />
 );
 
@@ -50,6 +57,7 @@ const meta = {
       description: 'Disabled',
       control: 'boolean',
     },
+    hidden,
     invalid: {
       description: 'Invalid',
       control: 'boolean',
@@ -91,6 +99,7 @@ const meta = {
   args: {
     autoComplete: null,
     disabled: false,
+    hidden: false,
     invalid: false,
     min: '',
     max: '',
@@ -268,6 +277,20 @@ export const Email: Story = {
     docs: {
       description: {
         story: 'Markup using the `type="email"` attribute.',
+      },
+    },
+  },
+};
+
+export const Hidden: Story = {
+  args: {
+    ...Default.args,
+    hidden: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: hiddenDocs,
       },
     },
   },

--- a/packages/storybook-html/src/UnorderedList.stories.tsx
+++ b/packages/storybook-html/src/UnorderedList.stories.tsx
@@ -4,16 +4,28 @@ import type { Meta, StoryObj } from '@storybook/react';
 import readme from '@utrecht/components/unordered-list/README.md?raw';
 import tokensDefinition from '@utrecht/components/unordered-list/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
-import React from 'react';
+import React, { HTMLAttributes, PropsWithChildren } from 'react';
+import hiddenDocs from './_hidden.md?raw';
 import { htmlContentDecorator } from './decorator';
 import { designTokenStory } from './design-token-story';
+import { hidden } from './util/htmlArgTypes';
 
-const UnorderedList = ({ children, ...attributes }) => <ul {...attributes}>{children}</ul>;
+interface UnorderedListItemStoryProps extends HTMLAttributes<HTMLLIElement> {}
 
-const UnorderedListItem = ({ children, ...attributes }) => <li {...attributes}>{children}</li>;
+interface UnorderedListProps extends HTMLAttributes<HTMLUListElement> {}
 
-const UnorderedListStory = ({ items }) => (
-  <UnorderedList>
+interface UnorderedListStoryProps extends UnorderedListProps {
+  items: PropsWithChildren<UnorderedListItemStoryProps>[];
+}
+
+const UnorderedList = ({ children, ...attributes }: UnorderedListProps) => <ul {...attributes}>{children}</ul>;
+
+const UnorderedListItem = ({ children, ...attributes }: UnorderedListItemStoryProps) => (
+  <li {...attributes}>{children}</li>
+);
+
+const UnorderedListStory = ({ items, ...restProps }: UnorderedListStoryProps) => (
+  <UnorderedList {...restProps}>
     {items.map(({ children }) => (
       <UnorderedListItem>{children}</UnorderedListItem>
     ))}
@@ -26,6 +38,7 @@ const meta = {
   component: UnorderedListStory,
   decorators: [htmlContentDecorator],
   argTypes: {
+    hidden,
     items: {
       description: 'List items',
       control: 'array',
@@ -41,6 +54,7 @@ const meta = {
   },
   args: {
     items: [],
+    hidden: false,
   },
   tags: ['autodocs'],
   parameters: {
@@ -100,6 +114,20 @@ export const Nested: Story = {
     </ul>
   ),
   name: 'Nested',
+};
+
+export const Hidden: Story = {
+  args: {
+    ...Default.args,
+    hidden: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: hiddenDocs,
+      },
+    },
+  },
 };
 
 export const DesignTokens = designTokenStory(meta);

--- a/packages/storybook-html/src/_hidden.md
+++ b/packages/storybook-html/src/_hidden.md
@@ -1,0 +1,4 @@
+<!-- @license CC0-1.0 -->
+<!-- markdownlint-disable MD041 -->
+
+The global HTML attribute `hidden` should work as expected, and CSS properties such as `display: inline`, `display: block`, `display: flex` or `display: inline-flex` from the component stylesheet should not interfere with this behavior.

--- a/packages/storybook-html/src/util/htmlArgTypes.ts
+++ b/packages/storybook-html/src/util/htmlArgTypes.ts
@@ -1,0 +1,17 @@
+// TODO: Use more accurate version when React supports `<div hidden="until-found">`
+/*
+export const hidden = {
+  description: 'Hidden',
+  control: { type: 'select' },
+  options: {
+    undefined: undefined,
+    '': true, // map to React `hidden` property
+    hidden: 'hidden',
+    'until-found': 'until-found',
+  },
+};
+*/
+export const hidden = {
+  description: 'Hidden',
+  control: 'boolean',
+};


### PR DESCRIPTION
Last week I noticed, while preparing a live coding demo, that a secret `<button hidden>` inside the light DOM of a custom element was actually visible, this was because our `html.css` had unintended side effects. I've hardened the web component using `style="display: none"`, however I don't want our `html.css` to have this effect.

To this end I have included a "Hidden" story for each of our HTML components, so in the future we will have visual regression tests for this.