### PR TITLE
fix: add missing bundled CSS for the React Button and Calendar

### DIFF
--- a/.changeset/chilly-mayflies-float.md
+++ b/.changeset/chilly-mayflies-float.md
@@ -1,0 +1,6 @@
+---
+"@utrecht/button-react": patch
+"@utrecht/calendar-react": patch
+---
+
+Fix missing bundled CSS for the React Button and Calendar components.

--- a/packages/component-library-react/rollup-component-package.mjs
+++ b/packages/component-library-react/rollup-component-package.mjs
@@ -61,7 +61,7 @@ export const createComponentPackageConfig = (path) => {
       ],
     },
     {
-      input: new URL('./src/index.tsx', path).pathname,
+      input: new URL('./src/css.tsx', path).pathname,
       output: [
         {
           file: 'dist/css.js',


### PR DESCRIPTION
🤦‍♂️