### PR TITLE
ci: change review teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
 # 3rd-party scripts must never be installed without security review
-package-lock.json @nl-design-system/sysadmin
-yarn.lock @nl-design-system/sysadmin
+
+pnpm.lock @nl-design-system/kernteam-maintainer
+package-lock.json @nl-design-system/kernteam-maintainer
+yarn.lock @nl-design-system/kernteam-maintainer

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,4 +14,4 @@ updates:
     versioning-strategy: "increase-if-necessary"
     open-pull-requests-limit: 20
     reviewers:
-      - "nl-design-system/sysadmin"
+      - "nl-design-system/kernteam-dependabot"


### PR DESCRIPTION
Enables us to easily add and remove people from 'dependabot review duty' and a step in the right direction to remove the root `kernteam-sysadmin`