### PR TITLE
fix: metadata for backdrop

### DIFF
--- a/.changeset/attitude-belt-cross.md
+++ b/.changeset/attitude-belt-cross.md
@@ -2,4 +2,13 @@
 "@utrecht/backdrop-css": minor
 ---
 
-Added and fixed metadata for backdrop tokens.
+Fixed metadata for backdrop.
+
+[Available tokens in Token Studio](https://docs.tokens.studio/available-tokens/available-tokens)
+
+Not supported
+- `z-index`
+- `animation-duration`
+
+Supported
+- `opacity`

--- a/.changeset/attitude-belt-cross.md
+++ b/.changeset/attitude-belt-cross.md
@@ -1,0 +1,5 @@
+---
+"@utrecht/backdrop-css": minor
+---
+
+Added and fixed metadata for backdrop tokens.

--- a/components/backdrop/src/tokens.json
+++ b/components/backdrop/src/tokens.json
@@ -60,7 +60,7 @@
               "syntax": "<number>",
               "inherits": true
             },
-            "nl.nldesignsystem.figma.supports-token": false
+            "nl.nldesignsystem.figma.supports-token": true
           },
           "type": "opacity"
         }

--- a/components/backdrop/src/tokens.json
+++ b/components/backdrop/src/tokens.json
@@ -60,7 +60,7 @@
               "syntax": "<number>",
               "inherits": true
             },
-            "nl.nldesignsystem.figma.supports-token": true
+            "nl.nldesignsystem.figma.supports-token": false
           },
           "type": "opacity"
         }

--- a/components/backdrop/src/tokens.json
+++ b/components/backdrop/src/tokens.json
@@ -29,7 +29,7 @@
           },
           "nl.nldesignsystem.figma.supports-token": true
         },
-        "type": "other"
+        "type": "opacity"
       },
       "z-index": {
         "$extensions": {
@@ -37,7 +37,7 @@
             "syntax": "<number>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": true
+          "nl.nldesignsystem.figma.supports-token": false
         },
         "type": "other"
       },
@@ -48,7 +48,7 @@
               "syntax": "<time>",
               "inherits": true
             },
-            "nl.nldesignsystem.figma.supports-token": true
+            "nl.nldesignsystem.figma.supports-token": false
           },
           "type": "other"
         }
@@ -60,9 +60,9 @@
               "syntax": "<number>",
               "inherits": true
             },
-            "nl.nldesignsystem.figma.supports-token": true
+            "nl.nldesignsystem.figma.supports-token": false
           },
-          "type": "other"
+          "type": "opacity"
         }
       }
     }


### PR DESCRIPTION
Fixed metadata for backdrop.

[Available tokens in Token Studio](https://docs.tokens.studio/available-tokens/available-tokens)

Not supported
- `z-index`
- `animation-duration`

Supported
- `opacity`
