### PR TITLE
fix: metadata for button component

### DIFF
--- a/.changeset/scrap-meal-heal.md
+++ b/.changeset/scrap-meal-heal.md
@@ -1,0 +1,5 @@
+---
+"@utrecht/button-css": minor
+---
+
+Changed value of `"nl.nldesignsystem.figma.supports-token"` from `true` to `false` as it's not used for the Figma component within the 'Voorbeeld' library.

--- a/.changeset/scrap-meal-heal.md
+++ b/.changeset/scrap-meal-heal.md
@@ -1,5 +1,5 @@
 ---
-"@utrecht/button-css": minor
+"@utrecht/button-css": patch
 ---
 
-Changed value of `"nl.nldesignsystem.figma.supports-token"` from `true` to `false` as it's not used for the Figma component within the 'Voorbeeld' library.
+Changed `utrecht.button. text-transform` setting `"nl.nldesignsystem.figma.supports-token"` from `true` to `false` as it's not used for the Figma component within the 'Voorbeeld' library.

--- a/components/button/src/tokens.json
+++ b/components/button/src/tokens.json
@@ -212,7 +212,7 @@
             "syntax": ["inherit", "uppercase"],
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": true
+          "nl.nldesignsystem.figma.supports-token": false
         },
         "type": "textCase"
       },


### PR DESCRIPTION
Changed value of `"nl.nldesignsystem.figma.supports-token"` from `true` to `false` as it's not used for the Figma component within the 'Voorbeeld' library.