### PR TITLE
feat: add metadata for radio-button

### DIFF
--- a/.changeset/stir-lake-route.md
+++ b/.changeset/stir-lake-route.md
@@ -1,0 +1,7 @@
+---
+"@utrecht/radio-button-css": minor
+---
+
+- Added metadata for radio-button tokens.
+- Added `margin-inline-end` token that was available in mixin.
+- Reordered some tokens in json for better scanning of tokens.

--- a/components/radio-button/src/tokens.json
+++ b/components/radio-button/src/tokens.json
@@ -6,40 +6,60 @@
           "nl.nldesignsystem.css.property": {
             "syntax": "<color>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": true
+        },
+        "type": "color"
       },
       "border-color": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<color>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": true
+        },
+        "type": "color"
       },
       "border-width": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": true
+        },
+        "type": "borderWidth"
       },
       "size": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<percentage>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": true
+        },
+        "type": "sizing"
       },
       "margin-block-start": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "spacing"
+      },
+      "margin-inline-end": {
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "spacing"
       },
       "icon": {
         "size": {
@@ -47,19 +67,34 @@
             "nl.nldesignsystem.css.property": {
               "syntax": "<length>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": true
+          },
+          "type": "sizing"
         }
       },
       "active": {
+        "background-color": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            },
+            "nl.nldesignsystem.fallback": ["utrecht.radio-button.background-color"],
+            "nl.nldesignsystem.figma.supports-token": true
+          },
+          "type": "color"
+        },
         "border-color": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<color>",
               "inherits": true
             },
-            "nl.nldesignsystem.fallback": ["utrecht.radio-button.border-color"]
-          }
+            "nl.nldesignsystem.fallback": ["utrecht.radio-button.border-color"],
+            "nl.nldesignsystem.figma.supports-token": true
+          },
+          "type": "color"
         },
         "border-width": {
           "$extensions": {
@@ -67,17 +102,10 @@
               "syntax": "<length>",
               "inherits": true
             },
-            "nl.nldesignsystem.fallback": ["utrecht.radio-button.border-width"]
-          }
-        },
-        "background-color": {
-          "$extensions": {
-            "nl.nldesignsystem.css.property": {
-              "syntax": "<color>",
-              "inherits": true
-            },
-            "nl.nldesignsystem.fallback": ["utrecht.radio-button.background-color"]
-          }
+            "nl.nldesignsystem.fallback": ["utrecht.radio-button.border-width"],
+            "nl.nldesignsystem.figma.supports-token": true
+          },
+          "type": "borderWidth"
         },
         "color": {
           "$extensions": {
@@ -85,86 +113,117 @@
               "syntax": "<color>",
               "inherits": true
             },
-            "nl.nldesignsystem.fallback": ["utrecht.radio-button.color"]
-          }
+            "nl.nldesignsystem.fallback": ["utrecht.radio-button.color"],
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "color"
         }
       },
       "checked": {
+        "background-color": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            },
+            "nl.nldesignsystem.figma.supports-token": true
+          },
+          "type": "color"
+        },
         "border-color": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<color>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": true
+          },
+          "type": "color"
         },
         "border-width": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<length>",
               "inherits": true
