### PR TITLE
style: fix rendering glitch in Firefox when hovering over a button

### DIFF
--- a/.changeset/angry-fans-move.md
+++ b/.changeset/angry-fans-move.md
@@ -1,0 +1,9 @@
+---
+"@utrecht/component-library-angular": patch
+"@utrecht/component-library-css": patch
+"@utrecht/component-library-react": patch
+"@utrecht/component-library-vue": patch
+"@utrecht/web-component-library-stencil": patch
+---
+
+fix rendering glitch in Firefox when hovering over a button

--- a/components/button/css/_mixin.scss
+++ b/components/button/css/_mixin.scss
@@ -233,6 +233,7 @@
   padding-block-start: var(--utrecht-button-padding-block-start);
   padding-inline-end: var(--utrecht-button-padding-inline-end);
   padding-inline-start: var(--utrecht-button-padding-inline-start);
+  scale: 1;
   text-transform: var(--utrecht-button-text-transform);
   -webkit-user-select: none;
   user-select: none;


### PR DESCRIPTION
The text in the button would move one pixel or so when hovering.