### PR TITLE
fix(react-storybook): fix style issue

### DIFF
--- a/packages/storybook-react/config/preview.tsx
+++ b/packages/storybook-react/config/preview.tsx
@@ -14,7 +14,7 @@ import '@gemeente-denhaag/design-tokens-components/dist/theme/index.css';
 
 const preview: Preview = {
   decorators: [
-    (Story: any) => <div className="utrecht-document">{Story()}</div>,
+    (Story: any) => <div className="utrecht-document utrecht-theme">{Story()}</div>,
     ///
     withTests({ results }),
   ],


### PR DESCRIPTION
The issue occurs only when you click the preview button to open the story on a separate page, outside of the iframe.