### PR TITLE
style: refactor alert design tokens

### DIFF
--- a/.changeset/lemon-cheetahs-live.md
+++ b/.changeset/lemon-cheetahs-live.md
@@ -19,4 +19,5 @@ Refactor the Alert component for more consistent token names and use flex instea
 - Add `utrecht.alert.content.row-gap` token
 - Add `utrecht.alert.icon.size` token
 - Add `utrecht.alert.icon.inset-block-start` token
+- Add `utrecht-alert__content` class
 - Change implementation of layout from grid to flex

--- a/.changeset/lemon-cheetahs-live.md
+++ b/.changeset/lemon-cheetahs-live.md
@@ -1,0 +1,22 @@
+---
+"@utrecht/design-tokens": major
+"@utrecht/alert-css": major
+"@utrecht/components": major
+"@utrecht/component-library-angular": major
+"@utrecht/component-library-css": major
+"@utrecht/component-library-react": major
+"@utrecht/component-library-vue": major
+"@utrecht/web-component-library-angular": major
+"@utrecht/web-component-library-react": major
+"@utrecht/web-component-library-stencil": major
+"@utrecht/web-component-library-vue": major
+---
+
+Refactor the Alert component for more consistent token names and use flex instead of grid layout. Adding support for content and message sections.
+
+- Rename `utrecht.alert.icon.gap` to `utrecht.alert.column-gap`
+- Add `utrecht.alert.message.row-gap` token
+- Add `utrecht.alert.content.row-gap` token
+- Add `utrecht.alert.icon.size` token
+- Add `utrecht.alert.icon.inset-block-start` token
+- Change implementation of layout from grid to flex

--- a/components/alert/README.md
+++ b/components/alert/README.md
@@ -33,11 +33,13 @@ Als je wel een button gebruikt (bijvoorbeeld om de alert te verbergen), plaats d
   <div class="utrecht-alert__icon">
     <!-- optioneel: een icon -->
   </div>
-  <div class="utrecht-alert__message" role="alert">
-    <!-- het bericht, bijvoorbeeld: -->
-    <p class="utrecht-paragraph">Let op: er is nu een storing waardoor...</p>
+  <div class="utrecht-alert__content">
+    <div class="utrecht-alert__message" role="alert">
+      <!-- het bericht, bijvoorbeeld: -->
+      <p class="utrecht-paragraph">Let op: er is nu een storing waardoor...</p>
+    </div>
+    <!-- optioneel en nog niet ondersteund: een button, buiten het bericht -->
   </div>
