### PR TITLE
feat: add metadata for skip-link component

### DIFF
--- a/.changeset/am-gasp-major.md
+++ b/.changeset/am-gasp-major.md
@@ -1,0 +1,6 @@
+---
+"@utrecht/skip-link-css": minor
+---
+
+- Added metadata for skip-link component.
+- Added tokens `utrecht.skip-link.focus.background-color` and `utrecht.skip-link.focus.color` because they were available in [Storybook](https://nl-design-system.github.io/utrecht/storybook/?path=/story/css_css-skip-link--design-tokens).

--- a/components/skip-link/src/tokens.json
+++ b/components/skip-link/src/tokens.json
@@ -126,7 +126,7 @@
         "text-decoration": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
-              "syntax": "none | underline",
+              "syntax": ["inherit", "none", "underline"],
               "inherits": true
             },
             "nl.nldesignsystem.figma.supports-token": true

--- a/components/skip-link/src/tokens.json
+++ b/components/skip-link/src/tokens.json
@@ -6,72 +6,90 @@
           "nl.nldesignsystem.css.property": {
             "syntax": "<color>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": true
+        },
+        "type": "color"
       },
       "color": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<color>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": true
+        },
+        "type": "color"
       },
       "min-block-size": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": true
+        },
+        "type": "sizing"
       },
       "min-inline-size": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": true
+        },
+        "type": "sizing"
       },
       "padding-block-start": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": true
+        },
+        "type": "spacing"
       },
       "padding-block-end": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": true
+        },
+        "type": "spacing"
       },
       "padding-inline-start": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": true
+        },
+        "type": "spacing"
       },
       "padding-inline-end": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": true
+        },
+        "type": "spacing"
       },
       "text-decoration": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
-            "syntax": "none | underline",
+            "syntax": ["inherit", "none", "underline"],
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": true
+        },
+        "type": "textDecoration"
       },
       "z-index": {
         "$extensions": {
@@ -79,17 +97,41 @@
             "syntax": "<number>",
             "inherits": false
           },
-          "nl.nldesignsystem.fallback": ["utrecht.layer.focus.z-index"]
+          "nl.nldesignsystem.fallback": ["utrecht.layer.focus.z-index"],
+          "nl.nldesignsystem.figma.supports-token": false
         },
-        "focus": {
-          "text-decoration": {
-            "$extensions": {
-              "nl.nldesignsystem.css.property": {
-                "syntax": "none | underline",
-                "inherits": true
-              }
-            }
-          }
+        "type": "other"
+      },
+      "focus": {
+        "background-color": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            },
+            "nl.nldesignsystem.figma.supports-token": true
+          },
+          "type": "color"
+        },
+        "color": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<color>",
+              "inherits": true
+            },
+            "nl.nldesignsystem.figma.supports-token": true
+          },
+          "type": "color"
+        },
+        "text-decoration": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "none | underline",
+              "inherits": true
+            },
+            "nl.nldesignsystem.figma.supports-token": true
+          },
+          "type": "textDecoration"
         }
       }
     }


### PR DESCRIPTION
- Added metadata for skip-link component.
- Added tokens
`utrecht.skip-link.focus.background-color` and `utrecht.skip-link.focus.color` because they were available in [Storybook](https://nl-design-system.github.io/utrecht/storybook/?path=/story/css_css-skip-link--design-tokens).

