### PR TITLE
build: update version numbers

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.1-alpha.12",
+  "version": "2.0.1-alpha.0",
   "author": "Community for NL Design System",
   "description": "Components for the Municipality of Utrecht based on the NL Design System architecture",
   "license": "EUPL-1.2",

--- a/packages/component-library-css/package.json
+++ b/packages/component-library-css/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2-alpha.10",
+  "version": "2.0.1-alpha.0",
   "author": "Community for NL Design System",
   "description": "Component library bundle for the Municipality of Utrecht based on the NL Design System architecture",
   "license": "EUPL-1.2",

--- a/packages/component-library-react/package.json
+++ b/packages/component-library-react/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2-alpha.10",
+  "version": "2.0.1-alpha.0",
   "author": "Community for NL Design System",
   "description": "React component library bundle for the Municipality of Utrecht based on the NL Design System architecture",
   "license": "EUPL-1.2",


### PR DESCRIPTION
Previously the 2.0.0 version was released to npm, but not merged into main. Now 2.0.0 is accedintally an older release than 1.0.2-alpha.10. This release should fix that.