### PR TITLE
build: bump actions/download-artifact

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      actions-upload-and-download-artifact:
+        patterns:
+          - "actions/upload-artifact"
+          - "actions/download-artifact"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -273,7 +273,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: "Restore build artifact: website"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: website
           path: packages/design-system-website/dist/


### PR DESCRIPTION
- actions/upload-artifact and actions/download-artifact should always have the same major version
- prevent dependabot from opening separate PRs to update these dependencies

This should fix https://github.com/nl-design-system/utrecht/actions/runs/7816568086/job/21322825042