### PR TITLE
chore: exclude generated files from linting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -14,6 +14,7 @@ CHANGELOG.md
 package-lock.json
 pnpm-lock.yaml
 .angular
+.nx/cache
 
 # Ignore generated files from Stencil
 components/components.d.ts

--- a/.prettierignore
+++ b/.prettierignore
@@ -14,7 +14,7 @@ CHANGELOG.md
 package-lock.json
 pnpm-lock.yaml
 .angular
-.nx/cache
+.nx
 
 # Ignore generated files from Stencil
 components/components.d.ts

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "lint-fix:js": "eslint --ext '.js,.json,.jsx,.mdx,.ts,.tsx,.vue' --fix --report-unused-disable-directives .",
     "lint-fix:md": "markdownlint --fix '**/*.md'",
     "lint:css": "stylelint '**/*.{css,scss}'",
-    "lint:html": "find . -type d \\( -name coverage -or -name dist -or -name node_modules -or -name build -or -name .docusaurus -or -name component-library-angular \\) -prune -false -o -name '*.html' -print0 | xargs -0 npx html-validate",
+    "lint:html": "find . -type d \\( -name coverage -or -name dist -or -name node_modules -or -name build -or -name .docusaurus -or -name component-library-angular -or -name www \\) -prune -false -o -name '*.html' -print0 | xargs -0 npx html-validate",
     "lint:js": "eslint --ext '.js,.json,.jsx,.mdx,.ts,.tsx,.vue' --report-unused-disable-directives .",
     "lint:md": "markdownlint '**/*.md'",
     "lint:package-json": "npmPkgJsonLint '**/package.json'",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "lint-fix:js": "eslint --ext '.js,.json,.jsx,.mdx,.ts,.tsx,.vue' --fix --report-unused-disable-directives .",
     "lint-fix:md": "markdownlint --fix '**/*.md'",
     "lint:css": "stylelint '**/*.{css,scss}'",
-    "lint:html": "find . -type d \\( -name coverage -or -name dist -or -name node_modules -or -name build -or -name .docusaurus -or -name component-library-angular -or -name www \\) -prune -false -o -name '*.html' -print0 | xargs -0 npx html-validate",
     "lint:js": "eslint --ext '.js,.json,.jsx,.mdx,.ts,.tsx,.vue' --report-unused-disable-directives .",
     "lint:md": "markdownlint '**/*.md'",
     "lint:package-json": "npmPkgJsonLint '**/package.json'",

--- a/project.json
+++ b/project.json
@@ -18,13 +18,6 @@
         "command": "npm run lint-fix:js"
       }
     },
-    "lint-html": {
-      "executor": "@nrwl/workspace:run-commands",
-      "inputs": ["{projectRoot}/**/*.html"],
-      "options": {
-        "command": "npm run lint:html"
-      }
-    },
     "lint-md": {
       "executor": "@nrwl/workspace:run-commands",
       "inputs": ["{projectRoot}/**/*.md"],


### PR DESCRIPTION
cached files and www files are now being ignored when prettier and lint:html are being run