-  <!-- optioneel en nog niet ondersteund: een button, buiten het bericht -->
 </div>
 ```
 

--- a/components/alert/src/_mixin.scss
+++ b/components/alert/src/_mixin.scss
@@ -11,10 +11,9 @@
   border-style: solid;
   border-width: var(--_utrecht-alert-border-width, var(--utrecht-alert-border-width, 0));
   color: var(--_utrecht-alert-color, var(--utrecht-alert-color));
-  display: grid;
-  gap: var(--utrecht-alert-icon-gap);
-  grid-template-areas: "icon message";
-  grid-template-columns: 0fr 100fr;
+  column-gap: var(--utrecht-alert-column-gap);
+  display: flex;
+  flex-direction: row;
   margin-block-end: calc(var(--utrecht-space-around, 0) * var(--utrecht-alert-margin-block-end, 0));
   margin-block-start: calc(var(--utrecht-space-around, 0) * var(--utrecht-alert-margin-block-start, 0));
   padding-block-end: var(--utrecht-alert-padding-block-end);
@@ -25,12 +24,17 @@
 
 @mixin utrecht-alert__icon {
   --utrecht-icon-color: var(--_utrecht-alert-icon-color, var(--utrecht-alert-icon-color));
-
-  grid-area: icon;
+  --utrecht-icon-size: var(--utrecht-alert-icon-size);
+  --utrecht-icon-inset-block-start: var(--utrecht-alert-icon-inset-block-start);
 }
 
+@mixin utrecht-alert__content {
+  row-gap: var(--utrecht-alert-content-row-gap);
+}
+
+/* stylelint-disable-next-line block-no-empty */
 @mixin utrecht-alert__message {
-  grid-area: message;
+  row-gap: var(--utrecht-alert-message-row-gap);
 }
 
 @mixin utrecht-alert-type($type) {

--- a/components/alert/src/index.scss
+++ b/components/alert/src/index.scss
@@ -14,6 +14,10 @@
   @include utrecht-alert__icon;
 }
 
+.utrecht-alert__content {
+  @include utrecht-alert__content;
+}
+
 .utrecht-alert__message {
   @include utrecht-alert__message;
 }

--- a/components/alert/src/tokens.json
+++ b/components/alert/src/tokens.json
@@ -41,6 +41,14 @@
           }
         }
       },
+      "column-gap": {
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          }
+        }
+      },
       "padding-block-start": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
@@ -86,6 +94,26 @@
           "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
             "inherits": true
+          }
+        }
+      },
+      "message": {
+        "row-gap": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
+          }
+        }
+      },
+      "content": {
+        "row-gap": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
           }
         }
       },
@@ -250,7 +278,15 @@
             }
           }
         },
-        "gap": {
+        "size": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            }
+          }
+        },
+        "inset-block-start": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<length>",

--- a/packages/component-library-react/src/Alert.tsx
+++ b/packages/component-library-react/src/Alert.tsx
@@ -33,7 +33,11 @@ export const Alert = forwardRef(
       )}
     >
       {icon && <div className="utrecht-alert__icon">{icon}</div>}
-      <div className="utrecht-alert__message">{children}</div>
+      <div className="utrecht-alert__content">
+        <div className="utrecht-alert__message" role="alert">
+          {children}
+        </div>
+      </div>
     </div>
   ),
 );

--- a/packages/storybook-css/src/Alert.stories.tsx
+++ b/packages/storybook-css/src/Alert.stories.tsx
@@ -4,17 +4,30 @@ import type { Meta, StoryObj } from '@storybook/react';
 import readme from '@utrecht/alert-css/README.md?raw';
 import tokensDefinition from '@utrecht/alert-css/src/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
-import { UtrechtIconCross } from '@utrecht/web-component-library-react';
+import iconSet from '@utrecht/icon/dist/index.json';
 import React from 'react';
-import { Alert } from './Alert';
+import { Alert, AlertProps } from './Alert';
 import { Heading2 } from './Heading2';
 import { Paragraph } from './Paragraph';
 import { designTokenStory } from './design-token-story';
 
+interface AlertStoryProps extends AlertProps {
+  icon?: string;
+}
+
+const AlertStory = ({ children, icon, ...props }: AlertStoryProps) => {
+  const IconElement = icon;
+  return (
+    <Alert icon={IconElement ? <IconElement /> : null} {...props}>
+      {children}
+    </Alert>
+  );
+};
+
 const meta = {
   title: 'CSS Component/Alert',
   id: 'css-alert',
-  component: Alert,
+  component: AlertStory,
   argTypes: {
     children: {
       description: 'HTML content of the alert',
@@ -23,6 +36,11 @@ const meta = {
       description: 'Type',
       control: { type: 'select' },
       options: ['', 'error', 'info', 'ok', 'warning'],
+    },
+    icon: {
+      description: 'Icon',
+      control: { type: 'select' },
+      options: ['', ...iconSet.map(({ id }) => id)],
     },
   },
   args: {
@@ -57,7 +75,7 @@ const meta = {
       },
     },
   },
-} satisfies Meta<typeof Alert>;
+} satisfies Meta<typeof AlertStory>;
 
 export default meta;
 
@@ -79,15 +97,21 @@ export const OK: Story = {
 
 export const Warning: Story = {
   args: {
-    icon: <UtrechtIconCross />,
     type: 'warning',
   },
 };
 
 export const Error: Story = {
   args: {
-    icon: <UtrechtIconCross />,
     type: 'error',
+  },
+};
+
+export const WithIcon: Story = {
+  args: {
+    ...Default.args,
+    type: 'info',
+    icon: 'utrecht-icon-loupe',
   },
 };
 

--- a/packages/storybook-css/src/Alert.stories.tsx
+++ b/packages/storybook-css/src/Alert.stories.tsx
@@ -4,6 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import readme from '@utrecht/alert-css/README.md?raw';
 import tokensDefinition from '@utrecht/alert-css/src/tokens.json';
 import tokens from '@utrecht/design-tokens/dist/index.json';
+import { UtrechtIconCross } from '@utrecht/web-component-library-react';
 import React from 'react';
 import { Alert } from './Alert';
 import { Heading2 } from './Heading2';
@@ -78,12 +79,14 @@ export const OK: Story = {
 
 export const Warning: Story = {
   args: {
+    icon: <UtrechtIconCross />,
     type: 'warning',
   },
 };
 
 export const Error: Story = {
   args: {
+    icon: <UtrechtIconCross />,
     type: 'error',
   },
 };

--- a/packages/storybook-css/src/Alert.tsx
+++ b/packages/storybook-css/src/Alert.tsx
@@ -3,7 +3,12 @@
 import clsx from 'clsx';
 import React, { PropsWithChildren, ReactNode } from 'react';
 
-export const Alert = ({ children, icon = null, type }: PropsWithChildren<{ icon?: ReactNode; type?: string }>) => (
+export interface AlertProps extends PropsWithChildren {
+  icon?: ReactNode;
+  type?: string;
+}
+
+export const Alert = ({ children, icon = null, type }: PropsWithChildren<AlertProps>) => (
   <div
     className={clsx('utrecht-alert', {
       'utrecht-alert--error': type === 'error',
@@ -13,8 +18,10 @@ export const Alert = ({ children, icon = null, type }: PropsWithChildren<{ icon?
     })}
   >
     {icon && <div className="utrecht-alert__icon">{icon}</div>}
-    <div className="utrecht-alert__message" role="alert">
-      {children}
+    <div className="utrecht-alert__content">
+      <div className="utrecht-alert__message" role="alert">
+        {children}
+      </div>
     </div>
   </div>
 );

--- a/packages/storybook-react/src/stories/Alert.stories.tsx
+++ b/packages/storybook-react/src/stories/Alert.stories.tsx
@@ -1,15 +1,32 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import readme from '@utrecht/alert-css/README.md?raw';
 import tokensDefinition from '@utrecht/alert-css/src/tokens.json';
-import { Alert, Heading1, Paragraph } from '@utrecht/component-library-react/dist/css-module';
+import { Alert, AlertProps, Heading1, Paragraph } from '@utrecht/component-library-react/dist/css-module';
 import tokens from '@utrecht/design-tokens/dist/index.json';
+import iconSet from '@utrecht/icon/dist/index.json';
 import React from 'react';
 import { designTokenStory } from './util';
+
+interface AlertStoryProps extends AlertProps {
+  icon?: string;
+}
+
+const AlertStory = ({ children, icon, ...props }: AlertStoryProps) => {
+  const IconElement = icon;
+  return <Alert icon={IconElement ? <IconElement /> : null}>{children}</Alert>;
+};
 
 const meta = {
   title: 'React Component/Alert',
   id: 'react-alert',
-  component: Alert,
+  component: AlertStory,
+  argTypes: {
+    icon: {
+      description: 'Icon',
+      control: { type: 'select' },
+      options: ['', ...iconSet.map(({ id }) => id)],
+    },
+  },
   args: {
     children: [
       <Heading1>Lorem ipsum</Heading1>,
@@ -21,6 +38,7 @@ const meta = {
         laborum.
       </Paragraph>,
     ],
+    icon: '',
   },
   parameters: {
     tokensPrefix: 'utrecht-alert',
@@ -32,7 +50,7 @@ const meta = {
       },
     },
   },
-} satisfies Meta<typeof Alert>;
+} satisfies Meta<typeof AlertStory>;
 
 export default meta;
 
@@ -64,6 +82,14 @@ export const Error: Story = {
   args: {
     ...Default.args,
     type: 'error',
+  },
+};
+
+export const WithIcon: Story = {
+  args: {
+    ...Default.args,
+    type: 'info',
+    icon: 'utrecht-icon-loupe',
   },
 };
 

--- a/packages/web-component-library-stencil/src/components/alert.tsx
+++ b/packages/web-component-library-stencil/src/components/alert.tsx
@@ -28,8 +28,10 @@ export class Alert {
         <div class="utrecht-alert__icon">
           <slot name="icon"></slot>
         </div>
-        <div class="utrecht-alert__message">
-          <slot></slot>
+        <div class="utrecht-alert__content">
+          <div class="utrecht-alert__message">
+            <slot></slot>
+          </div>
         </div>
       </div>
     );

--- a/proprietary/design-tokens/src/component/utrecht/alert.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/alert.tokens.json
@@ -2,7 +2,11 @@
   "utrecht": {
     "alert": {
       "background-color": { "value": "{utrecht.color.blue.90}" },
+      "border-color": {},
+      "border-width": {},
+      "border-radius": {},
       "color": { "value": "{utrecht.color.black}" },
+      "column-gap": { "value": "{utrecht.space.column.md}" },
       "padding-block-end": { "value": "{utrecht.space.block.lg}" },
       "padding-block-start": { "value": "{utrecht.space.block.lg}" },
       "padding-inline-end": { "value": "{utrecht.space.block.lg}" },
@@ -32,8 +36,8 @@
         "border-width": {}
       },
       "icon": {
+        "size": { "value": "24px" },
         "color": { "value": "{utrecht.color.blue.35}" },
-        "gap": { "value": "{utrecht.space.column.md}" },
         "info": {
           "color": { "value": "{utrecht.color.blue.35}" }
         },

--- a/proprietary/design-tokens/src/component/utrecht/alert.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/alert.tokens.json
@@ -37,6 +37,7 @@
       },
       "icon": {
         "size": { "value": "24px" },
+        "inset-block-start": { "value": "6px" },
         "color": { "value": "{utrecht.color.blue.35}" },
         "info": {
           "color": { "value": "{utrecht.color.blue.35}" }


### PR DESCRIPTION
Refactor the Alert component for more consistent token names and use flex instead of grid layout. Adding support for content and message sections.

- Rename `utrecht.alert.icon.gap` to `utrecht.alert.column-gap`
- Add `utrecht.alert.message.row-gap` token
- Add `utrecht.alert.content.row-gap` token
- Add `utrecht.alert.icon.size` token
- Add `utrecht.alert.icon.inset-block-start` token
- Change implementation of layout from grid to flex

(_Totally didn't copy paste the changelog_)