### PR TITLE
style: add link-list.row-gap token and other link list tweaks

### DIFF
--- a/.changeset/chatty-islands-refuse.md
+++ b/.changeset/chatty-islands-refuse.md
@@ -1,0 +1,5 @@
+---
+"@utrecht/link-list-css": major
+---
+
+Remove the class name `utrecht-link-list--distanced`.

--- a/.changeset/clean-ways-guess.md
+++ b/.changeset/clean-ways-guess.md
@@ -1,0 +1,9 @@
+---
+"@utrecht/design-tokens": major
+"@utrecht/link-list-css": major
+"@utrecht/components": major
+"@utrecht/component-library-css": major
+"@utrecht/component-library-react": major
+---
+
+Replace `utrecht.link-list.item.margin-block-start` design token with `utrecht.link-list.row-gap`.

--- a/.changeset/early-needles-knock.md
+++ b/.changeset/early-needles-knock.md
@@ -1,0 +1,5 @@
+---
+"@utrecht/component-library-react": patch
+---
+
+Use `<ul role="list">` for the `LinkList` component, so VoiceOver in Safari recognizes the list. See ["Fixing" lists (by Scott O'Hara)](https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html) for context.

--- a/.changeset/ten-plums-reply.md
+++ b/.changeset/ten-plums-reply.md
@@ -1,0 +1,9 @@
+---
+"@utrecht/component-library-react": minor
+"@utrecht/design-tokens": minor
+"@utrecht/link-list-css": minor
+"@utrecht/components": minor
+"@utrecht/component-library-css": minor
+---
+
+Add design token to Link list component: `utrecht.link-list.link.text-decoration`, so you can enable or disable the underline. By default the links have no underline.

--- a/.changeset/wet-coins-study.md
+++ b/.changeset/wet-coins-study.md
@@ -1,0 +1,5 @@
+---
+"@utrecht/link-list-css": minor
+---
+
+Add SCSS mixins for `utrecht-link-list`.

--- a/.changeset/wise-students-swim.md
+++ b/.changeset/wise-students-swim.md
@@ -1,0 +1,12 @@
+---
+"@utrecht/component-library-react": major
+"@utrecht/design-tokens": major
+"@utrecht/link-list-css": major
+"@utrecht/components": major
+"@utrecht/component-library-css": major
+---
+
+Rename tokens in the Link list component, because they should be on `link` instead of on `item`. "Item" currently only exists in CSS, but is not necessary to build the Link list in Figma.
+
+- Rename `utrecht.link-list.item.font-weight` to `utrecht.link-list.link.font-weight`.
+- Rename `utrecht.link-list.item.column-gap` to `utrecht.link-list.link.column-gap`.

--- a/components/link-list/src/_mixin.scss
+++ b/components/link-list/src/_mixin.scss
@@ -17,10 +17,6 @@
 }
 
 @mixin utrecht-link-list {
-  --utrecht-link-text-decoration: none;
-  --utrecht-link-hover-text-decoration: underline;
-  --utrecht-link-focus-text-decoration: underline;
-
   display: flex;
   flex-direction: column;
   margin-block-end: calc(var(--utrecht-space-around, 0) * var(--utrecht-link-list-margin-block-end, 0));
@@ -37,6 +33,11 @@
 }
 
 @mixin utrecht-link-list__link {
+  /* TODO: I wish we could make it fall back to `var(--utrecht-link-text-decoration)`
+   * when `var(--utrecht-link-list-text-decoration)` is not set.
+   */
+  --utrecht-link-text-decoration: var(--utrecht-link-list-link-text-decoration, none);
+
   align-items: baseline;
   column-gap: var(--utrecht-link-list-link-column-gap);
   display: inline-flex;

--- a/components/link-list/src/_mixin.scss
+++ b/components/link-list/src/_mixin.scss
@@ -1,0 +1,44 @@
+/**
+ * @license EUPL-1.2
+ * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2021 Robbert Broersma
+ */
+
+@mixin reset-ul() {
+  margin-block-end: 0;
+  margin-block-start: 0;
+  margin-inline-end: 0;
+  margin-inline-start: 0;
+  padding-inline-start: 0;
+}
+
+@mixin reset-li() {
+  list-style: none;
+}
+
+@mixin utrecht-link-list {
+  --utrecht-link-text-decoration: none;
+  --utrecht-link-hover-text-decoration: underline;
+  --utrecht-link-focus-text-decoration: underline;
+
+  display: flex;
+  flex-direction: column;
+  margin-block-end: calc(var(--utrecht-space-around, 0) * var(--utrecht-link-list-margin-block-end, 0));
+  margin-block-start: calc(var(--utrecht-space-around, 0) * var(--utrecht-link-list-margin-block-start, 0));
+  row-gap: var(--utrecht-link-list-row-gap);
+}
+
+@mixin utrecht-link-list__item {
+  --utrecht-icon-size: var(--utrecht-link-list-icon-size);
+  --utrecht-link-icon-size: var(--utrecht-link-list-icon-size);
+  --utrecht-icon-inset-block-start: var(--utrecht-link-list-icon-inset-block-start);
+
+  display: block;
+  font-weight: var(--utrecht-link-list-item-font-weight);
+}
+
+@mixin utrecht-link-list__link {
+  align-items: baseline;
+  column-gap: var(--utrecht-link-list-item-column-gap);
+  display: inline-flex;
+}

--- a/components/link-list/src/_mixin.scss
+++ b/components/link-list/src/_mixin.scss
@@ -34,11 +34,11 @@
   --utrecht-icon-inset-block-start: var(--utrecht-link-list-icon-inset-block-start);
 
   display: block;
-  font-weight: var(--utrecht-link-list-item-font-weight);
 }
 
 @mixin utrecht-link-list__link {
   align-items: baseline;
-  column-gap: var(--utrecht-link-list-item-column-gap);
+  column-gap: var(--utrecht-link-list-link-column-gap);
   display: inline-flex;
+  font-weight: var(--utrecht-link-list-link-font-weight);
 }

--- a/components/link-list/src/_mixin.scss
+++ b/components/link-list/src/_mixin.scss
@@ -17,6 +17,14 @@
 }
 
 @mixin utrecht-link-list {
+  /* TODO: I wish we could make `--utrecht-link-text-decoration` fall back to `var(--utrecht-link-text-decoration)`
+   * when `var(--utrecht-link-list-text-decoration)` is not set.
+   */
+  --utrecht-icon-inset-block-start: var(--utrecht-link-list-icon-inset-block-start);
+  --utrecht-icon-size: var(--utrecht-link-list-icon-size);
+  --utrecht-link-icon-size: var(--utrecht-link-list-icon-size);
+  --utrecht-link-text-decoration: var(--utrecht-link-list-link-text-decoration, none);
+
   display: flex;
   flex-direction: column;
   margin-block-end: calc(var(--utrecht-space-around, 0) * var(--utrecht-link-list-margin-block-end, 0));
@@ -25,19 +33,10 @@
 }
 
 @mixin utrecht-link-list__item {
-  --utrecht-icon-size: var(--utrecht-link-list-icon-size);
-  --utrecht-link-icon-size: var(--utrecht-link-list-icon-size);
-  --utrecht-icon-inset-block-start: var(--utrecht-link-list-icon-inset-block-start);
-
   display: block;
 }
 
 @mixin utrecht-link-list__link {
-  /* TODO: I wish we could make it fall back to `var(--utrecht-link-text-decoration)`
-   * when `var(--utrecht-link-list-text-decoration)` is not set.
-   */
-  --utrecht-link-text-decoration: var(--utrecht-link-list-link-text-decoration, none);
-
   align-items: baseline;
   column-gap: var(--utrecht-link-list-link-column-gap);
   display: inline-flex;

--- a/components/link-list/src/index.scss
+++ b/components/link-list/src/index.scss
@@ -4,20 +4,9 @@
  * Copyright (c) 2021 Robbert Broersma
  */
 
-@mixin reset-ul() {
-  margin-block-end: 0;
-  margin-block-start: 0;
-  margin-inline-end: 0;
-  margin-inline-start: 0;
-  padding-inline-start: 0;
-}
-
-@mixin reset-li() {
-  list-style: none;
-}
+@import "./mixin";
 
 /* reset before other stylesheets */
-.utrecht-link-list,
 .utrecht-link-list--html-ul {
   @include reset-ul;
 
@@ -27,28 +16,13 @@
 }
 
 .utrecht-link-list {
-  --utrecht-link-text-decoration: none;
-  --utrecht-link-hover-text-decoration: underline;
-  --utrecht-link-focus-text-decoration: underline;
-
-  display: flex;
-  flex-direction: column;
-  margin-block-end: calc(var(--utrecht-space-around, 0) * var(--utrecht-link-list-margin-block-end, 0));
-  margin-block-start: calc(var(--utrecht-space-around, 0) * var(--utrecht-link-list-margin-block-start, 0));
-  row-gap: var(--utrecht-link-list-row-gap);
+  @include utrecht-link-list;
 }
 
 .utrecht-link-list__item {
-  --utrecht-icon-size: var(--utrecht-link-list-icon-size);
-  --utrecht-link-icon-size: var(--utrecht-link-list-icon-size);
-  --utrecht-icon-inset-block-start: var(--utrecht-link-list-icon-inset-block-start);
-
-  display: block;
-  font-weight: var(--utrecht-link-list-item-font-weight);
+  @include utrecht-link-list__item;
 }
 
 .utrecht-link-list__link {
-  align-items: baseline;
-  column-gap: var(--utrecht-link-list-item-column-gap);
-  display: inline-flex;
+  @include utrecht-link-list__link;
 }

--- a/components/link-list/src/index.scss
+++ b/components/link-list/src/index.scss
@@ -31,8 +31,11 @@
   --utrecht-link-hover-text-decoration: underline;
   --utrecht-link-focus-text-decoration: underline;
 
+  display: flex;
+  flex-direction: column;
   margin-block-end: calc(var(--utrecht-space-around, 0) * var(--utrecht-link-list-margin-block-end, 0));
   margin-block-start: calc(var(--utrecht-space-around, 0) * var(--utrecht-link-list-margin-block-start, 0));
+  row-gap: var(--utrecht-link-list-row-gap);
 }
 
 .utrecht-link-list--distanced {
@@ -46,10 +49,6 @@
 
   display: block;
   font-weight: var(--utrecht-link-list-item-font-weight);
-}
-
-.utrecht-link-list__item + .utrecht-link-list__item {
-  margin-block-start: var(--utrecht-link-list-item-margin-block-start);
 }
 
 .utrecht-link-list__link {

--- a/components/link-list/src/index.scss
+++ b/components/link-list/src/index.scss
@@ -38,10 +38,6 @@
   row-gap: var(--utrecht-link-list-row-gap);
 }
 
