### PR TITLE
feat: add metadata for mapcontrolbutton

### DIFF
--- a/.changeset/sheet-shock-round.md
+++ b/.changeset/sheet-shock-round.md
@@ -1,5 +1,5 @@
 ---
-"@utrecht/mapcontrolbutton}-css": major
+"@utrecht/map-control-button-css": major
 ---
 
 - Added metadata for `mapcontrolbutton` tokens.

--- a/.changeset/sheet-shock-round.md
+++ b/.changeset/sheet-shock-round.md
@@ -1,0 +1,7 @@
+---
+"@utrecht/mapcontrolbutton}-css": major
+---
+
+- Added metadata for `mapcontrolbutton` tokens.
+- Added missing tokens for variables that were in the index.scss file.
+- Removed the tokens `mapcontrolbutton.disabled.hover-background-color` and `mapcontrolbutton.primary-action.hover-background-color`.

--- a/components/mapcontrolbutton/src/tokens.json
+++ b/components/mapcontrolbutton/src/tokens.json
@@ -1,126 +1,262 @@
 {
   "utrecht": {
     "mapcontrolbutton": {
+      "background-color": {
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "color"
+      },
+      "border-color": {
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "color"
+      },
+      "border-radius": {
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length-percentage>",
+            "inherits": true
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "borderRadius"
+      },
+      "border-style": {
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "*",
+            "inherits": true
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "other"
+      },
       "border-width": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "borderWidth"
+      },
+      "color": {
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<color>",
+            "inherits": true
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "color"
       },
       "focus-transform-scale": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<number>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "other"
       },
       "font-size": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "fontSizes"
       },
       "min-block-size": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "sizing"
       },
       "min-inline-size": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "sizing"
       },
       "margin-block-start": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "spacing"
       },
       "margin-block-end": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "spacing"
       },
       "margin-inline-start": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "spacing"
       },
       "margin-inline-end": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "spacing"
       },
       "padding-block-start": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "spacing"
       },
       "padding-block-end": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "spacing"
       },
       "padding-inline-start": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "spacing"
       },
       "padding-inline-end": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "spacing"
       },
       "disabled": {
+        "background-color": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "color"
+        },
+        "border-color": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "color"
+        },
         "color": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<color>",
               "inherits": true
-            }
-          }
-        },
-        "hover-background-color": {
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "color"
+        }
+      },
+      "focus": {
+        "color": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<color>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "color"
+        }
+      },
+      "hover": {
+        "background-color": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "color"
+        }
+      },
+      "label": {
+        "margin-inline-start": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "spacing"
+        },
+        "margin-inline-end": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "spacing"
         }
       },
       "primary-action": {
@@ -129,24 +265,20 @@
             "nl.nldesignsystem.css.property": {
               "syntax": "<color>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "color"
         },
         "color": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<color>",
               "inherits": true
-            }
-          }
-        },
-        "hover-background-color": {
-          "$extensions": {
-            "nl.nldesignsystem.css.property": {
-              "syntax": "<color>",
-              "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "color"
         }
       }
     }


### PR DESCRIPTION
- Added metadata for mapcontrolbutton tokens.
- Added missing tokens for variables that were in the index.scss file.
- Removed the tokens `mapcontrolbutton.disabled.hover-background-color` and `mapcontrolbutton.primary-action.hover-background-color` as I assume it was a mistake.
- Could not find any mention of `mapcontrolbutton.primary-action*` tokens but kept them in there.
- Also wonder about the naming. Should it be mapcontrol-button? Anyway... kept it this way.