### PR TITLE
fix: image width height auto

### DIFF
--- a/.changeset/slow-drinks-applaud.md
+++ b/.changeset/slow-drinks-applaud.md
@@ -1,0 +1,5 @@
+---
+"@utrecht/img-css": patch
+---
+
+Fix CSS image component to support `img` attributes `width` and `height`.

--- a/components/img/src/_mixin.scss
+++ b/components/img/src/_mixin.scss
@@ -5,11 +5,15 @@
  */
 
 @mixin utrecht-img {
-  /* stylelint-disable-next-line property-disallowed-list */
-  height: auto;
+  &:not(img[height]) {
+    /* stylelint-disable-next-line property-disallowed-list */
+    height: auto;
+  }
 
-  /* stylelint-disable-next-line property-disallowed-list */
-  width: auto;
+  &:not(img[width]) {
+    /* stylelint-disable-next-line property-disallowed-list */
+    width: auto;
+  }
 }
 
 @mixin utrecht-img--scale-down {


### PR DESCRIPTION
Doordat de height en width altijd op auto staan kun je de img size niet aanpassen: https://nl-design-system.github.io/utrecht/storybook/?path=/docs/css_css-img--docs