### PR TITLE
feat: add metadata for toptask-link tokens

### DIFF
--- a/.changeset/cheap-crown-linen.md
+++ b/.changeset/cheap-crown-linen.md
@@ -1,0 +1,6 @@
+---
+"@utrecht/toptask-link-css": minor
+---
+
+- Added metadata for toptask-link tokens.
+- Added missing tokens that were available as CSS variants in the mixin.

--- a/components/toptask-link/src/tokens.json
+++ b/components/toptask-link/src/tokens.json
@@ -6,80 +6,110 @@
           "nl.nldesignsystem.css.property": {
             "syntax": "<color>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "color"
       },
       "color": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<color>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "color"
       },
       "font-size": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "fontSizes"
       },
       "line-height": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
+            "syntax": ["<length>", "<number>"],
+            "inherits": true
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "lineHeights"
+      },
+      "max-inline-size": {
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "sizing"
       },
       "min-block-size": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "sizing"
       },
       "min-inline-size": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "sizing"
       },
       "padding-block-end": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "spacing"
       },
       "padding-block-start": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "spacing"
       },
       "padding-inline-end": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "spacing"
       },
       "padding-inline-start": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
             "inherits": true
-          }
-        }
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "spacing"
       },
       "hover": {
         "background-color": {
@@ -89,24 +119,29 @@
               "inherits": true
             },
             "nl.nldesignsystem.fallback": ["utrecht.toptask-link.background-color"]
-          }
+          },
+          "type": "color"
         },
         "color": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<color>",
               "inherits": true
-            }
+            },
+            "nl.nldesignsystem.fallback": ["utrecht.toptask-link.color"],
+            "nl.nldesignsystem.figma.supports-token": false
           },
-          "nl.nldesignsystem.fallback": ["utrecht.toptask-link.color"]
+          "type": "color"
         },
         "transform-scale": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {
               "syntax": "<number>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "other"
         }
       },
       "focus": {
@@ -116,8 +151,10 @@
               "syntax": "<color>",
               "inherits": true
             },
-            "nl.nldesignsystem.fallback": ["utrecht.toptask-link.background-color"]
-          }
+            "nl.nldesignsystem.fallback": ["utrecht.toptask-link.background-color"],
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "color"
         },
         "color": {
           "$extensions": {
@@ -125,8 +162,10 @@
               "syntax": "<color>",
               "inherits": true
             },
-            "nl.nldesignsystem.fallback": ["utrecht.toptask-link.color"]
-          }
+            "nl.nldesignsystem.fallback": ["utrecht.toptask-link.color"],
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "color"
         }
       },
       "icon": {
@@ -135,8 +174,10 @@
             "nl.nldesignsystem.css.property": {
               "syntax": "<length>",
               "inherits": true
-            }
-          }
+            },
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "sizing"
         }
       }
     }


### PR DESCRIPTION
- Added metadata for toptask-link tokens.
- Added missing tokens that were available as CSS variants in the mixin.