### PR TITLE
style: accordion text align

### DIFF
--- a/components/accordion/css/_mixin.scss
+++ b/components/accordion/css/_mixin.scss
@@ -39,6 +39,7 @@
 
   justify-content: start !important;
   position: relative;
+  text-align: start;
 }
 
 @mixin utrecht-accordion__button-icon {


### PR DESCRIPTION
Browser default for the button is to align text in the center. This means that text is visibly center aligned when the button is full-width in the accordion. 