### PR TITLE
fix: changed support token for form toggle

### DIFF
--- a/.changeset/delay-mass-pole.md
+++ b/.changeset/delay-mass-pole.md
@@ -1,0 +1,5 @@
+---
+"@utrecht/form-toggle-css": minor
+---
+
+Fixed metadata for Form toggle tokens.

--- a/components/form-toggle/src/tokens.json
+++ b/components/form-toggle/src/tokens.json
@@ -87,7 +87,7 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": true
+          "nl.nldesignsystem.figma.supports-token": false
         },
         "type": "spacing"
       },
@@ -97,7 +97,7 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": true
+          "nl.nldesignsystem.figma.supports-token": false
         },
         "type": "spacing"
       },
@@ -107,7 +107,7 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": true
+          "nl.nldesignsystem.figma.supports-token": false
         },
         "type": "spacing"
       },
@@ -117,7 +117,7 @@
             "syntax": "<length>",
             "inherits": true
           },
-          "nl.nldesignsystem.figma.supports-token": true
+          "nl.nldesignsystem.figma.supports-token": false
         },
         "type": "spacing"
       },


### PR DESCRIPTION
Weet niet hoe deze er tussendoor zijn geslipt, maar de tokens voor Form toggle worden (nog) niet in Figma gebruikt. Met deze PR wordt dat weer rechtgetrokken.