### PR TITLE
feat: add metadata for link-social

### DIFF
--- a/.changeset/delicate-dark-coin.md
+++ b/.changeset/delicate-dark-coin.md
@@ -4,4 +4,3 @@
 
 - Added metadata for link-social tokens.
 - Added missing token for --utrecht-link-social-icon-size variable which was found in the mixin.
-- Changed order of tokens so they are easier to scan.

--- a/.changeset/delicate-dark-coin.md
+++ b/.changeset/delicate-dark-coin.md
@@ -1,5 +1,5 @@
 ---
-"@utrecht/{naam-component}-css": minor
+"@utrecht/link-social-css": minor
 ---
 
 - Added metadata for link-social tokens.

--- a/.changeset/delicate-dark-coin.md
+++ b/.changeset/delicate-dark-coin.md
@@ -1,0 +1,7 @@
+---
+"@utrecht/{naam-component}-css": minor
+---
+
+- Added metadata for link-social tokens.
+- Added missing token for --utrecht-link-social-icon-size variable which was found in the mixin.
+- Changed order of tokens so they are easier to scan.

--- a/components/link-social/src/tokens.json
+++ b/components/link-social/src/tokens.json
@@ -6,73 +6,103 @@
           "nl.nldesignsystem.css.property": {
             "syntax": "<color>",
             "inherits": true
-          }
-        }
-      },
-      "border-width": {
-        "$extensions": {
-          "nl.nldesignsystem.css.property": {
-            "syntax": "<length>",
-            "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "color"
       },
       "border-color": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<color>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "color"
       },
-      "size": {
+      "border-width": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
             "inherits": true
-          }
-        }
-      },
-      "margin-inline-start": {
-        "$extensions": {
-          "nl.nldesignsystem.css.property": {
-            "syntax": "<length>",
-            "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "borderWidth"
       },
       "color": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<color>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "color"
       },
-      "hover": {
-        "scale": {
+      "margin-inline-start": {
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "spacing"
+      },
+      "size": {
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "sizing"
+      },
+      "icon": {
+        "size": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<length>",
               "inherits": true
-            }
-          }
-        },
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "sizing"
+        }
+      },
+      "hover": {
         "background-color": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<color>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "color"
         },
         "color": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<color>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "color"
+        },
+        "scale": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "other"
         }
       }
     }

--- a/components/link-social/src/tokens.json
+++ b/components/link-social/src/tokens.json
@@ -97,7 +97,7 @@
         "scale": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
-              "syntax": "<length>",
+              "syntax": "<number>",
               "inherits": true
             },
             "nl.nldesignsystem.figma.supports-token": false


### PR DESCRIPTION
- Added metadata for link-social tokens.
- Added missing token for `--utrecht-link-social-icon-size` variable which was found in the mixin.
- Changed order of tokens so they are easier to scan.