### PR TITLE
feat: :wheelchair: feat(added aria-hidden="true" to svg icons for bet…

### DIFF
--- a/components/icon/svgo.config.mjs
+++ b/components/icon/svgo.config.mjs
@@ -29,6 +29,7 @@ export default {
             fill: 'currentColor',
             height: '1em',
             width: '1em',
+            'aria-hidden': 'true',
           },
         ],
       },


### PR DESCRIPTION
### add aria-hidden="true"  to [Utrecht SVG icon set](https://github.com/nl-design-system/utrecht/tree/main/components/icon) ♿️

- [ ]  The element is hidden from the accessibility API. 

I added the attribute to all the SVG icons by adding it to the svgo.config.mjs file so all SVG icons are affected with
the change
with the added change i tested it in the Utrecht storybook and the icon is hidden/ignored, but still visible on the page

![image](https://github.com/nl-design-system/utrecht/assets/100311542/7c052d4e-fabe-44eb-9d9c-d4b18bef6478)