### PR TITLE
style: add header margin block tokens

### DIFF
--- a/.changeset/proud-ants-sing.md
+++ b/.changeset/proud-ants-sing.md
@@ -1,0 +1,6 @@
+---
+"@utrecht/accordion-css": minor
+---
+
+Removed white space between content and expand button.
+Added row gap token to accordion for spacing.

--- a/components/accordion/src/_mixin.scss
+++ b/components/accordion/src/_mixin.scss
@@ -6,14 +6,14 @@
 
 /* stylelint-disable-next-line block-no-empty */
 @mixin utrecht-accordion {
+  display: grid;
   margin-block-end: calc(var(--utrecht-space-around, 0) * var(--utrecht-accordion-margin-block-end, 0));
   margin-block-start: calc(var(--utrecht-space-around, 0) * var(--utrecht-accordion-margin-block-start, 0));
+  row-gap: var(--utrecht-accordion-row-gap);
 }
 
 @mixin utrecht-accordion__section {
   break-inside: avoid;
-  margin-block-end: var(--utrecht-accordion-section-margin-block-end);
-  margin-block-start: var(--utrecht-accordion-section-margin-block-start);
 }
 
 @mixin utrecht-accordion__button {
@@ -94,8 +94,6 @@
 }
 
 @mixin utrecht-accordion__header {
-  --utrecht-space-around: 0;
-
-  margin-block-end: calc(var(--utrecht-space-around, 0) * var(--utrecht-accordion-header-margin-block-end, 0));
-  margin-block-start: calc(var(--utrecht-space-around, 0) * var(--utrecht-accordion-header-margin-block-start, 0));
+  margin-block-end: 0;
+  margin-block-start: 0;
 }

--- a/components/accordion/src/_mixin.scss
+++ b/components/accordion/src/_mixin.scss
@@ -95,4 +95,7 @@
 
 @mixin utrecht-accordion__header {
   --utrecht-space-around: 0;
+
+  margin-block-end: calc(var(--utrecht-space-around, 0) * var(--utrecht-accordion-header-margin-block-end, 0));
+  margin-block-start: calc(var(--utrecht-space-around, 0) * var(--utrecht-accordion-header-margin-block-start, 0));
 }

--- a/components/accordion/src/tokens.json
+++ b/components/accordion/src/tokens.json
@@ -21,6 +21,16 @@
         },
         "type": "spacing"
       },
+      "row-gap": {
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "spacing"
+      },
       "button": {
         "padding-inline-end": {
           "$extensions": {

--- a/proprietary/design-tokens/src/component/utrecht/accordion.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/accordion.tokens.json
@@ -1,6 +1,7 @@
 {
   "utrecht": {
     "accordion": {
+      "row-gap": { "value": "{utrecht.space.block.xs}" },
       "section": {
         "margin-block-start": { "value": "{utrecht.space.block.2xs}" },
         "margin-block-end": {}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/180b0ca5-5a0f-4399-943a-2b830dbad47d)

Deze tokens accordion header tokens die ik heb toegevoegd, zijn nodig om de white space tussen de expand button en de content weg te halen.

Die tokens waren er eerst wel voor dat we de html heading hadden toegevoegd.
