### PR TITLE
chore: add missing http-server in packages

### DIFF
--- a/packages/storybook-css/package.json
+++ b/packages/storybook-css/package.json
@@ -60,6 +60,7 @@
     "css-loader": "6.8.1",
     "firacode": "6.2.0",
     "html-react-parser": "3.0.16",
+    "http-server": "14.1.1",
     "lodash.defaultsdeep": "4.6.1",
     "lodash.groupby": "4.6.0",
     "prettier": "2.8.8",
@@ -81,7 +82,7 @@
     "build": "storybook build --output-dir dist/ --config-dir config/ --quiet",
     "clean": "rimraf dist/",
     "lint:typescript": "tsc --noEmit --project tsconfig.json",
-    "start": "npx http-server dist/",
+    "start": "http-server dist/",
     "storybook": "storybook dev --config-dir config/ --port 6012"
   }
 }

--- a/packages/storybook-html/package.json
+++ b/packages/storybook-html/package.json
@@ -60,6 +60,7 @@
     "css-loader": "6.8.1",
     "firacode": "6.2.0",
     "html-react-parser": "3.0.16",
+    "http-server": "14.1.1",
     "lodash.defaultsdeep": "4.6.1",
     "lodash.groupby": "4.6.0",
     "prettier": "2.8.8",
@@ -81,7 +82,7 @@
     "build": "storybook build --output-dir dist/ --config-dir config/ --quiet",
     "clean": "rimraf dist/",
     "lint:typescript": "tsc --noEmit --project tsconfig.json",
-    "start": "npx http-server dist/",
+    "start": "http-server dist/",
     "storybook": "storybook dev --config-dir config/ --port 6011"
   }
 }

--- a/packages/storybook-vue/package.json
+++ b/packages/storybook-vue/package.json
@@ -46,6 +46,7 @@
     "@vitejs/plugin-vue-jsx": "3.1.0",
     "@vue/compiler-sfc": "3.3.11",
     "@vue/tsconfig": "0.1.3",
+    "http-server": "14.1.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "storybook": "7.6.4",
@@ -60,7 +61,7 @@
     "storybook-docs": "storybook dev --config-dir config/ --docs --no-manager-cache",
     "clean": "rimraf dist/",
     "lint:typescript": "tsc --noEmit --project tsconfig.json",
-    "start": "npx http-server dist/",
+    "start": "http-server dist/",
     "storybook": "storybook dev --config-dir config/ --port 6007"
   }
 }

--- a/packages/storybook-web-component/package.json
+++ b/packages/storybook-web-component/package.json
@@ -60,6 +60,7 @@
     "css-loader": "6.8.1",
     "firacode": "6.2.0",
     "html-react-parser": "3.0.16",
+    "http-server": "14.1.1",
     "lodash.defaultsdeep": "4.6.1",
     "lodash.groupby": "4.6.0",
     "prettier": "2.8.8",
@@ -81,7 +82,7 @@
     "build": "storybook build --output-dir dist/ --config-dir config/ --quiet",
     "clean": "rimraf dist/",
     "lint:typescript": "tsc --noEmit --project tsconfig.json",
-    "start": "npx http-server dist/",
+    "start": "http-server dist/",
     "storybook": "storybook dev --config-dir config/ --port 6010"
   }
 }

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -61,6 +61,7 @@
     "css-loader": "6.8.1",
     "firacode": "6.2.0",
     "html-react-parser": "3.0.16",
+    "http-server": "14.1.1",
     "lodash.defaultsdeep": "4.6.1",
     "lodash.groupby": "4.6.0",
     "prettier": "2.8.8",
@@ -83,7 +84,7 @@
     "build": "storybook build --output-dir dist/ --config-dir config/ --quiet",
     "clean": "rimraf dist/",
     "lint:typescript": "tsc --noEmit --project tsconfig.json",
-    "start": "npx http-server dist/",
+    "start": "http-server dist/",
     "storybook": "storybook dev --config-dir config/ --port 6006"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 patchedDependencies:
   '@stencil/core@4.8.2':
     hash: a5iuwt5l2qu5cukh7ozwyzp4ky
@@ -801,6 +805,9 @@ importers:
       html-react-parser:
         specifier: 3.0.16
         version: 3.0.16(react@18.2.0)
+      http-server:
+        specifier: 14.1.1
+        version: 14.1.1
       lodash.defaultsdeep:
         specifier: 4.6.1
         version: 4.6.1
@@ -1164,6 +1171,9 @@ importers:
       html-react-parser:
         specifier: 3.0.16
         version: 3.0.16(react@18.2.0)
+      http-server:
+        specifier: 14.1.1
+        version: 14.1.1
       lodash.defaultsdeep:
         specifier: 4.6.1
         version: 4.6.1
@@ -1365,6 +1375,9 @@ importers:
       html-react-parser:
         specifier: 3.0.16
         version: 3.0.16(react@18.2.0)
+      http-server:
+        specifier: 14.1.1
+        version: 14.1.1
       lodash.defaultsdeep:
         specifier: 4.6.1
         version: 4.6.1
@@ -1674,6 +1687,9 @@ importers:
       '@vue/tsconfig':
         specifier: 0.1.3
         version: 0.1.3(@types/node@20.11.16)
+      http-server:
+        specifier: 14.1.1
+        version: 14.1.1
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -1842,6 +1858,9 @@ importers:
       html-react-parser:
         specifier: 3.0.16
         version: 3.0.16(react@18.2.0)
+      http-server:
+        specifier: 14.1.1
+        version: 14.1.1
       lodash.defaultsdeep:
         specifier: 4.6.1
         version: 4.6.1
@@ -30151,8 +30170,6 @@ packages:
     peerDependenciesMeta:
       webpack:
         optional: true
-      webpack-sources:
-        optional: true
     dependencies:
       webpack: 5.76.1(esbuild@0.17.8)
       webpack-sources: 3.2.3
@@ -30164,8 +30181,6 @@ packages:
       webpack: '*'
     peerDependenciesMeta:
       webpack:
-        optional: true
-      webpack-sources:
         optional: true
     dependencies:
       webpack: 5.89.0(esbuild@0.19.11)
@@ -43143,7 +43158,3 @@ packages:
     dependencies:
       acorn: 8.11.2
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
http-server was not installed but npx was used instead. This resulted in

> `sh: line 1: http-server: command not found`