### PR TITLE
feat: add metadata for textarea

### DIFF
--- a/.changeset/node-big-rock.md
+++ b/.changeset/node-big-rock.md
@@ -1,0 +1,6 @@
+---
+"@utrecht/textarea-css": minor
+---
+
+- Added metadata for textarea tokens.
+- Added token and metadata for `utrecht.textarea.border-block-end-width`.

--- a/.changeset/textarea-quux-bar.md
+++ b/.changeset/textarea-quux-bar.md
@@ -1,0 +1,6 @@
+---
+"@utrecht/textarea-css": major
+---
+
+- Renamed CSS variable in mixin `--utrecht-textarea-border-bottom-width` to `--utrecht-textarea-border-block-end-width`.
+- Renamed CSS variable in mixin `--utrecht-textarea-invalid-border-bottom-width` to `--utrecht-textarea-invalid-border-block-end-width`.

--- a/components/textarea/src/_mixin.scss
+++ b/components/textarea/src/_mixin.scss
@@ -80,12 +80,12 @@ $utrecht-support-prince-xml: false !default;
   );
   border-width: var(--_utrecht-textarea-border-width);
   border-block-end-width: var(
-    --utrecht-textarea-invalid-border-bottom-width,
+    --utrecht-textarea-invalid-border-block-end-width,
     var(
-      --utrecht-form-control-invalid-border-bottom-width,
+      --utrecht-form-control-invalid-border-block-end-width,
       var(
-        --utrecht-textarea-border-bottom-width,
-        var(--utrecht-form-control-border-bottom-width, var(--_utrecht-textarea-border-width))
+        --utrecht-textarea-border-block-end-width,
+        var(--utrecht-form-control-border-block-end-width, var(--_utrecht-textarea-border-width))
       )
     )
   );

--- a/components/textarea/src/_mixin.scss
+++ b/components/textarea/src/_mixin.scss
@@ -16,7 +16,7 @@ $utrecht-support-prince-xml: false !default;
   block-size: initial; /* harden */
   border-width: var(--utrecht-textarea-border-width, var(--utrecht-form-control-border-width));
   border-block-end-width: var(
-    --utrecht-textarea-border-bottom-width,
+    --utrecht-textarea-border-block-end-width,
     var(--utrecht-textarea-border-width, var(--utrecht-form-control-border-width))
   );
   border-color: var(--utrecht-textarea-border-color, var(--utrecht-form-control-border-color));

--- a/components/textarea/src/tokens.json
+++ b/components/textarea/src/tokens.json
@@ -7,7 +7,8 @@
             "syntax": "<color>",
             "inherits": true
           },
-          "nl.nldesignsystem.fallback": ["utrecht.form-control.background-color"]
+          "nl.nldesignsystem.fallback": ["utrecht.form-control.background-color"],
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "color"
       },
@@ -17,7 +18,11 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.fallback": ["utrecht.form-control.border-block-end-width"]
+          "nl.nldesignsystem.fallback": [
+            "utrecht.textarea.border-width",
+            "utrecht.form-control.border-block-end-width"
+          ],
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "borderWidth"
       },
@@ -27,7 +32,8 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.deprecated": true
+          "nl.nldesignsystem.deprecated": true,
+          "nl.nldesignsystem.redirect": "utrecht.textarea.border-block-end-width"
         },
         "type": "borderWidth"
       },
@@ -37,7 +43,8 @@
             "syntax": "<color>",
             "inherits": true
           },
-          "nl.nldesignsystem.fallback": ["utrecht.form-control.border-color"]
+          "nl.nldesignsystem.fallback": ["utrecht.form-control.border-color"],
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "color"
       },
@@ -47,7 +54,8 @@
             "syntax": "<length-percentage>",
             "inherits": true
           },
-          "nl.nldesignsystem.fallback": ["utrecht.form-control.border-radius"]
+          "nl.nldesignsystem.fallback": ["utrecht.form-control.border-radius"],
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "borderRadius"
       },
