### PR TITLE
feat: allow FormField's error message position to be changed

### DIFF
--- a/packages/component-library-react/src/FormField.test.tsx
+++ b/packages/component-library-react/src/FormField.test.tsx
@@ -75,4 +75,48 @@ describe('Form field', () => {
 
     expect(ref.current).toBe(div);
   });
+
+  describe('error message position', () => {
+    it('is displayed after the input field by default', () => {
+      const errorMessage = 'Check this required field to continue.';
+
+      render(
+        <FormField invalid errorMessage={errorMessage}>
+          <input type="text" />
+        </FormField>,
+      );
+
+      const errorMessageElement = screen.getByText(errorMessage);
+
+      expect(errorMessageElement).toHaveClass('utrecht-form-field__error-message--after');
+    });
+
+    it('displays the error message after the input field with `errorMessagePosition="after"`', () => {
+      const errorMessage = 'Check this required field to continue.';
+
+      render(
+        <FormField invalid errorMessage={errorMessage} errorMessagePosition="after">
+          <input type="text" />
+        </FormField>,
+      );
+
+      const errorMessageElement = screen.getByText(errorMessage);
+
+      expect(errorMessageElement).toHaveClass('utrecht-form-field__error-message--after');
+    });
+
+    it('displays the error message before the input field with `errorMessagePosition="before"`', () => {
+      const errorMessage = 'Check this required field to continue.';
+
+      render(
+        <FormField invalid errorMessage={errorMessage} errorMessagePosition="before">
+          <input type="text" />
+        </FormField>,
+      );
+
+      const errorMessageElement = screen.getByText(errorMessage);
+
+      expect(errorMessageElement).toHaveClass('utrecht-form-field__error-message--before');
+    });
+  });
 });

--- a/packages/component-library-react/src/FormField.tsx
+++ b/packages/component-library-react/src/FormField.tsx
@@ -4,6 +4,7 @@ import { ForwardedRef, forwardRef, HTMLAttributes, PropsWithChildren, ReactNode 
 export interface FormFieldProps extends HTMLAttributes<HTMLDivElement> {
   description?: ReactNode;
   errorMessage?: ReactNode;
+  errorMessagePosition?: 'before' | 'after';
   input?: ReactNode; // TODO: Should this be named `control` instead of `input`?
   invalid?: boolean;
   label?: ReactNode;
@@ -17,6 +18,7 @@ export const FormField = forwardRef(
       children,
       description,
       errorMessage,
+      errorMessagePosition,
       input,
       invalid,
       label,
@@ -41,8 +43,15 @@ export const FormField = forwardRef(
     >
       {label && <div className="utrecht-form-field__label">{label}</div>}
       {description && <div className="utrecht-form-field__description">{description}</div>}
+      {errorMessage && errorMessagePosition === 'before' && (
+        <div className="utrecht-form-field__error-message utrecht-form-field__error-message--before">
+          {errorMessage}
+        </div>
+      )}
       {input && <div className="utrecht-form-field__input">{input}</div>}
-      {errorMessage && <div className="utrecht-form-field__error-message">{errorMessage}</div>}
+      {errorMessage && (!errorMessagePosition || errorMessagePosition === 'after') && (
+        <div className="utrecht-form-field__error-message utrecht-form-field__error-message--after">{errorMessage}</div>
+      )}
       {children}
     </div>
   ),

--- a/packages/storybook-react/src/stories/FormFieldTextbox.stories.tsx
+++ b/packages/storybook-react/src/stories/FormFieldTextbox.stories.tsx
@@ -94,6 +94,17 @@ const storyArgTypes = {
       category: 'API',
     },
   },
+  errorMessagePosition: {
+    name: 'errorMessagePosition',
+    description: 'Position of the error message in regards to the form control',
+    type: { name: 'text', required: false },
+    control: 'select',
+    options: ['', 'after', 'before'],
+    table: {
+      defaultValue: { summary: '' },
+      category: 'API',
+    },
+  },
   description: {
     description: 'Description',
     type: { name: 'text', required: false },
@@ -274,6 +285,7 @@ const meta = {
     disabled: false,
     invalid: false,
     errorMessage: '',
+    errorMessagePosition: '',
     label: '',
     name: '',
     defaultValue: '',
@@ -295,6 +307,7 @@ const meta = {
       id,
       invalid,
       errorMessage,
+      errorMessagePosition,
       status,
       inputRequired,
       label,
@@ -318,6 +331,7 @@ const meta = {
         description={description || undefined}
         disabled={disabled}
         errorMessage={errorMessage || undefined}
+        errorMessagePosition={errorMessagePosition || undefined}
         status={status || undefined}
         invalid={invalid}
         label={label || undefined}
@@ -363,6 +377,26 @@ export const ErrorMessage: Story = {
     name: 'subject',
     label: 'Onderwerp',
     errorMessage: 'Vul een onderwerp in.',
+    invalid: true,
+  },
+};
+
+export const ErrorMessagePositionAfter: Story = {
+  args: {
+    name: 'subject',
+    label: 'Onderwerp',
+    errorMessage: 'Vul een onderwerp in.',
+    errorMessagePosition: 'after',
+    invalid: true,
+  },
+};
+
+export const ErrorMessagePositionBefore: Story = {
+  args: {
+    name: 'subject',
+    label: 'Onderwerp',
+    errorMessage: 'Vul een onderwerp in.',
+    errorMessagePosition: 'before',
     invalid: true,
   },
 };


### PR DESCRIPTION
This change doesn't change anything it the current behaviour. It just adds the possibility to set the position of the error message (if present) to a certain place in regards to the field which has the faulty value. Either `before` (above) or `after` (underneath). The latter is the default value, representing the current behaviour.