### PR TITLE
feat: add border-block-end-width token for invalid state

### DIFF
--- a/.changeset/idea-lie-shelf.md
+++ b/.changeset/idea-lie-shelf.md
@@ -1,0 +1,5 @@
+---
+"@utrecht/select-css": minor
+---
+
+Added token `select.invalid.border-block-end-width` that is available as CSS variable.

--- a/components/select/src/tokens.json
+++ b/components/select/src/tokens.json
@@ -284,6 +284,17 @@
           },
           "type": "color"
         },
+        "border-block-end-width": {
+          "$extensions": {
+            "nl.nldesignsystem.css.property": {
+              "syntax": "<length>",
+              "inherits": true
+            },
+            "nl.nldesignsystem.fallback": ["utrecht.form-control.border-block-end-width"],
+            "nl.nldesignsystem.figma.supports-token": true
+          },
+          "type": "borderWidth"
+        },
         "border-color": {
           "$extensions": {
             "nl.nldesignsystem.css.property": {


### PR DESCRIPTION
Not a fix but a feat, sorry.

Added token `select.invalid.border-block-end-width` to the json because it is available as CSS variable in the mixin.