### PR TITLE
ci: check changeset correctness in GitHub Actions as lint step

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "lint-fix:css": "stylelint --fix '**/*.{css,scss}'",
     "lint-fix:js": "eslint --ext '.js,.json,.jsx,.mdx,.ts,.tsx,.vue' --fix --report-unused-disable-directives .",
     "lint-fix:md": "markdownlint --fix '**/*.md'",
+    "lint:changeset": "changeset status",
     "lint:css": "stylelint '**/*.{css,scss}'",
     "lint:js": "eslint --ext '.js,.json,.jsx,.mdx,.ts,.tsx,.vue' --report-unused-disable-directives .",
     "lint:md": "markdownlint '**/*.md'",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "./components/",
     "./components/*/",
     "./packages/*",
+    "./packages/component-library-react/packages/*",
     "./proprietary/*"
   ],
   "repository": {


### PR DESCRIPTION
Fixes the pipeline:
https://github.com/nl-design-system/utrecht/actions/runs/10472110363/job/29001119320#step:7:28

The following error occurs when a package referenced in a changeset cannot be found:

```
  error TypeError: Cannot destructure property 'packageJson' of 'undefined' as it is undefined.
```