### PR TITLE
chore: simplify npm-check-updates configuration

### DIFF
--- a/.ncurc.major.js
+++ b/.ncurc.major.js
@@ -1,5 +1,7 @@
 const minorConfig = require('./.ncurc.minor');
 
 module.exports = {
+  ...minorConfig,
   reject: [...minorConfig.reject, '@mdx-js/react'],
+  target: 'latest',
 };

--- a/.ncurc.minor.js
+++ b/.ncurc.minor.js
@@ -1,5 +1,7 @@
 const patchConfig = require('./.ncurc.patch');
 
 module.exports = {
+  ...patchConfig,
   reject: [...patchConfig.reject, 'typescript', '@vue/tsconfig', 'zone.js'],
+  target: 'minor',
 };

--- a/.ncurc.patch.js
+++ b/.ncurc.patch.js
@@ -1,3 +1,9 @@
 module.exports = {
+  dep: ['dev', 'prod'],
+  install: 'always',
   reject: [],
+  root: true,
+  target: 'patch',
+  upgrade: true,
+  workspaces: true,
 };

--- a/package.json
+++ b/package.json
@@ -100,9 +100,9 @@
     "nx-test": "nx run-many --target=test --all --parallel",
     "test-build": "pnpm run --recursive test-build",
     "test-update": "pnpm run lint && pnpm run build && pnpm run test && pnpm run lint-build && pnpm run test-build",
-    "update-major": "npm-check-updates --configFileName .ncurc.major.js --deep --dep dev,prod --target latest --upgrade && pnpm install",
-    "update-minor": "npm-check-updates --configFileName .ncurc.minor.js --deep --dep dev,prod --target minor --upgrade && pnpm install",
-    "update-patch": "npm-check-updates --configFileName .ncurc.patch.js --deep --dep dev,prod --target patch --upgrade && pnpm install"
+    "update-major": "npm-check-updates --configFileName .ncurc.major.js",
+    "update-minor": "npm-check-updates --configFileName .ncurc.minor.js",
+    "update-patch": "npm-check-updates --configFileName .ncurc.patch.js"
   },
   "pnpm": {
     "patchedDependencies": {


### PR DESCRIPTION
Move the configuration from command line arguments into `.ncurc.patch.js` and override the necessary values in `.ncurc.minor.js` and `.ncurc.major.js`.

Clean up `package.json`.