### PR TITLE
fix: metadata for accordion

### DIFF
--- a/.changeset/helpless-listen-perfect.md
+++ b/.changeset/helpless-listen-perfect.md
@@ -2,4 +2,5 @@
 "@utrecht/accordion-css": minor
 ---
 
-Fixed metadata for border-radius token of accordion.
+- Fixed metadata for `border-radius` token of accordion.
+- Added missing tokens and metadata for `accordion.section`

--- a/.changeset/helpless-listen-perfect.md
+++ b/.changeset/helpless-listen-perfect.md
@@ -1,0 +1,5 @@
+---
+"@utrecht/accordion-css": minor
+---
+
+Fixed metadata for border-radius token of accordion.

--- a/components/accordion/src/tokens.json
+++ b/components/accordion/src/tokens.json
@@ -95,7 +95,7 @@
         "border-radius": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
-              "syntax": "<length>",
+              "syntax": "<length-percentage>",
               "inherits": true
             },
             "nl.nldesignsystem.figma.supports-token": true

--- a/components/accordion/src/tokens.json
+++ b/components/accordion/src/tokens.json
@@ -324,6 +324,28 @@
           },
           "type": "spacing"
         }
+      },
+      "section": {
+        "margin-block-start": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "spacing"
+        },
+        "margin-block-end": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "spacing"
+        }
       }
     }
   }

--- a/components/accordion/src/tokens.json
+++ b/components/accordion/src/tokens.json
@@ -256,7 +256,7 @@
                   "syntax": "<color>",
                   "inherits": true
                 },
-                "nl.nldesignsystem.figma.supports-token": true
+                "nl.nldesignsystem.figma.supports-token": false
               },
               "type": "color"
             }


### PR DESCRIPTION
- Fixed metadata for `border-radius` token of accordion.
- Changend figma support value of `button.icon.background-color` form `true` to `false`.
- Added missing tokens and metadata for `accordion.section`