### PR TITLE
feat: add metadata for search bar

### DIFF
--- a/.changeset/star-honor-sin.md
+++ b/.changeset/star-honor-sin.md
@@ -1,5 +1,5 @@
 ---
-"@utrecht/search-bar-css": minor
+"@utrecht/search-bar-css": major
 ---
 
 - Added metadata for search bar tokens.

--- a/.changeset/star-honor-sin.md
+++ b/.changeset/star-honor-sin.md
@@ -1,0 +1,6 @@
+---
+"@utrecht/search-bar-css": minor
+---
+
+- Added metadata for search bar tokens.
+- Changed CSS variable name in mixin from `--utrecht-search-bar-hover-transform` to `--utrecht-search-bar-hover-scale` to align with the token name.

--- a/components/search-bar/src/_mixin.scss
+++ b/components/search-bar/src/_mixin.scss
@@ -7,7 +7,7 @@
 
 @mixin utrecht-search-bar {
   --utrecht-button-border-color: var(--utrecht-search-bar-button-border-color);
-  --utrecht-button-hover-scale: var(--utrecht-search-bar-hover-transform);
+  --utrecht-button-hover-scale: var(--utrecht-search-bar-hover-scale);
   --utrecht-button-font-size: var(--utrecht-search-bar-button-font-size);
   --utrecht-button-font-weight: var(--utrecht-search-bar-button-font-weight);
   --utrecht-button-primary-action-background-color: var(--utrecht-search-bar-button-background-color);

--- a/components/search-bar/src/tokens.json
+++ b/components/search-bar/src/tokens.json
@@ -7,40 +7,50 @@
             "nl.nldesignsystem.css.property": {
               "syntax": "<color>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "color"
         },
         "border-color": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<length>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "color"
         },
         "color": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<color>",
               "inherits": true
-            }
-          }
-        },
-        "font-weight": {
-          "$extensions": {
-            "nl.nldesignsystem.css.property": {
-              "syntax": "<number>",
-              "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "color"
         },
         "font-size": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<number>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "fontSizes"
+        },
+        "font-weight": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<number>",
+              "inherits": true
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "fontWeights"
         },
         "hover": {
           "background-color": {
@@ -48,16 +58,20 @@
               "nl.nldesignsystem.css.property": {
                 "syntax": "<color>",
                 "inherits": true
-              }
-            }
+              },
+              "nl.nldesignsystem.figma.supports-token": false
+            },
+            "type": "color"
           },
           "scale": {
             "$extensions": {
               "nl.nldesignsystem.css.property": {
                 "syntax": "<number>",
                 "inherits": true
-              }
-            }
+              },
+              "nl.nldesignsystem.figma.supports-token": false
+            },
+            "type": "other"
           }
         }
       },
@@ -67,64 +81,80 @@
             "nl.nldesignsystem.css.property": {
               "syntax": "<length>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "borderWidth"
         },
         "border-color": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "color"
         },
         "padding-inline-start": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<length>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "spacing"
         },
         "max-inline-size": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<length>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "sizing"
         },
         "background-image": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<image>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "other"
         },
         "background-position-x": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<length>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "other"
         },
         "background-position-y": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<length>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "other"
         },
         "background-size": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<length>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "other"
         }
       },
       "dropdown": {
@@ -133,72 +163,90 @@
             "nl.nldesignsystem.css.property": {
               "syntax": "<length>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "sizing"
         },
         "z-index": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<number>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "other"
         },
         "border-width": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<length>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "borderWidth"
         },
         "border-color": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<color>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "color"
         },
         "padding-block-start": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<number>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "spacing"
         },
         "padding-block-end": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<number>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "spacing"
         },
         "padding-inline-start": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<number>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "spacing"
         },
         "padding-inline-end": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<number>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "spacing"
         },
         "max-block-size": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<length>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "sizing"
         }
       },
       "section": {
@@ -207,8 +255,10 @@
             "nl.nldesignsystem.css.property": {
               "syntax": "<number>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "spacing"
         },
         "title": {
           "font-size": {
@@ -216,40 +266,50 @@
               "nl.nldesignsystem.css.property": {
                 "syntax": "<number>",
                 "inherits": true
-              }
-            }
+              },
+              "nl.nldesignsystem.figma.supports-token": false
+            },
+            "type": "fontSizes"
           },
           "font-weight": {
             "$extensions": {
               "nl.nldesignsystem.css.property": {
                 "syntax": "<number>",
                 "inherits": true
-              }
-            }
+              },
+              "nl.nldesignsystem.figma.supports-token": false
+            },
+            "type": "fontWeights"
           },
           "line-height": {
             "$extensions": {
               "nl.nldesignsystem.css.property": {
-                "syntax": "<number>",
+                "syntax": ["<length>", "<number>"],
                 "inherits": true
-              }
-            }
+              },
+              "nl.nldesignsystem.figma.supports-token": false
+            },
+            "type": "lineHeights"
           },
           "color": {
             "$extensions": {
               "nl.nldesignsystem.css.property": {
                 "syntax": "<color>",
                 "inherits": true
-              }
-            }
+              },
+              "nl.nldesignsystem.figma.supports-token": false
+            },
+            "type": "color"
           },
           "margin-inline-start": {
             "$extensions": {
               "nl.nldesignsystem.css.property": {
                 "syntax": "<number>",
                 "inherits": true
-              }
-            }
+              },
+              "nl.nldesignsystem.figma.supports-token": false
+            },
+            "type": "spacing"
           }
         }
       },
@@ -259,32 +319,40 @@
             "nl.nldesignsystem.css.property": {
               "syntax": "<number>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "spacing"
         },
         "padding-inline-end": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<number>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "spacing"
         },
         "padding-block-start": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<number>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "spacing"
         },
         "padding-block-end": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<number>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "spacing"
         },
         "is-active": {
           "color": {
@@ -292,24 +360,30 @@
               "nl.nldesignsystem.css.property": {
                 "syntax": "<color>",
                 "inherits": true
-              }
-            }
+              },
+              "nl.nldesignsystem.figma.supports-token": false
+            },
+            "type": "color"
           },
           "background-color": {
             "$extensions": {
               "nl.nldesignsystem.css.property": {
                 "syntax": "<color>",
                 "inherits": true
-              }
-            }
+              },
+              "nl.nldesignsystem.figma.supports-token": false
+            },
+            "type": "color"
           },
           "font-weight": {
             "$extensions": {
               "nl.nldesignsystem.css.property": {
                 "syntax": "<length>",
                 "inherits": true
-              }
-            }
+              },
+              "nl.nldesignsystem.figma.supports-token": false
+            },
+            "type": "fontWeights"
           }
         },
         "is-selected": {
@@ -318,16 +392,20 @@
               "nl.nldesignsystem.css.property": {
                 "syntax": "<color>",
                 "inherits": true
-              }
-            }
+              },
+              "nl.nldesignsystem.figma.supports-token": false
+            },
+            "type": "color"
           },
           "background-color": {
             "$extensions": {
               "nl.nldesignsystem.css.property": {
                 "syntax": "<color>",
                 "inherits": true
-              }
-            }
+              },
+              "nl.nldesignsystem.figma.supports-token": false
+            },
+            "type": "color"
           }
         }
       }


### PR DESCRIPTION
- Added metadata for search bar tokens.
- Changed CSS variable name in mixin from `--utrecht-search-bar-hover-transform` to `--utrecht-search-bar-hover-scale` to align with the token name.