### PR TITLE
style: use "inert" cursor only for disabled current links

### DIFF
--- a/components/breadcrumb-nav/css/_mixin.scss
+++ b/components/breadcrumb-nav/css/_mixin.scss
@@ -63,7 +63,9 @@
 @mixin utrecht-breadcrumb-nav__link--current {
   --utrecht-link-current-font-weight: var(--utrecht-breadcrumb-nav-link-current-font-weight, inherit);
 
-  cursor: var(--utrecht-action-inert-cursor, default);
+  /* configure the `current` `cursor` only when the current state is applied */
+  --_utrecht-breadcrumb-nav-link-current-cursor: var(--utrecht-action-inert-cursor, default);
+
   font-weight: var(--utrecht-breadcrumb-nav-link-current-font-weight, inherit);
 }
 
@@ -73,12 +75,16 @@
     var(--utrecht-breadcrumb-nav-link-color)
   );
 
+  /* configure the `disabled` `cursor` only when the current state is applied */
+  --_utrecht-breadcrumb-nav-link-disabled-cursor: var(--utrecht-action-disabled-cursor, not-allowed);
+
   background-color: var(
     --utrecht-breadcrumb-nav-link-disabled-background-color,
     var(--utrecht-breadcrumb-nav-link-background-color)
   );
-  color: var(--utrecht-link-placeholder-color);
-  cursor: var(--utrecht-action-disabled-cursor, not-allowed);
+
+  /* Use the `current` cursor when available, otherwise use the `disabled` cursor */
+  cursor: var(--_utrecht-breadcrumb-nav-link-current-cursor, var(--_utrecht-breadcrumb-nav-link-disabled-cursor));
 }
 
 /* stylelint-disable-next-line block-no-empty */

--- a/components/breadcrumb-nav/css/index.scss
+++ b/components/breadcrumb-nav/css/index.scss
@@ -45,16 +45,12 @@
   @include utrecht-breadcrumb-nav__link;
 }
 
-.utrecht-breadcrumb-nav__link--disabled {
-  @include utrecht-breadcrumb-nav__link--disabled;
+.utrecht-breadcrumb-nav__link--current {
+  @include utrecht-breadcrumb-nav__link--current;
 }
 
-.utrecht-breadcrumb-nav__link--current {
-  /*
-   * `current` should apply to `disabled` links too, and it should override `disabled`.
-   * The override is the reason why this selector is not ordered alphabetically.
-   */
-  @include utrecht-breadcrumb-nav__link--current;
+.utrecht-breadcrumb-nav__link--disabled {
+  @include utrecht-breadcrumb-nav__link--disabled;
 }
 
 /* stylelint-disable-next-line block-no-empty */

--- a/packages/storybook-css/src/BreadcrumbNav.stories.tsx
+++ b/packages/storybook-css/src/BreadcrumbNav.stories.tsx
@@ -200,6 +200,35 @@ export const Disabled: Story = {
   },
 };
 
+export const DisabledCurrent: Story = {
+  args: {
+    label: 'Kruimelpad:',
+    children: [
+      <BreadcrumbNavLink href="https://example.com/" rel="home" index={0}>
+        Home
+      </BreadcrumbNavLink>,
+      <BreadcrumbNavSeparator>
+        <UtrechtIconChevronRight />
+      </BreadcrumbNavSeparator>,
+      <BreadcrumbNavLink href="https://example.com/a/" index={1}>
+        Wonen en leven
+      </BreadcrumbNavLink>,
+      <BreadcrumbNavSeparator>
+        <UtrechtIconChevronRight />
+      </BreadcrumbNavSeparator>,
+      <BreadcrumbNavLink href="https://example.com/a/b/" current disabled index={2}>
+        Afval
+      </BreadcrumbNavLink>,
+    ],
+  },
+  name: 'Current page link is disabled',
+  parameters: {
+    status: {
+      type: 'ALPHA',
+    },
+  },
+};
+
 export const Home: Story = {
   args: {
     label: 'Home only',
@@ -314,35 +343,6 @@ export const CodeTitle: Story = {
     ],
   },
   name: 'Code in link text',
-  parameters: {
-    status: {
-      type: 'ALPHA',
-    },
-  },
-};
-
-export const DisabledCurrent: Story = {
-  args: {
-    label: 'Kruimelpad:',
-    children: [
-      <BreadcrumbNavLink href="https://example.com/" rel="home" index={0}>
-        Home
-      </BreadcrumbNavLink>,
-      <BreadcrumbNavSeparator>
-        <UtrechtIconChevronRight />
-      </BreadcrumbNavSeparator>,
-      <BreadcrumbNavLink href="https://example.com/a/" index={1}>
-        Wonen en leven
-      </BreadcrumbNavLink>,
-      <BreadcrumbNavSeparator>
-        <UtrechtIconChevronRight />
-      </BreadcrumbNavSeparator>,
-      <BreadcrumbNavLink href="https://example.com/a/b/" current disabled index={2}>
-        Afval
-      </BreadcrumbNavLink>,
-    ],
-  },
-  name: 'Current page link is disabled',
   parameters: {
     status: {
       type: 'ALPHA',


### PR DESCRIPTION
Naar aanleiding van een vraag in Slack: https://codefornl.slack.com/archives/C01DAT4TRPF/p1715946802625149

> Ik gebruik het BreadcrumbNav component van de Gemeente Utrecht.
> Maar ik zie een verschillende cursors voor normale NavLinks en voor de huidige / "current" NavLink.
> Als ik over de NavLinks hover met mijn cursor krijg ik de “pointer” cursor (vanuit de user agent stylesheet).
> Maar bij het huidige / “current” NavLink Item krijg ik de pointer vanuit het --utrecht-action-inert-cursor token. (in mijn geval de default pointer)
> Zit er een reden achter het verschil voor de “current” NavLink en de andere NavLink’s?




