### PR TITLE
fix: metadata for backdrop

### DIFF
--- a/.changeset/good-sport-resource.md
+++ b/.changeset/good-sport-resource.md
@@ -1,0 +1,16 @@
+---
+"@utrecht/backdrop-css": minor
+---
+
+Fixed metadata for backdrop tokens.
+
+[Available tokens in Token Studio](https://docs.tokens.studio/available-tokens/available-tokens)
+
+Not supported:
+
+- `z-index`
+- `animation-duration`
+
+Supported:
+
+`opacity`

--- a/components/backdrop/src/tokens.json
+++ b/components/backdrop/src/tokens.json
@@ -60,7 +60,7 @@
               "syntax": "<number>",
               "inherits": true
             },
-            "nl.nldesignsystem.figma.supports-token": true
+            "nl.nldesignsystem.figma.supports-token": false
           },
           "type": "opacity"
         }

--- a/components/backdrop/src/tokens.json
+++ b/components/backdrop/src/tokens.json
@@ -29,7 +29,7 @@
           },
           "nl.nldesignsystem.figma.supports-token": true
         },
-        "type": "other"
+        "type": "opacity"
       },
       "z-index": {
         "$extensions": {
@@ -37,7 +37,7 @@
             "syntax": "<number>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": true
+          "nl.nldesignsystem.figma.supports-token": false
         },
         "type": "other"
       },
@@ -48,7 +48,7 @@
               "syntax": "<time>",
               "inherits": true
             },
-            "nl.nldesignsystem.figma.supports-token": true
+            "nl.nldesignsystem.figma.supports-token": false
           },
           "type": "other"
         }
@@ -62,7 +62,7 @@
             },
             "nl.nldesignsystem.figma.supports-token": true
           },
-          "type": "other"
+          "type": "opacity"
         }
       }
     }


### PR DESCRIPTION
Fixed metadata for backdrop.

[Available tokens in Token Studio](https://docs.tokens.studio/available-tokens/available-tokens)

Not supported:

- `z-index`
- `animation-duration`

Supported:

`opacity`