-            }
-          }
-        },
-        "background-color": {
-          "$extensions": {
-            "nl.nldesignsystem.css.property": {
-              "syntax": "<color>",
-              "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": true
+          },
+          "type": "borderWidth"
         },
         "color": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<color>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": true
+          },
+          "type": "color"
         },
         "active": {
+          "background-color": {
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              },
+              "nl.nldesignsystem.figma.supports-token": true
+            },
+            "type": "color"
+          },
           "border-color": {
             "$extensions": {
               "nl.nldesignsystem.css.property": {
                 "syntax": "<color>",
                 "inherits": true
-              }
-            }
+              },
+              "nl.nldesignsystem.figma.supports-token": true
+            },
+            "type": "color"
           },
           "border-width": {
             "$extensions": {
               "nl.nldesignsystem.css.property": {
                 "syntax": "<length>",
                 "inherits": true
-              }
-            }
-          },
-          "background-color": {
-            "$extensions": {
-              "nl.nldesignsystem.css.property": {
-                "syntax": "<color>",
-                "inherits": true
-              }
-            }
+              },
+              "nl.nldesignsystem.figma.supports-token": true
+            },
+            "type": "borderWidth"
           },
           "color": {
             "$extensions": {
               "nl.nldesignsystem.css.property": {
                 "syntax": "<color>",
                 "inherits": true
-              }
-            }
+              },
+              "nl.nldesignsystem.figma.supports-token": true
+            },
+            "type": "color"
           }
         },
         "hover": {
+          "background-color": {
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              },
+              "nl.nldesignsystem.fallback": ["utrecht.radio-button.background-color"],
+              "nl.nldesignsystem.figma.supports-token": true
+            },
+            "type": "color"
+          },
           "border-color": {
             "$extensions": {
               "nl.nldesignsystem.css.property": {
                 "syntax": "<color>",
                 "inherits": true
               },
-              "nl.nldesignsystem.fallback": ["utrecht.radio-button.border-color"]
-            }
+              "nl.nldesignsystem.fallback": ["utrecht.radio-button.border-color"],
+              "nl.nldesignsystem.figma.supports-token": true
+            },
+            "type": "color"
           },
           "border-width": {
             "$extensions": {
@@ -172,17 +231,10 @@
                 "syntax": "<length>",
                 "inherits": true
               },
-              "nl.nldesignsystem.fallback": ["utrecht.radio-button.border-width"]
-            }
-          },
-          "background-color": {
-            "$extensions": {
-              "nl.nldesignsystem.css.property": {
-                "syntax": "<color>",
-                "inherits": true
-              },
-              "nl.nldesignsystem.fallback": ["utrecht.radio-button.background-color"]
-            }
+              "nl.nldesignsystem.fallback": ["utrecht.radio-button.border-width"],
+              "nl.nldesignsystem.figma.supports-token": true
+            },
+            "type": "borderWidth"
           },
           "color": {
             "$extensions": {
@@ -190,19 +242,34 @@
                 "syntax": "<color>",
                 "inherits": true
               },
-              "nl.nldesignsystem.fallback": ["utrecht.radio-button.color"]
-            }
+              "nl.nldesignsystem.fallback": ["utrecht.radio-button.color"],
+              "nl.nldesignsystem.figma.supports-token": true
+            },
+            "type": "color"
           }
         },
         "focus": {
+          "background-color": {
+            "$extensions": {
+              "nl.nldesignsystem.css.property": {
+                "syntax": "<color>",
+                "inherits": true
+              },
+              "nl.nldesignsystem.fallback": ["utrecht.radio-button.background-color"],
+              "nl.nldesignsystem.figma.supports-token": true
+            },
+            "type": "color"
+          },
           "border-color": {
             "$extensions": {
               "nl.nldesignsystem.css.property": {
                 "syntax": "<color>",
                 "inherits": true
               },
-              "nl.nldesignsystem.fallback": ["utrecht.radio-button.border-color"]
-            }
+              "nl.nldesignsystem.fallback": ["utrecht.radio-button.border-color"],
+              "nl.nldesignsystem.figma.supports-token": true
+            },
+            "type": "color"
           },
           "border-width": {
             "$extensions": {
@@ -210,17 +277,10 @@
                 "syntax": "<length>",
                 "inherits": true
               },
-              "nl.nldesignsystem.fallback": ["utrecht.radio-button.border-width"]
-            }
-          },
-          "background-color": {
-            "$extensions": {
-              "nl.nldesignsystem.css.property": {
-                "syntax": "<color>",
-                "inherits": true
-              },
-              "nl.nldesignsystem.fallback": ["utrecht.radio-button.background-color"]
-            }
+              "nl.nldesignsystem.fallback": ["utrecht.radio-button.border-width"],
+              "nl.nldesignsystem.figma.supports-token": true
+            },
+            "type": "borderWidth"
           },
           "color": {
             "$extensions": {
@@ -228,20 +288,35 @@
                 "syntax": "<color>",
                 "inherits": true
               },
-              "nl.nldesignsystem.fallback": ["utrecht.radio-button.color"]
-            }
+              "nl.nldesignsystem.fallback": ["utrecht.radio-button.color"],
+              "nl.nldesignsystem.figma.supports-token": true
+            },
+            "type": "color"
           }
         }
       },
       "hover": {
+        "background-color": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            },
+            "nl.nldesignsystem.fallback": ["utrecht.radio-button.background-color"],
+            "nl.nldesignsystem.figma.supports-token": true
+          },
+          "type": "color"
+        },
         "border-color": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<color>",
               "inherits": true
             },
-            "nl.nldesignsystem.fallback": ["utrecht.radio-button.border-color"]
-          }
+            "nl.nldesignsystem.fallback": ["utrecht.radio-button.border-color"],
+            "nl.nldesignsystem.figma.supports-token": true
+          },
+          "type": "color"
         },
         "border-width": {
           "$extensions": {
@@ -249,17 +324,10 @@
               "syntax": "<length>",
               "inherits": true
             },
-            "nl.nldesignsystem.fallback": ["utrecht.radio-button.border-width"]
-          }
-        },
-        "background-color": {
-          "$extensions": {
-            "nl.nldesignsystem.css.property": {
-              "syntax": "<color>",
-              "inherits": true
-            },
-            "nl.nldesignsystem.fallback": ["utrecht.radio-button.background-color"]
-          }
+            "nl.nldesignsystem.fallback": ["utrecht.radio-button.border-width"],
+            "nl.nldesignsystem.figma.supports-token": true
+          },
+          "type": "borderWidth"
         },
         "color": {
           "$extensions": {
@@ -267,19 +335,34 @@
               "syntax": "<color>",
               "inherits": true
             },
-            "nl.nldesignsystem.fallback": ["utrecht.radio-button.color"]
-          }
+            "nl.nldesignsystem.fallback": ["utrecht.radio-button.color"],
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "color"
         }
       },
       "focus": {
+        "background-color": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            },
+            "nl.nldesignsystem.fallback": ["utrecht.radio-button.background-color"],
+            "nl.nldesignsystem.figma.supports-token": true
+          },
+          "type": "color"
+        },
         "border-color": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<color>",
               "inherits": true
             },
