### PR TITLE
fix: renamed badge-list spacing tokens

### DIFF
--- a/.changeset/bee-baa-boop.md
+++ b/.changeset/bee-baa-boop.md
@@ -1,0 +1,6 @@
+---
+"@utrecht/utrecht-badge-list-css": major
+---
+
+- Renamed `utrecht-badge-list-item-margin-block` to `utrecht-badge-list-row-gap`.
+- Renamed `utrecht-badge-list-item-margin-inline` to `utrecht-badge-list-column-gap`.

--- a/components/badge-list/src/_mixin.scss
+++ b/components/badge-list/src/_mixin.scss
@@ -5,7 +5,8 @@
  */
 
 @mixin utrecht-badge-list {
+  column-gap: var(--utrecht-badge-list-column-gap);
   display: flex;
   flex-wrap: wrap;
-  gap: var(--utrecht-badge-list-item-margin-block) var(--utrecht-badge-list-item-margin-inline);
+  row-gap: var(--utrecht-badge-list-row-gap);
 }

--- a/components/badge-list/src/tokens.json
+++ b/components/badge-list/src/tokens.json
@@ -1,27 +1,25 @@
 {
   "utrecht": {
     "badge-list": {
-      "item": {
-        "margin-block": {
-          "$extensions": {
-            "nl.nldesignsystem.css.property": {
-              "syntax": "<length>",
-              "inherits": true
-            },
-            "nl.nldesignsystem.figma.supports-token": false
+      "row-gap": {
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
           },
-          "type": "spacing"
+          "nl.nldesignsystem.figma.supports-token": false
         },
-        "margin-inline": {
-          "$extensions": {
-            "nl.nldesignsystem.css.property": {
-              "syntax": "<length>",
-              "inherits": true
-            },
-            "nl.nldesignsystem.figma.supports-token": false
+        "type": "spacing"
+      },
+      "column-gap": {
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
           },
-          "type": "spacing"
-        }
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "spacing"
       }
     }
   }


### PR DESCRIPTION
- Renamed `utrecht-badge-list-item-margin-block` to `utrecht-badge-list-row-gap`.
- Renamed `utrecht-badge-list-item-margin-inline` to `utrecht-badge-list-column-gap`.