### PR TITLE
fix: avoid translation of index characters

### DIFF
--- a/packages/component-library-react/src/IndexCharNav.test.tsx
+++ b/packages/component-library-react/src/IndexCharNav.test.tsx
@@ -146,7 +146,7 @@ describe('Index character navigation', () => {
 
     render(<IndexCharNav characters={characters} currentChar="A" />);
 
-    const link = screen.queryByText('A');
+    const link = screen.getByRole('link', { name: 'A' });
 
     expect(link).toHaveClass('utrecht-button-link--primary-action');
   });
@@ -156,7 +156,7 @@ describe('Index character navigation', () => {
 
     render(<IndexCharNav characters={characters} currentChar="C" />);
 
-    const link = screen.queryByText('B');
+    const link = screen.getByRole('link', { name: 'B' });
     expect(link).toHaveClass('utrecht-button-link--secondary-action');
   });
 
@@ -165,7 +165,7 @@ describe('Index character navigation', () => {
 
     render(<IndexCharNav characters={characters} currentChar="A" />);
 
-    const link = screen.queryByText('A');
+    const link = screen.getByRole('link', { name: 'A' });
 
     expect(link).toHaveClass('utrecht-index-char-nav__link--current');
   });
@@ -175,7 +175,7 @@ describe('Index character navigation', () => {
 
     render(<IndexCharNav characters={characters} currentChar="A" component="button" />);
 
-    const link = screen.queryByText('A');
+    const link = screen.getByRole('button', { name: 'A' });
 
     expect(link).toHaveClass('utrecht-button--primary-action');
   });
@@ -185,7 +185,7 @@ describe('Index character navigation', () => {
 
     render(<IndexCharNav characters={characters} currentChar="C" component="button" />);
 
-    const link = screen.queryByText('B');
+    const link = screen.getByRole('button', { name: 'B' });
     expect(link).toHaveClass('utrecht-button--secondary-action');
   });
 
@@ -194,7 +194,7 @@ describe('Index character navigation', () => {
 
     render(<IndexCharNav characters={characters} currentChar="A" component="button" />);
 
-    const link = screen.queryByText('A');
+    const link = screen.getByRole('button', { name: 'A' });
 
     expect(link).toHaveClass('utrecht-index-char-nav__link--current');
   });
@@ -210,7 +210,7 @@ describe('Index character navigation', () => {
     const characters = [{ char: 'B', disabled: true, href: './b/' }];
     render(<IndexCharNav characters={characters} currentChar="A" Link={CustomLink} />);
 
-    const customLink = screen.getByText('B');
+    const customLink = screen.getByRole('link', { name: 'B' });
     expect(customLink).toHaveClass('utrecht-button-link--placeholder');
   });
 
@@ -218,7 +218,7 @@ describe('Index character navigation', () => {
     const characters = [{ char: 'B', disabled: true, href: './b/' }];
     render(<IndexCharNav characters={characters} />);
 
-    const customLink = screen.getByText('B');
+    const customLink = screen.getByRole('link', { name: 'B' });
     expect(customLink).toHaveClass('utrecht-button-link--placeholder');
   });
 
@@ -283,5 +283,25 @@ describe('Index character navigation', () => {
     fireEvent.click(letterA);
 
     expect(mockHandleLetterClick).toHaveBeenCalledWith('A');
+  });
+
+  it('prevents translation of the letters in links', () => {
+    const characters = [{ char: 'A', href: './a/' }];
+
+    render(<IndexCharNav characters={characters} component="link" />);
+
+    const text = screen.queryByText('A');
+
+    expect(text?.closest('[translate]')).toHaveAttribute('translate', 'no');
+  });
+
+  it('prevents translation of the letters in buttons', () => {
+    const characters = [{ char: 'A', href: './a/' }];
+
+    render(<IndexCharNav characters={characters} component="button" />);
+
+    const text = screen.queryByText('A');
+
+    expect(text?.closest('[translate]')).toHaveAttribute('translate', 'no');
   });
 });

--- a/packages/component-library-react/src/IndexCharNav.tsx
+++ b/packages/component-library-react/src/IndexCharNav.tsx
@@ -83,7 +83,8 @@ export const IndexCharNav = forwardRef(
             onClick={() => typeof onLinkClick === 'function' && onLinkClick(char)}
             pressed={current}
           >
-            {char}
+            {/* The character must not be translated, but any aria-label attributes should be translatable */}
+            <span translate="no">{char}</span>
           </Button>
         );
       });
@@ -118,7 +119,7 @@ export const IndexCharNav = forwardRef(
             onClick={() => typeof onLinkClick === 'function' && onLinkClick(char)}
             {...restProps}
           >
-            {char}
+            <span translate="no">{char}</span>
           </LinkComponent>
         );
       });


### PR DESCRIPTION
Voorkomt dit soort rare situaties:

## Before

Arabic:

<img width="1021" alt="Index navigation translated to Arabic with Google Translate, with some letters translated to words" src="https://github.com/user-attachments/assets/975173c8-b6b4-4ed3-8617-4cd94316e014">

Chinese (Traditional):
<img width="1036" alt="ScrIndex navigation translated to Chinese (Traditional) with Google Translate, with some letters translated to characters and some characters left intract" src="https://github.com/user-attachments/assets/576e425d-b9c4-4ae0-8708-b3f61f73665d">

Ik moest enkele bestaande unit tests refactoren om dit mogelijk te maken.

## After

<img width="1266" alt="Screenshot 2024-07-22 at 14 06 20" src="https://github.com/user-attachments/assets/2b8fe945-ff56-4630-9315-297d746be829">
