### PR TITLE
fix: copy new pnpm workspace settings to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "./components/",
     "./components/*/",
     "./packages/*",
-    "./packages/component-library-react/packages/*",
+    "./packages/components-react/*",
     "./proprietary/*"
   ],
   "repository": {


### PR DESCRIPTION
This missing configuration prevents `lint:changeset` to succeed and it blocks doing new releases.