### PR TITLE
fix: changed figma support value for roos components

### DIFF
--- a/.changeset/aap-noot-mies.md
+++ b/.changeset/aap-noot-mies.md
@@ -1,9 +1,9 @@
 ---
-"@utrecht/code-block-css": minor
-"@utrecht/code-css": minor
-"@utrecht/color-sample-css": minor
-"@utrecht/drawer-css": minor
-"@utrecht/pre-heading-css": minor
+"@utrecht/code-block-css": patch
+"@utrecht/code-css": patch
+"@utrecht/color-sample-css": patch
+"@utrecht/drawer-css": patch
+"@utrecht/pre-heading-css": patch
 ---
 
 Changed value for Figma support metadata:

--- a/.changeset/aap-noot-mies.md
+++ b/.changeset/aap-noot-mies.md
@@ -1,0 +1,14 @@
+---
+"@utrecht/code-block-css": minor
+"@utrecht/code-css": minor
+"@utrecht/color-sample-css": minor
+"@utrecht/drawer-css": minor
+"@utrecht/pre-heading-css": minor
+---
+
+Changed value for Figma support metadata:
+- Code block
+- Code
+- Color sample
+- Drawer
+- Pre heading

--- a/.changeset/aap-noot-mies.md
+++ b/.changeset/aap-noot-mies.md
@@ -7,6 +7,7 @@
 ---
 
 Changed value for Figma support metadata:
+
 - Code block
 - Code
 - Color sample

--- a/components/code-block/src/tokens.json
+++ b/components/code-block/src/tokens.json
@@ -7,7 +7,7 @@
             "syntax": "<color>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "color"
       },
@@ -17,7 +17,7 @@
             "syntax": "<color>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "color"
       },
@@ -27,7 +27,7 @@
             "syntax": "*",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "fontFamilies"
       },
@@ -37,7 +37,7 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "fontSizes"
       },
@@ -47,7 +47,7 @@
             "syntax": ["<length>", "<number>"],
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "lineHeights"
       },
@@ -97,7 +97,7 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "spacing"
       },
@@ -107,7 +107,7 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "spacing"
       },
@@ -117,7 +117,7 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "spacing"
       },
@@ -127,7 +127,7 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "spacing"
       }

--- a/components/code/src/tokens.json
+++ b/components/code/src/tokens.json
@@ -7,7 +7,7 @@
             "syntax": "<color>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "color"
       },
@@ -17,7 +17,7 @@
             "syntax": "<color>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "color"
       },
@@ -27,7 +27,7 @@
             "syntax": "*",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "fontFamilies"
       },
@@ -37,7 +37,7 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "fontSizes"
       },
@@ -47,7 +47,7 @@
             "syntax": ["<length>", "<number>"],
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "lineHeights"
       }

--- a/components/color-sample/src/tokens.json
+++ b/components/color-sample/src/tokens.json
@@ -7,7 +7,7 @@
             "syntax": "<color>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "color"
       },
@@ -17,7 +17,7 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "borderWidth"
       },
@@ -27,7 +27,7 @@
             "syntax": "<color>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "color"
       },
@@ -37,7 +37,7 @@
             "syntax": "<length-percentage>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "borderRadius"
       },
@@ -47,7 +47,7 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "sizing"
       },
@@ -57,7 +57,7 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "sizing"
       },
@@ -68,7 +68,7 @@
               "syntax": "<color>",
               "inherits": true
             },
-            "nl.nldesignsystem.figma.supports-token": false
+            "nl.nldesignsystem.figma.supports-token": true
           },
           "type": "color"
         }
@@ -80,7 +80,7 @@
               "syntax": "<color>",
               "inherits": true
             },
-            "nl.nldesignsystem.figma.supports-token": false
+            "nl.nldesignsystem.figma.supports-token": true
           },
           "type": "color"
         }

--- a/components/drawer/src/tokens.json
+++ b/components/drawer/src/tokens.json
@@ -7,7 +7,7 @@
             "syntax": "<color>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "color"
       },
@@ -17,7 +17,7 @@
             "syntax": "<color>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "color"
       },
@@ -27,7 +27,7 @@
             "syntax": "<length-percentage>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "borderRadius"
       },
@@ -37,7 +37,7 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "borderWidth"
       },
@@ -47,7 +47,7 @@
             "syntax": "<color>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "color"
       },
@@ -57,7 +57,7 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "sizing"
       },
@@ -67,7 +67,7 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "sizing"
       },
@@ -77,7 +77,7 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "sizing"
       },
@@ -87,7 +87,7 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "sizing"
       },
@@ -97,7 +97,7 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "spacing"
       },
@@ -107,7 +107,7 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "spacing"
       },
@@ -117,7 +117,7 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "spacing"
       },
@@ -127,7 +127,7 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "spacing"
       },
@@ -148,7 +148,7 @@
               "syntax": "<length>",
               "inherits": true
             },
-            "nl.nldesignsystem.figma.supports-token": false
+            "nl.nldesignsystem.figma.supports-token": true
           },
           "type": "sizing"
         }

--- a/components/pre-heading/src/tokens.json
+++ b/components/pre-heading/src/tokens.json
@@ -8,7 +8,7 @@
             "inherits": true
           },
           "nl.nldesignsystem.fallback": ["utrecht.document.color"],
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "color"
       },
@@ -19,7 +19,7 @@
             "inherits": true
           },
           "nl.nldesignsystem.fallback": ["utrecht.document.font-family"],
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "fontFamilies"
       },
@@ -29,7 +29,7 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "fontSizes"
       },
@@ -39,7 +39,7 @@
             "syntax": "<number>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "fontWeights"
       },
@@ -49,7 +49,7 @@
             "syntax": "<length-percentage>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": false
+          "nl.nldesignsystem.figma.supports-token": true
         },
         "type": "lineHeights"
       },


### PR DESCRIPTION
@Rozerinay added new components to Figma. So Figma support for corresponding component tokens is now 'true'.

Changed value for Figma support metadata:
- Code block
- Code
- Color sample
- Drawer
- Pre heading