### PR TITLE
feat: button appearance font-size and line-height tokens

### DIFF
--- a/.changeset/dry-rats-dress.md
+++ b/.changeset/dry-rats-dress.md
@@ -1,0 +1,5 @@
+---
+"@utrecht/button-css": minor
+---
+
+Add `utrecht-button-appearance-properties` mixin, to generate the custom properties for a button variant without the selector.

--- a/.changeset/tough-apricots-drum.md
+++ b/.changeset/tough-apricots-drum.md
@@ -1,0 +1,24 @@
+---
+"@utrecht/button-css": minor
+"@utrecht/components": minor
+"@utrecht/combobox-css": minor
+"@utrecht/component-library-angular": minor
+"@utrecht/component-library-css": minor
+"@utrecht/component-library-react": minor
+"@utrecht/component-library-vue": minor
+"@utrecht/web-component-library-angular": minor
+"@utrecht/web-component-library-react": minor
+"@utrecht/web-component-library-stencil": minor
+"@utrecht/web-component-library-vue": minor
+---
+
+Button now support two new design tokens for each appearance: `font-size` and a matching `line-height`. These are optional, by default the button still uses `utrecht.button.font-size` and `utrecht.button.line-height`.
+
+These are the 6 new design tokens:
+
+- `utrecht.button.primary-action.font-size`
+- `utrecht.button.primary-action.line-height`
+- `utrecht.button.secondary-action.font-size`
+- `utrecht.button.secondary-action.line-height`
+- `utrecht.button.subtle.font-size`
+- `utrecht.button.subtle.line-height`

--- a/components/button/src/_mixin.scss
+++ b/components/button/src/_mixin.scss
@@ -206,6 +206,8 @@
     --utrecht-button-border-bottom-width,
     var(--_utrecht-button-border-width, 0)
   );
+  --_utrecht-button-font-size: var(--_utrecht-button-appearance-font-size, var(--utrecht-button-font-size));
+  --_utrecht-button-line-height: var(--_utrecht-button-appearance-line-height, var(--utrecht-button-line-height));
   --utrecht-icon-size: var(--utrecht-button-icon-size, 1em);
 
   align-items: center;
@@ -221,13 +223,13 @@
   color: var(--_utrecht-button-color);
   cursor: var(--utrecht-action-activate-cursor, revert);
   display: inline-flex;
-  font-family: var(--utrecht-button-font-family, var(--utrecht-document-font-family));
-  font-size: var(--utrecht-button-font-size, var(--utrecht-document-font-family, inherit));
+  font-family: var(--_utrecht-button-font-family, var(--utrecht-document-font-family));
+  font-size: var(--_utrecht-button-font-size, var(--utrecht-document-font-family, inherit));
   font-weight: var(--_utrecht-button-appearance-font-weight, var(--utrecht-button-font-weight));
   gap: var(--utrecht-button-icon-gap);
   inline-size: var(--utrecht-button-inline-size, auto);
   justify-content: center;
-  line-height: var(--utrecht-button-line-height);
+  line-height: var(--_utrecht-button-line-height);
   max-inline-size: var(--utrecht-button-max-inline-size, fit-content);
   min-block-size: var(--utrecht-button-min-block-size, 44px);
   min-inline-size: var(--utrecht-button-min-inline-size, 44px);