@@ -57,7 +65,8 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.fallback": ["utrecht.form-control.border-width"]
+          "nl.nldesignsystem.fallback": ["utrecht.form-control.border-width"],
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "borderWidth"
       },
@@ -67,7 +76,8 @@
             "syntax": "<color>",
             "inherits": true
           },
-          "nl.nldesignsystem.fallback": ["utrecht.form-control.color"]
+          "nl.nldesignsystem.fallback": ["utrecht.form-control.color"],
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "color"
       },
@@ -77,7 +87,8 @@
             "syntax": "*",
             "inherits": true
           },
-          "nl.nldesignsystem.fallback": ["utrecht.form-control.font-family"]
+          "nl.nldesignsystem.fallback": ["utrecht.form-control.font-family"],
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "fontFamilies"
       },
@@ -87,7 +98,8 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.fallback": ["utrecht.form-control.font-size"]
+          "nl.nldesignsystem.fallback": ["utrecht.form-control.font-size"],
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "fontSizes"
       },
@@ -108,7 +120,8 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.fallback": ["utrecht.form-control.line-height"]
+          "nl.nldesignsystem.fallback": ["utrecht.form-control.line-height"],
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "lineHeights"
       },
@@ -118,7 +131,8 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.fallback": ["utrecht.form-control.max-inline-size"]
+          "nl.nldesignsystem.fallback": ["utrecht.form-control.max-inline-size"],
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "sizing"
       },
@@ -128,7 +142,8 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.fallback": ["utrecht.pointer-target.min-size"]
+          "nl.nldesignsystem.fallback": ["utrecht.pointer-target.min-size"],
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "sizing"
       },
@@ -138,7 +153,8 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.fallback": ["utrecht.form-control.padding-block-end"]
+          "nl.nldesignsystem.fallback": ["utrecht.form-control.padding-block-end"],
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "spacing"
       },
@@ -148,7 +164,8 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.fallback": ["utrecht.form-control.padding-block-start"]
+          "nl.nldesignsystem.fallback": ["utrecht.form-control.padding-block-start"],
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "spacing"
       },
@@ -158,7 +175,8 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.fallback": ["utrecht.form-control.padding-inline-end"]
+          "nl.nldesignsystem.fallback": ["utrecht.form-control.padding-inline-end"],
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "spacing"
       },
@@ -168,7 +186,8 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.fallback": ["utrecht.form-control.padding-inline-start"]
+          "nl.nldesignsystem.fallback": ["utrecht.form-control.padding-inline-start"],
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "spacing"
       },
@@ -179,9 +198,25 @@
               "syntax": "<color>",
               "inherits": true
             },
-            "nl.nldesignsystem.fallback": ["utrecht.textarea.color", "utrecht.form-control.color"]
+            "nl.nldesignsystem.fallback": [
+              "utrecht.form-control.placeholder.color",
+              "utrecht.textarea.color",
+              "utrecht.form-control.color"
+            ],
+            "nl.nldesignsystem.figma.supports-token": true
           },
           "type": "color"
+        },
+        "font-style": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": ["inherit", "italic", "normal"],
+              "inherits": true
+            },
+            "nl.nldesignsystem.fallback": ["utrecht.form-control.placeholder.font-style"],
+            "nl.nldesignsystem.figma.supports-token": false
+          },
+          "type": "other"
         }
       },
       "disabled": {
@@ -195,7 +230,8 @@
               "utrecht.form-control.disabled.background-color",
               "utrecht.textarea.background-color",
               "utrecht.form-control.background-color"
-            ]
+            ],
+            "nl.nldesignsystem.figma.supports-token": true
           },
           "type": "color"
         },
@@ -209,7 +245,8 @@
               "utrecht.form-control.disabled.border-color",
               "utrecht.textarea.border-color",
               "utrecht.form-control.border-color"
-            ]
+            ],
+            "nl.nldesignsystem.figma.supports-token": true
           },
           "type": "color"
         },
@@ -223,7 +260,8 @@
               "utrecht.form-control.disabled.color",
               "utrecht.textarea.color",
               "utrecht.form-control.color"