-.utrecht-link-list--distanced {
-  --utrecht-space-around: 1;
-}
-
 .utrecht-link-list__item {
   --utrecht-icon-size: var(--utrecht-link-list-icon-size);
   --utrecht-link-icon-size: var(--utrecht-link-list-icon-size);

--- a/components/link-list/src/tokens.json
+++ b/components/link-list/src/tokens.json
@@ -17,15 +17,15 @@
           }
         }
       },
-      "item": {
-        "margin-block-start": {
-          "$extensions": {
-            "nl.nldesignsystem.css.property": {
-              "syntax": "<length>",
-              "inherits": true
-            }
+      "row-gap": {
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
           }
-        },
+        }
+      },
+      "item": {
         "column-gap": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {

--- a/components/link-list/src/tokens.json
+++ b/components/link-list/src/tokens.json
@@ -41,6 +41,15 @@
               "inherits": true
             }
           }
+        },
+        "text-decoration": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "none | underline",
+              "inherits": true
+            }
+          },
+          "type": "textDecoration"
         }
       },
       "icon": {

--- a/components/link-list/src/tokens.json
+++ b/components/link-list/src/tokens.json
@@ -25,11 +25,19 @@
           }
         }
       },
-      "item": {
+      "link": {
         "column-gap": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<length>",
+              "inherits": true
+            }
+          }
+        },
+        "font-weight": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<number>",
               "inherits": true
             }
           }