-            "nl.nldesignsystem.fallback": ["utrecht.radio-button.border-color"]
-          }
+            "nl.nldesignsystem.fallback": ["utrecht.radio-button.border-color"],
+            "nl.nldesignsystem.figma.supports-token": true
+          },
+          "type": "color"
         },
         "border-width": {
           "$extensions": {
@@ -287,17 +370,10 @@
               "syntax": "<length>",
               "inherits": true
             },
-            "nl.nldesignsystem.fallback": ["utrecht.radio-button.border-width"]
-          }
-        },
-        "background-color": {
-          "$extensions": {
-            "nl.nldesignsystem.css.property": {
-              "syntax": "<color>",
-              "inherits": true
-            },
-            "nl.nldesignsystem.fallback": ["utrecht.radio-button.background-color"]
-          }
+            "nl.nldesignsystem.fallback": ["utrecht.radio-button.border-width"],
+            "nl.nldesignsystem.figma.supports-token": true
+          },
+          "type": "borderWidth"
         },
         "color": {
           "$extensions": {
@@ -305,19 +381,34 @@
               "syntax": "<color>",
               "inherits": true
             },
-            "nl.nldesignsystem.fallback": ["utrecht.radio-button.color"]
-          }
+            "nl.nldesignsystem.fallback": ["utrecht.radio-button.color"],
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "color"
         }
       },
       "disabled": {
+        "background-color": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            },
+            "nl.nldesignsystem.fallback": ["utrecht.radio-button.background-color"],
+            "nl.nldesignsystem.figma.supports-token": true
+          },
+          "type": "color"
+        },
         "border-color": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<color>",
               "inherits": true
             },
-            "nl.nldesignsystem.fallback": ["utrecht.radio-button.border-color"]
-          }
+            "nl.nldesignsystem.fallback": ["utrecht.radio-button.border-color"],
+            "nl.nldesignsystem.figma.supports-token": true
+          },
+          "type": "color"
         },
         "border-width": {
           "$extensions": {
@@ -325,17 +416,10 @@
               "syntax": "<length>",
               "inherits": true
             },
-            "nl.nldesignsystem.fallback": ["utrecht.radio-button.border-width"]
-          }
-        },
-        "background-color": {
-          "$extensions": {
-            "nl.nldesignsystem.css.property": {
-              "syntax": "<color>",
-              "inherits": true
-            },
-            "nl.nldesignsystem.fallback": ["utrecht.radio-button.background-color"]
-          }
+            "nl.nldesignsystem.fallback": ["utrecht.radio-button.border-width"],
+            "nl.nldesignsystem.figma.supports-token": true
+          },
+          "type": "borderWidth"
         },
         "color": {
           "$extensions": {
@@ -343,19 +427,33 @@
               "syntax": "<color>",
               "inherits": true
             },
-            "nl.nldesignsystem.fallback": ["utrecht.radio-button.color"]
-          }
+            "nl.nldesignsystem.fallback": ["utrecht.radio-button.color"],
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "color"
         }
       },
       "invalid": {
+        "background-color": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            },
+            "nl.nldesignsystem.figma.supports-token": true
+          },
+          "type": "color"
+        },
         "border-color": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<color>",
               "inherits": true
             },
-            "nl.nldesignsystem.fallback": ["utrecht.radio-button.border-color"]
-          }
+            "nl.nldesignsystem.fallback": ["utrecht.radio-button.border-color"],
+            "nl.nldesignsystem.figma.supports-token": true
+          },
+          "type": "color"
         },
         "border-width": {
           "$extensions": {
@@ -363,16 +461,10 @@
               "syntax": "<length>",
               "inherits": true
             },
-            "nl.nldesignsystem.fallback": ["utrecht.radio-button.border-width"]
-          }
-        },
-        "background-color": {
-          "$extensions": {
-            "nl.nldesignsystem.css.property": {
-              "syntax": "<color>",
-              "inherits": true
-            }
-          }
+            "nl.nldesignsystem.fallback": ["utrecht.radio-button.border-width"],
+            "nl.nldesignsystem.figma.supports-token": true
+          },
+          "type": "borderWidth"
         },
         "color": {
           "$extensions": {
@@ -381,8 +473,10 @@
               "inherits": true
             },
             "nl.nldesignsystem.fallback": ["utrecht.radio-button.color"]
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "color"
       }
     }
   }


### PR DESCRIPTION
- Added metadata for radio-button tokens.
- Added `margin-inline-end` token that was available in mixin.
- Reordered tokens in json for better scanning of tokens.