### PR TITLE
Feat/improve paragraph robbert

### DIFF
--- a/.changeset/tiny-buckets-fail.md
+++ b/.changeset/tiny-buckets-fail.md
@@ -2,4 +2,9 @@
 "@utrecht/component-library-react": minor
 ---
 
-For the `Paragraph` component, deprecate the `lead` and `small` attributes in favor of the new `appearance` attribute
+For the `Paragraph` component, introduce the `appearance` property. It replaces the `lead` and `small` boolean properties, which are now deprecated.
+
+Perform the following migration steps:
+
+- Use `<Paragraph appearance="lead">` instead of `<Paragraph lead>`
+- Use `<Paragraph appearance="small">` instead of `<Paragraph small>`

--- a/packages/component-library-react/src/Paragraph.tsx
+++ b/packages/component-library-react/src/Paragraph.tsx
@@ -7,7 +7,7 @@ import clsx from 'clsx';
 import { ForwardedRef, forwardRef, HTMLAttributes, PropsWithChildren } from 'react';
 
 export interface ParagraphProps extends HTMLAttributes<HTMLParagraphElement> {
-  appearance?: 'lead' | 'small';
+  appearance?: string | 'lead' | 'small';
   /**
    *
    * @deprecated Use `appearance="lead"` instead

--- a/packages/storybook-react/src/stories/Paragraph.stories.tsx
+++ b/packages/storybook-react/src/stories/Paragraph.stories.tsx
@@ -11,13 +11,13 @@ const meta = {
   component: Paragraph,
   tags: ['autodocs'],
   args: {
-    appearance: 'default',
+    appearance: undefined,
     children:
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum',
   },
   argTypes: {
     appearance: {
-      options: ['default', 'lead', 'small'],
+      options: [undefined, 'lead', 'small'],
       control: {
         type: 'select',
       },


### PR DESCRIPTION
- als je niet de `enum` kan valideren, bijvoorbeeld als die uit een CMS komt, dan is het handig dat `string` ook mag
- ik wil niet `appearance="default"` in de code samples hebben, die bestaat niet
- handig om migration steps uit te leggen

<img width="361" alt="Screenshot 2024-10-13 at 15 22 35" src="https://github.com/user-attachments/assets/01c6b0cc-b6fe-46dc-ba4d-a30c3cb623b3">