--- a/packages/component-library-react/src/LinkList.tsx
+++ b/packages/component-library-react/src/LinkList.tsx
@@ -38,7 +38,12 @@ export const LinkList = forwardRef(
     { children, icon, links, className, ...restProps }: PropsWithChildren<LinkListProps>,
     ref: ForwardedRef<HTMLUListElement>,
   ) => (
-    <ul ref={ref} className={clsx('utrecht-link-list', 'utrecht-link-list--html-ul', className)} {...restProps}>
+    <ul
+      role="list"
+      ref={ref}
+      className={clsx('utrecht-link-list', 'utrecht-link-list--html-ul', className)}
+      {...restProps}
+    >
       {children}
       {Array.isArray(links) &&
         links.map((linkProps, index) => (

--- a/packages/storybook-css/src/PageFooter.stories.tsx
+++ b/packages/storybook-css/src/PageFooter.stories.tsx
@@ -1,10 +1,20 @@
 /* @license CC0-1.0 */
 
 import { Meta, StoryObj } from '@storybook/react';
-import { Heading2, Heading3, Link, PageFooter, Paragraph, Strong } from '@utrecht/component-library-react';
+import {
+  Heading2,
+  Heading3,
+  Link,
+  LinkList,
+  LinkListLink,
+  PageFooter,
+  Paragraph,
+  Strong,
+} from '@utrecht/component-library-react';
 import tokens from '@utrecht/design-tokens/dist/index.json';
 import readme from '@utrecht/page-footer-css/README.md?raw';
 import tokensDefinition from '@utrecht/page-footer-css/src/tokens.json';
+import { UtrechtIconChevronRight } from '@utrecht/web-component-library-react';
 import React from 'react';
 import { designTokenStory } from './design-token-story';
 
@@ -58,14 +68,14 @@ export const Default: Story = {
         </section>
       </address>,
       <div className="utrecht-page-footer__navigation">
-        <ul className="utrecht-link-list utrecht-link-list--chevron">
-          <li className="utrecht-link-list__item">
-            <Link href="/contact/">Meer contactinformatie</Link>
-          </li>
-          <li className="utrecht-link-list__item">
-            <Link href="/over-deze-website">Over deze website</Link>
-          </li>
-        </ul>
+        <LinkList>
+          <LinkListLink href="/contact/" icon={<UtrechtIconChevronRight />}>
+            Meer contactinformatie
+          </LinkListLink>
+          <LinkListLink href="/over-deze-website" icon={<UtrechtIconChevronRight />}>
+            Over deze website
+          </LinkListLink>
+        </LinkList>
       </div>,
     ],
   },

--- a/proprietary/design-tokens/src/component/utrecht/link-list.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/link-list.tokens.json
@@ -4,7 +4,7 @@
       "row-gap": {
         "value": "{utrecht.space.block.xs}"
       },
-      "item": {
+      "link": {
         "font-weight": {
           "value": "{utrecht.typography.weight-scale.bold.font-weight}"
         },

--- a/proprietary/design-tokens/src/component/utrecht/link-list.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/link-list.tokens.json
@@ -10,6 +10,9 @@
         },
         "column-gap": {
           "value": "{utrecht.space.block.xs}"
+        },
+        "text-decoration": {
+          "value": "none"
         }
       },
       "icon": {

--- a/proprietary/design-tokens/src/component/utrecht/link-list.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/link-list.tokens.json
@@ -1,10 +1,10 @@
 {
   "utrecht": {
     "link-list": {
+      "row-gap": {
+        "value": "{utrecht.space.block.xs}"
+      },
       "item": {
-        "margin-block-start": {
-          "value": "{utrecht.space.block.xs}"
-        },
         "font-weight": {
           "value": "{utrecht.typography.weight-scale.bold.font-weight}"
         },


### PR DESCRIPTION
This is part of getting the [Link list in the NL Design System community Figma](https://www.figma.com/design/gX3fq7k0uUKC45AJbuItDv/Local---Voorbeeld---Bibliotheek?node-id=1548-6863&t=KuOvWHVyjBq0moFp-4) consistent with the code from the Utrecht community component.

See also: [Link list GitHub discussion at NL Design System](https://github.com/orgs/nl-design-system/discussions/266)