-            ]
+            ],
+            "nl.nldesignsystem.figma.supports-token": true
           },
           "type": "color"
         }
@@ -239,7 +277,8 @@
               "utrecht.form-control.focus.background-color",
               "utrecht.textarea.background-color",
               "utrecht.form-control.background-color"
-            ]
+            ],
+            "nl.nldesignsystem.figma.supports-token": true
           },
           "type": "color"
         },
@@ -253,7 +292,8 @@
               "utrecht.form-control.focus.border-color",
               "utrecht.textarea.border-color",
               "utrecht.form-control.border-color"
-            ]
+            ],
+            "nl.nldesignsystem.figma.supports-token": true
           },
           "type": "color"
         },
@@ -267,7 +307,8 @@
               "utrecht.form-control.focus.color",
               "utrecht.textarea.color",
               "utrecht.form-control.color"
-            ]
+            ],
+            "nl.nldesignsystem.figma.supports-token": true
           },
           "type": "color"
         }
@@ -283,7 +324,8 @@
               "utrecht.form-control.invalid.background-color",
               "utrecht.textarea.background-color",
               "utrecht.form-control.background-color"
-            ]
+            ],
+            "nl.nldesignsystem.figma.supports-token": true
           },
           "type": "color"
         },
@@ -297,7 +339,8 @@
               "utrecht.form-control.invalid.border-color",
               "utrecht.textarea.border-color",
               "utrecht.form-control.border-color"
-            ]
+            ],
+            "nl.nldesignsystem.figma.supports-token": true
           },
           "type": "color"
         },
@@ -311,7 +354,19 @@
               "utrecht.form-control.invalid.border-width",
               "utrecht.textarea.border-width",
               "utrecht.form-control.border-width"
-            ]
+            ],
+            "nl.nldesignsystem.figma.supports-token": true
+          },
+          "type": "borderWidth"
+        },
+        "border-block-end-width": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            },
+            "nl.nldesignsystem.fallback": ["utrecht.form-control.border-block-end-width"],
+            "nl.nldesignsystem.figma.supports-token": true
           },
           "type": "borderWidth"
         },
@@ -325,7 +380,8 @@
               "utrecht.form-control.invalid.color",
               "utrecht.textarea.color",
               "utrecht.form-control.color"
-            ]
+            ],
+            "nl.nldesignsystem.figma.supports-token": true
           },
           "type": "color"
         }
@@ -341,7 +397,8 @@
               "utrecht.form-control.read-only.background-color",
               "utrecht.textarea.background-color",
               "utrecht.form-control.background-color"
-            ]
+            ],
+            "nl.nldesignsystem.figma.supports-token": true
           },
           "type": "color"
         },
@@ -355,7 +412,8 @@
               "utrecht.form-control.read-only.border-color",
               "utrecht.textarea.border-color",
               "utrecht.form-control.border-color"
-            ]
+            ],
+            "nl.nldesignsystem.figma.supports-token": true
           },
           "type": "color"
         },
@@ -369,7 +427,8 @@
               "utrecht.form-control.read-only.color",
               "utrecht.textarea.color",
               "utrecht.form-control.color"
-            ]
+            ],
+            "nl.nldesignsystem.figma.supports-token": true
           },
           "type": "color"
         }

--- a/proprietary/design-tokens/src/component/utrecht/textarea.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/textarea.tokens.json
@@ -2,6 +2,7 @@
   "utrecht": {
     "textarea": {
       "border-bottom-width": { "value": "3px" },
+      "border-block-end-width": { "value": "3px" },
       "line-height": { "value": "{utrecht.typography.line-height.md}" },
       "disabled": {
         "border-color": {},


### PR DESCRIPTION
- Added metadata for textarea tokens.
- Renamed CSS variable in mixin `--utrecht-textarea-border-bottom-width` to `--utrecht-textarea-border-block-end-width`.
- Renamed CSS variable in mixin `--utrecht-textarea-invalid-border-bottom-width` to `--utrecht-textarea-invalid-border-block-end-width`.
- Added token and metadata for `utrecht.textarea.invalid.border-block-end-width`.