### PR TITLE
fix: form toggle token variable name

### DIFF
--- a/.changeset/dominant-first-poor.md
+++ b/.changeset/dominant-first-poor.md
@@ -1,0 +1,3 @@
+Fixed form toggle token variable name te be in line with our naming convention.
+
+`--utrecht-form-toggle-background-disabled-background-color` to `--utrecht-form-toggle-disabled-background-color`

--- a/.changeset/dominant-first-poor.md
+++ b/.changeset/dominant-first-poor.md
@@ -1,3 +1,7 @@
-Fixed form toggle token variable name te be in line with our naming convention.
+---
+"@utrecht/form-toggle-css": patch
+---
+
+Fixed form toggle token variable name to be in line with our naming convention.
 
 `--utrecht-form-toggle-background-disabled-background-color` to `--utrecht-form-toggle-disabled-background-color`

--- a/components/form-toggle/src/_mixin.scss
+++ b/components/form-toggle/src/_mixin.scss
@@ -115,7 +115,7 @@
 }
 
 @mixin utrecht-form-toggle__track--disabled {
-  background-color: var(--utrecht-form-toggle-background-disabled-background-color, #ddd);
+  background-color: var(--utrecht-form-toggle-disabled-background-color, #ddd);
   color: var(--utrecht-form-toggle-disabled-color, black);
 }
 


### PR DESCRIPTION
Fixed form toggle token variable name te be in line with our naming convention.

`--utrecht-form-toggle-background-disabled-background-color` to `--utrecht-form-toggle-disabled-background-color`