### PR TITLE
feat: add `ForwardRef` to Combobox and Listbox components

### DIFF
--- a/packages/component-library-react/src/Combobox.test.tsx
+++ b/packages/component-library-react/src/Combobox.test.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { createRef } from 'react';
 import { Combobox } from './Combobox';
 
 describe('Combobox', () => {
@@ -18,5 +19,15 @@ describe('Combobox', () => {
     const combobox = container.querySelector(':only-child');
 
     expect(combobox).toHaveClass('utrecht-combobox');
+  });
+
+  it('supports ForwardRef in React', () => {
+    const ref = createRef<HTMLDivElement>();
+
+    const { container } = render(<Combobox ref={ref} />);
+
+    const combobox = container.querySelector(':only-child');
+
+    expect(ref.current).toBe(combobox);
   });
 });

--- a/packages/component-library-react/src/Combobox.tsx
+++ b/packages/component-library-react/src/Combobox.tsx
@@ -4,27 +4,39 @@
  */
 
 import clsx from 'clsx';
-import { HTMLAttributes, PropsWithChildren } from 'react';
+import { ForwardedRef, forwardRef, HTMLAttributes, PropsWithChildren } from 'react';
 
 export type ComboboxProps = HTMLAttributes<HTMLDivElement>;
 
-export const Combobox = ({ className, ...restProps }: PropsWithChildren<ComboboxProps>) => (
-  <div className={clsx('utrecht-combobox', className)} {...restProps} />
+export const Combobox = forwardRef(
+  ({ className, ...restProps }: PropsWithChildren<ComboboxProps>, ref: ForwardedRef<HTMLDivElement>) => (
+    <div className={clsx('utrecht-combobox', className)} {...restProps} ref={ref} />
+  ),
 );
+
+Combobox.displayName = 'Combobox';
 
 export interface ComboboxPopoverProps extends HTMLAttributes<HTMLDivElement> {
   position?: string | 'block-end' | 'block-start';
 }
 
-export const ComboboxPopover = ({ className, position, ...restProps }: PropsWithChildren<ComboboxPopoverProps>) => (
-  <div
-    className={clsx(
-      'utrecht-combobox__popover',
-      {
-        'utrecht-search-bar__popover--block-end': !position || position === 'block-end',
-      },
-      className,
-    )}
-    {...restProps}
-  />
+export const ComboboxPopover = forwardRef(
+  (
+    { className, position, ...restProps }: PropsWithChildren<ComboboxPopoverProps>,
+    ref: ForwardedRef<HTMLDivElement>,
+  ) => (
+    <div
+      className={clsx(
+        'utrecht-combobox__popover',
+        {
+          'utrecht-search-bar__popover--block-end': !position || position === 'block-end',
+        },
+        className,
+      )}
+      {...restProps}
+      ref={ref}
+    />
+  ),
 );
+
+ComboboxPopover.displayName = 'ComboboxPopover';

--- a/packages/component-library-react/src/Listbox.test.tsx
+++ b/packages/component-library-react/src/Listbox.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { createRef } from 'react';
 import { Listbox, ListboxOption, ListboxOptionGroup } from './Listbox';
 
 describe('Listbox', () => {
@@ -59,6 +60,16 @@ describe('Listbox', () => {
     });
   });
 
+  it('supports ForwardRef in React', () => {
+    const ref = createRef<HTMLDivElement>();
+
+    const { container } = render(<Listbox ref={ref} />);
+
+    const listbox = container.querySelector(':only-child');
+
+    expect(ref.current).toBe(listbox);
+  });
+
   describe('option', () => {
     it('renders a li HTML element', () => {
       const { container } = render(
@@ -87,6 +98,16 @@ describe('Listbox', () => {
       const option = screen.getByRole('option', { name: 'Option 1' });
 
       expect(option).toBeInTheDocument();
+    });
+
+    it('supports ForwardRef in React', () => {
+      const ref = createRef<HTMLLIElement>();
+
+      const { container } = render(<ListboxOption ref={ref} />);
+
+      const option = container.querySelector(':only-child');
+
+      expect(ref.current).toBe(option);
     });
   });
 
@@ -125,6 +146,16 @@ describe('Listbox', () => {
       const optionGroup = screen.getByRole('group', { name: 'Odd' });
 
       expect(optionGroup).toBeInTheDocument();
+    });
+
+    it('supports ForwardRef in React', () => {
+      const ref = createRef<HTMLLIElement>();
+
+      const { container } = render(<ListboxOptionGroup ref={ref} />);
+
+      const optionGroup = container.querySelector(':only-child');
+
+      expect(ref.current).toBe(optionGroup);
     });
   });
 });

--- a/packages/component-library-react/src/Listbox.tsx
+++ b/packages/component-library-react/src/Listbox.tsx
@@ -4,7 +4,7 @@
  */
 
 import clsx from 'clsx';
-import { HTMLAttributes, LiHTMLAttributes, PropsWithChildren, ReactNode, useId } from 'react';
+import { ForwardedRef, forwardRef, HTMLAttributes, LiHTMLAttributes, PropsWithChildren, ReactNode, useId } from 'react';
 
 export interface ListboxProps extends HTMLAttributes<HTMLDivElement> {
   disabled?: boolean;
@@ -14,57 +14,69 @@ export interface ListboxProps extends HTMLAttributes<HTMLDivElement> {
   required?: boolean;
 }
 
-export const Listbox = ({
-  children,
-  className,
-  disabled,
-  invalid,
-  multiple,
-  readOnly,
-  required,
-  ...restProps
-}: PropsWithChildren<ListboxProps>) => (
-  <div
-    className={clsx(
-      'utrecht-listbox',
-      'utrecht-listbox--html-div',
-      {
-        'utrecht-listbox--disabled': disabled,
-        'utrecht-listbox--invalid': invalid,
-        'utrecht-listbox--read-only': readOnly,
-      },
+export const Listbox = forwardRef(
+  (
+    {
+      children,
       className,
-    )}
-    role="listbox"
-    aria-disabled={disabled || undefined}
-    aria-invalid={invalid || undefined}
-    aria-multiselectable={multiple || undefined}
-    aria-readonly={readOnly || undefined}
-    aria-required={required || undefined}
-    tabIndex={0}
-    {...restProps}
-  >
-    <ul className="utrecht-listbox__list">{children}</ul>
-  </div>
+      disabled,
+      invalid,
+      multiple,
+      readOnly,
+      required,
+      ...restProps
+    }: PropsWithChildren<ListboxProps>,
+    ref: ForwardedRef<HTMLDivElement>,
+  ) => (
+    <div
+      className={clsx(
+        'utrecht-listbox',
+        'utrecht-listbox--html-div',
+        {
+          'utrecht-listbox--disabled': disabled,
+          'utrecht-listbox--invalid': invalid,
+          'utrecht-listbox--read-only': readOnly,
+        },
+        className,
+      )}
+      role="listbox"
+      aria-disabled={disabled || undefined}
+      aria-invalid={invalid || undefined}
+      aria-multiselectable={multiple || undefined}
+      aria-readonly={readOnly || undefined}
+      aria-required={required || undefined}
+      tabIndex={0}
+      {...restProps}
+      ref={ref}
+    >
+      <ul className="utrecht-listbox__list">{children}</ul>
+    </div>
+  ),
 );
+
+Listbox.displayName = 'Listbox';
 
 export interface ListboxOptionGroupProps extends LiHTMLAttributes<HTMLLIElement> {
   label?: ReactNode;
 }
 
-export const ListboxOptionGroup = ({ children, label, ...restProps }: PropsWithChildren<ListboxOptionGroupProps>) => {
-  const id = useId();
-  return (
-    <li className="utrecht-listbox__group" role="group" aria-labelledby={id} {...restProps}>
-      {label && (
-        <div id={id} className="utrecht-listbox__group-label">
-          {label}
-        </div>
-      )}
-      <ul>{children}</ul>
-    </li>
-  );
-};
+export const ListboxOptionGroup = forwardRef(
+  ({ children, label, ...restProps }: PropsWithChildren<ListboxOptionGroupProps>, ref: ForwardedRef<HTMLLIElement>) => {
+    const id = useId();
+    return (
+      <li className="utrecht-listbox__group" role="group" aria-labelledby={id} {...restProps} ref={ref}>
+        {label && (
+          <div id={id} className="utrecht-listbox__group-label">
+            {label}
+          </div>
+        )}
+        <ul>{children}</ul>
+      </li>
+    );
+  },
+);
+
+ListboxOptionGroup.displayName = 'ListboxOptionGroup';
 
 export interface ListboxOptionProps extends HTMLAttributes<HTMLLIElement> {
   active?: boolean;
@@ -72,28 +84,30 @@ export interface ListboxOptionProps extends HTMLAttributes<HTMLLIElement> {
   selected?: boolean;
 }
 
-export const ListboxOption = ({
-  active,
-  className,
-  disabled,
-  selected,
-  ...restProps
-}: PropsWithChildren<ListboxOptionProps>) => (
-  <li
-    className={clsx(
-      'utrecht-listbox__option',
-      'utrecht-listbox__option--html-li',
-      {
-        'utrecht-listbox__option--active': active,
-        'utrecht-listbox__option--disabled': disabled,
-        'utrecht-listbox__option--selected': selected,
-      },
-      className,
-    )}
-    aria-disabled={disabled || undefined}
-    aria-selected={selected ? 'true' : 'false'}
-    tabIndex={disabled ? undefined : -1}
-    role="option"
-    {...restProps}
-  />
+export const ListboxOption = forwardRef(
+  (
+    { active, className, disabled, selected, ...restProps }: PropsWithChildren<ListboxOptionProps>,
+    ref: ForwardedRef<HTMLLIElement>,
+  ) => (
+    <li
+      className={clsx(
+        'utrecht-listbox__option',
+        'utrecht-listbox__option--html-li',
+        {
+          'utrecht-listbox__option--active': active,
+          'utrecht-listbox__option--disabled': disabled,
+          'utrecht-listbox__option--selected': selected,
+        },
+        className,
+      )}
+      aria-disabled={disabled || undefined}
+      aria-selected={selected ? 'true' : 'false'}
+      tabIndex={disabled ? undefined : -1}
+      role="option"
+      {...restProps}
+      ref={ref}
+    />
+  ),
 );
+
+ListboxOption.displayName = 'ListboxOption';


### PR DESCRIPTION
`ref={ref}` support is needed for [implementing Downshift](https://github.com/downshift-js/downshift).