@@ -321,7 +323,9 @@
   --_utrecht-button-appearance-border-color: var(--utrecht-button-#{$modifier}-border-color);
   --_utrecht-button-appearance-border-width: var(--utrecht-button-#{$modifier}-border-width);
   --_utrecht-button-appearance-color: var(--utrecht-button-#{$modifier}-color);
+  --_utrecht-button-appearance-font-size: var(--utrecht-button-#{$modifier}-font-size);
   --_utrecht-button-appearance-font-weight: var(--utrecht-button-#{$modifier}-font-weight);
+  --_utrecht-button-appearance-line-height: var(--utrecht-button-#{$modifier}-line-height);
   --_utrecht-button-appearance-disabled-background-color: var(--utrecht-button-#{$modifier}-disabled-background-color);
   --_utrecht-button-appearance-disabled-border-color: var(--utrecht-button-#{$modifier}-disabled-border-color);
   --_utrecht-button-appearance-disabled-color: var(--utrecht-button-#{$modifier}-disabled-color);

--- a/components/button/src/_mixin.scss
+++ b/components/button/src/_mixin.scss
@@ -313,30 +313,32 @@
   color: var(--_utrecht-button-pressed-color);
 }
 
+@mixin utrecht-button-appearance-properties($block, $modifier) {
+  --_utrecht-button-appearance-active-background-color: var(--utrecht-button-#{$modifier}-active-background-color);
+  --_utrecht-button-appearance-active-border-color: var(--utrecht-button-#{$modifier}-active-border-color);
+  --_utrecht-button-appearance-active-color: var(--utrecht-button-#{$modifier}-active-color);
+  --_utrecht-button-appearance-background-color: var(--utrecht-button-#{$modifier}-background-color);
+  --_utrecht-button-appearance-border-color: var(--utrecht-button-#{$modifier}-border-color);
+  --_utrecht-button-appearance-border-width: var(--utrecht-button-#{$modifier}-border-width);
+  --_utrecht-button-appearance-color: var(--utrecht-button-#{$modifier}-color);
+  --_utrecht-button-appearance-font-weight: var(--utrecht-button-#{$modifier}-font-weight);
+  --_utrecht-button-appearance-disabled-background-color: var(--utrecht-button-#{$modifier}-disabled-background-color);
+  --_utrecht-button-appearance-disabled-border-color: var(--utrecht-button-#{$modifier}-disabled-border-color);
+  --_utrecht-button-appearance-disabled-color: var(--utrecht-button-#{$modifier}-disabled-color);
+  --_utrecht-button-appearance-focus-background-color: var(--utrecht-button-#{$modifier}-focus-background-color);
+  --_utrecht-button-appearance-focus-border-color: var(--utrecht-button-#{$modifier}-focus-border-color);
+  --_utrecht-button-appearance-focus-color: var(--utrecht-button-#{$modifier}-focus-color);
+  --_utrecht-button-appearance-hover-background-color: var(--utrecht-button-#{$modifier}-hover-background-color);
+  --_utrecht-button-appearance-hover-border-color: var(--utrecht-button-#{$modifier}-hover-border-color);
+  --_utrecht-button-appearance-hover-color: var(--utrecht-button-#{$modifier}-hover-color);
+  --_utrecht-button-appearance-pressed-background-color: var(--utrecht-button-#{$modifier}-pressed-background-color);
+  --_utrecht-button-appearance-pressed-border-color: var(--utrecht-button-#{$modifier}-pressed-border-color);
+  --_utrecht-button-appearance-pressed-color: var(--utrecht-button-#{$modifier}-pressed-color);
+}
+
 @mixin utrecht-button-appearance($block, $modifier) {
   .#{$block}--#{$modifier} {
-    --_utrecht-button-appearance-active-background-color: var(--utrecht-button-#{$modifier}-active-background-color);
-    --_utrecht-button-appearance-active-border-color: var(--utrecht-button-#{$modifier}-active-border-color);
-    --_utrecht-button-appearance-active-color: var(--utrecht-button-#{$modifier}-active-color);
-    --_utrecht-button-appearance-background-color: var(--utrecht-button-#{$modifier}-background-color);
-    --_utrecht-button-appearance-border-color: var(--utrecht-button-#{$modifier}-border-color);
-    --_utrecht-button-appearance-border-width: var(--utrecht-button-#{$modifier}-border-width);
-    --_utrecht-button-appearance-color: var(--utrecht-button-#{$modifier}-color);
-    --_utrecht-button-appearance-font-weight: var(--utrecht-button-#{$modifier}-font-weight);
-    --_utrecht-button-appearance-disabled-background-color: var(
-      --utrecht-button-#{$modifier}-disabled-background-color
-    );
-    --_utrecht-button-appearance-disabled-border-color: var(--utrecht-button-#{$modifier}-disabled-border-color);
-    --_utrecht-button-appearance-disabled-color: var(--utrecht-button-#{$modifier}-disabled-color);
-    --_utrecht-button-appearance-focus-background-color: var(--utrecht-button-#{$modifier}-focus-background-color);
-    --_utrecht-button-appearance-focus-border-color: var(--utrecht-button-#{$modifier}-focus-border-color);
-    --_utrecht-button-appearance-focus-color: var(--utrecht-button-#{$modifier}-focus-color);
-    --_utrecht-button-appearance-hover-background-color: var(--utrecht-button-#{$modifier}-hover-background-color);
-    --_utrecht-button-appearance-hover-border-color: var(--utrecht-button-#{$modifier}-hover-border-color);
-    --_utrecht-button-appearance-hover-color: var(--utrecht-button-#{$modifier}-hover-color);
-    --_utrecht-button-appearance-pressed-background-color: var(--utrecht-button-#{$modifier}-pressed-background-color);
-    --_utrecht-button-appearance-pressed-border-color: var(--utrecht-button-#{$modifier}-pressed-border-color);
-    --_utrecht-button-appearance-pressed-color: var(--utrecht-button-#{$modifier}-pressed-color);
+    @include utrecht-button-appearance-properties($block, $modifier);
   }
 }
 

--- a/components/button/src/tokens.json
+++ b/components/button/src/tokens.json
@@ -51,7 +51,8 @@
           "nl.nldesignsystem.css.property": {
             "syntax": "*",
             "inherits": true
-          }
+          },
+          "nl.nldesignsystem.fallback": ["utrecht.document.font-family"]
         },
         "type": "fontFamilies"
       },
@@ -426,6 +427,16 @@
           },
           "type": "color"
         },
+        "font-size": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            },
+            "nl.nldesignsystem.fallback": ["utrecht.button.font-size"]
+          },
+          "type": "fontSizes"
+        },
         "font-weight": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
@@ -435,6 +446,16 @@
             "nl.nldesignsystem.fallback": ["utrecht.button.font-weight"]
           },
           "type": "fontWeights"
+        },
+        "line-height": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            },
+            "nl.nldesignsystem.fallback": ["utrecht.button.line-height"]
+          },
+          "type": "lineHeights"
         },
         "active": {
           "background-color": {
@@ -705,6 +726,16 @@
           },
           "type": "color"
         },
+        "font-size": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            },
+            "nl.nldesignsystem.fallback": ["utrecht.button.font-size"]
+          },
+          "type": "fontSizes"
+        },
         "font-weight": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
@@ -714,6 +745,16 @@
             "nl.nldesignsystem.fallback": ["utrecht.button.font-weight"]
           },
           "type": "fontWeights"
+        },
+        "line-height": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            },
+            "nl.nldesignsystem.fallback": ["utrecht.button.line-height"]
+          },
+          "type": "lineHeights"
         },
         "active": {
           "background-color": {
@@ -976,6 +1017,16 @@
           },
           "type": "color"
         },
+        "font-size": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            },
+            "nl.nldesignsystem.fallback": ["utrecht.button.font-size"]
+          },
+          "type": "fontSizes"
+        },
         "font-weight": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
@@ -985,6 +1036,16 @@
             "nl.nldesignsystem.fallback": ["utrecht.button.font-weight"]
           },
           "type": "fontWeights"
+        },
+        "line-height": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            },
+            "nl.nldesignsystem.fallback": ["utrecht.button.line-height"]
+          },
+          "type": "lineHeights"
         },
         "active": {
           "background-color": {


### PR DESCRIPTION
Resolves #2236 and #1828.

De mogelijkheden zijn nu eindeloos! Maar het belangrijkste is natuurlijk dat de oranje DigiD button nu 18.6667px kan zijn in plaats van 18px om voor een Status A bij het DigiToegankelijk Dashboard.

<img width="691" alt="4 button appearances met diverse font sizes" src="https://github.com/nl-design-system/utrecht/assets/30694/1bceddee-2379-4174-98ff-b2b87748d50e">
