### PR TITLE
style: add `min-block-size` to select and make the default minimum 44px

### DIFF
--- a/components/select/css/_mixin.scss
+++ b/components/select/css/_mixin.scss
@@ -24,6 +24,8 @@
   font-family: var(--utrecht-select-font-family, var(--utrecht-form-control-font-family));
   font-size: var(--utrecht-select-font-size, var(--utrecht-form-control-font-size));
   inline-size: 100%;
+  min-block-size: var(--utrecht-select-min-block-size, var(--utrecht-pointer-target-min-size, 44px));
+  min-inline-size: var(--utrecht-pointer-target-min-size, 44px);
   max-inline-size: var(--utrecht-select-max-inline-size, var(--utrecht-form-control-max-inline-size));
   padding-block-end: var(--utrecht-select-padding-block-end, var(--utrecht-form-control-padding-block-end));
   padding-block-start: var(--utrecht-select-padding-block-start, var(--utrecht-form-control-padding-block-start));

--- a/components/select/tokens.json
+++ b/components/select/tokens.json
@@ -82,6 +82,15 @@
           "nl.nldesignsystem.fallback": ["utrecht.form-control.font-size"]
         }
       },
+      "min-block-size": {
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          },
+          "nl.nldesignsystem.fallback": ["utrecht.pointertarget.min-size"]
+        }
+      },
       "max-inline-size": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {


### PR DESCRIPTION
This is a breaking change for folks who have select components smaller than 44px, should I be more careful?

Het gaat om deze stories:

- [CSS Storybook — Select](https://utrecht-git-style-select-min-block-size-nl-design-system.vercel.app/storybook-css/index.html?path=/docs/css-select--docs)
- [CSS Storybook — Select design tokens](https://utrecht-git-style-select-min-block-size-nl-design-system.vercel.app/storybook-css/index.html?path=/story/css-select--design-tokens)