### PR TITLE
fix: regression in `utrecht.button.font-family` support

### DIFF
--- a/.changeset/perfect-masks-heal.md
+++ b/.changeset/perfect-masks-heal.md
@@ -1,0 +1,11 @@
+---
+"@utrecht/button-css": patch
+"@utrecht/components": patch
+"@utrecht/component-library-angular": patch
+"@utrecht/component-library-css": patch
+"@utrecht/component-library-react": patch
+"@utrecht/component-library-vue": patch
+"@utrecht/web-component-library-stencil": patch
+---
+
+Fix regression in `utrecht.button.font-family` support.

--- a/components/button/src/_mixin.scss
+++ b/components/button/src/_mixin.scss
@@ -223,7 +223,7 @@
   color: var(--_utrecht-button-color);
   cursor: var(--utrecht-action-activate-cursor, revert);
   display: inline-flex;
-  font-family: var(--_utrecht-button-font-family, var(--utrecht-document-font-family));
+  font-family: var(--utrecht-button-font-family, var(--utrecht-document-font-family));
   font-size: var(--_utrecht-button-font-size, var(--utrecht-document-font-family, inherit));
   font-weight: var(--_utrecht-button-appearance-font-weight, var(--utrecht-button-font-weight));
   gap: var(--utrecht-button-icon-gap);


### PR DESCRIPTION
Fixes #2399 