### PR TITLE
chore: fix SVG title

### DIFF
--- a/components/icon/src/svg/chevron-left.svg
+++ b/components/icon/src/svg/chevron-left.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" width="8" height="14"
     xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 8 14">
-    <title>›</title>
+    <title>‹</title>
     <defs>
         <clipPath id="clippath">
             <rect width="8" height="14" style="fill:none; stroke-width:0px;" />

--- a/components/icon/src/svg/chevron-right.svg
+++ b/components/icon/src/svg/chevron-right.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" width="8" height="14"
     xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 8 14">
-    <title>‹</title>
+    <title>›</title>
     <defs>
         <clipPath id="clippath">
             <rect width="8" height="14" style="fill:none; stroke-width:0px;" />


### PR DESCRIPTION
Does not affect the working, because both characters are flagged as bidirectional in Unicode. No changeset needed.