### PR TITLE
chore: use consistent copyright notice

### DIFF
--- a/components/accordion/src/_mixin.scss
+++ b/components/accordion/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 /* stylelint-disable-next-line block-no-empty */

--- a/components/accordion/src/index.scss
+++ b/components/accordion/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/alert-dialog/src/_mixin.scss
+++ b/components/alert-dialog/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/alert-css/src/mixin";

--- a/components/alert-dialog/src/index.scss
+++ b/components/alert-dialog/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/alert/src/_mixin.scss
+++ b/components/alert/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-alert {

--- a/components/alert/src/index.scss
+++ b/components/alert/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/alternate-lang-nav/src/_mixin.scss
+++ b/components/alternate-lang-nav/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 /* stylelint-disable-next-line block-no-empty */

--- a/components/alternate-lang-nav/src/index.scss
+++ b/components/alternate-lang-nav/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/article/src/_mixin.scss
+++ b/components/article/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-article {

--- a/components/article/src/html/_mixin.scss
+++ b/components/article/src/html/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/article/src/html/index.scss
+++ b/components/article/src/html/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/article/src/index.scss
+++ b/components/article/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/backdrop/src/_mixin.scss
+++ b/components/backdrop/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-backdrop {

--- a/components/backdrop/src/index.scss
+++ b/components/backdrop/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/badge-counter/src/_mixin.scss
+++ b/components/badge-counter/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-badge-counter {

--- a/components/badge-counter/src/index.scss
+++ b/components/badge-counter/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/badge-data/src/_mixin.scss
+++ b/components/badge-data/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/badge-css/src/mixin";

--- a/components/badge-data/src/index.scss
+++ b/components/badge-data/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/badge-data/src/story-template.jsx
+++ b/components/badge-data/src/story-template.jsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import React from 'react';

--- a/components/badge-list/src/_mixin.scss
+++ b/components/badge-list/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-badge-list {

--- a/components/badge-list/src/index.scss
+++ b/components/badge-list/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/badge-status/src/_mixin.scss
+++ b/components/badge-status/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/badge-css/src/mixin";

--- a/components/badge-status/src/index.scss
+++ b/components/badge-status/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/badge/src/_mixin.scss
+++ b/components/badge/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-badge {

--- a/components/blockquote/src/_mixin.scss
+++ b/components/blockquote/src/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-blockquote {

--- a/components/blockquote/src/html/_mixin.scss
+++ b/components/blockquote/src/html/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/blockquote/src/html/index.scss
+++ b/components/blockquote/src/html/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/blockquote/src/index.scss
+++ b/components/blockquote/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/blockquote/src/story-template.jsx
+++ b/components/blockquote/src/story-template.jsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/components/breadcrumb-nav/src/_mixin.scss
+++ b/components/breadcrumb-nav/src/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin reset-ol {

--- a/components/breadcrumb-nav/src/index.scss
+++ b/components/breadcrumb-nav/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/button-link/src/_mixin.scss
+++ b/components/button-link/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 The Knights Who Say NIH! B.V.
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/button-css/src/mixin";

--- a/components/button-link/src/index.scss
+++ b/components/button-link/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 The Knights Who Say NIH! B.V.
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/button-css/src/mixin";

--- a/components/button/src/_mixin.scss
+++ b/components/button/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 The Knights Who Say NIH! B.V.
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/focus-ring-css/src/mixin";

--- a/components/button/src/html/_mixin.scss
+++ b/components/button/src/html/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/button/src/html/index.scss
+++ b/components/button/src/html/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/button/src/index.scss
+++ b/components/button/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 The Knights Who Say NIH! B.V.
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/focus-ring-css/src/mixin";

--- a/components/calendar/src/index.scss
+++ b/components/calendar/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021-2022 Gemeente Utrecht
- * Copyright (c) 2021-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/checkbox/src/_mixin.scss
+++ b/components/checkbox/src/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 @import "~@utrecht/focus-ring-css/src/mixin";
 

--- a/components/checkbox/src/html/_mixin.scss
+++ b/components/checkbox/src/html/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/checkbox/src/html/index.scss
+++ b/components/checkbox/src/html/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/checkbox/src/index.scss
+++ b/components/checkbox/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 @import "~@utrecht/focus-ring-css/src/mixin";
 @import "./mixin";

--- a/components/checkbox/src/story-template.jsx
+++ b/components/checkbox/src/story-template.jsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/components/code-block/src/_mixin.scss
+++ b/components/code-block/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/code-css/src/mixin";

--- a/components/code-block/src/html/_mixin.scss
+++ b/components/code-block/src/html/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/code-block/src/html/index.scss
+++ b/components/code-block/src/html/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/code-block/src/index.scss
+++ b/components/code-block/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/code/src/_mixin.scss
+++ b/components/code/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-code {

--- a/components/code/src/html/_mixin.scss
+++ b/components/code/src/html/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/code/src/html/index.scss
+++ b/components/code/src/html/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/code/src/index.scss
+++ b/components/code/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/color-sample/src/_mixin.scss
+++ b/components/color-sample/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021-2022 Gemeente Utrecht
- * Copyright (c) 2021-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-color-sample {

--- a/components/color-sample/src/index.scss
+++ b/components/color-sample/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021-2022 Gemeente Utrecht
- * Copyright (c) 2021-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/column-layout/src/_mixin.scss
+++ b/components/column-layout/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 $utrecht-support-prince-xml: false !default;

--- a/components/column-layout/src/index.scss
+++ b/components/column-layout/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/currency-data/src/_mixin.scss
+++ b/components/currency-data/src/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-currency-data {

--- a/components/currency-data/src/index.scss
+++ b/components/currency-data/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/custom-checkbox/src/_mixin.scss
+++ b/components/custom-checkbox/src/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/focus-ring-css/src/mixin";

--- a/components/custom-checkbox/src/index.scss
+++ b/components/custom-checkbox/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/custom-checkbox/src/story-template.jsx
+++ b/components/custom-checkbox/src/story-template.jsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/components/data-list/src/_mixin.scss
+++ b/components/data-list/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021-2022 Gemeente Utrecht
- * Copyright (c) 2021-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin reset-html-dd {

--- a/components/data-list/src/index.scss
+++ b/components/data-list/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021-2022 Gemeente Utrecht
- * Copyright (c) 2021-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/data-list/src/story-template.jsx
+++ b/components/data-list/src/story-template.jsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/components/data-placeholder/src/_mixin.scss
+++ b/components/data-placeholder/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-data-placeholder--print {

--- a/components/data-placeholder/src/index.scss
+++ b/components/data-placeholder/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 The Knights Who Say NIH! B.V.
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/digid-button/src/index.scss
+++ b/components/digid-button/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 .utrecht-digid-button {

--- a/components/document/src/_mixin.scss
+++ b/components/document/src/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin reset-font-smoothing {

--- a/components/document/src/html/_mixin.scss
+++ b/components/document/src/html/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/document/src/html/index.scss
+++ b/components/document/src/html/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/document/src/index.scss
+++ b/components/document/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/drawer/src/_mixin.scss
+++ b/components/drawer/src/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/backdrop-css/src/mixin";

--- a/components/drawer/src/index.scss
+++ b/components/drawer/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/emphasis/src/_mixin.scss
+++ b/components/emphasis/src/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-emphasis--stressed {

--- a/components/emphasis/src/html/_mixin.scss
+++ b/components/emphasis/src/html/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/emphasis/src/html/index.scss
+++ b/components/emphasis/src/html/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/emphasis/src/index.scss
+++ b/components/emphasis/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/figure/src/_mixin.scss
+++ b/components/figure/src/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-figure {

--- a/components/figure/src/html/_mixin.scss
+++ b/components/figure/src/html/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/figure/src/html/index.scss
+++ b/components/figure/src/html/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/figure/src/index.scss
+++ b/components/figure/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/focus-ring/src/_mixin.scss
+++ b/components/focus-ring/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-focus-ring {

--- a/components/form-field-description/src/_mixin.scss
+++ b/components/form-field-description/src/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-form-field-description {

--- a/components/form-field-description/src/index.scss
+++ b/components/form-field-description/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/form-field-description/src/story-template.jsx
+++ b/components/form-field-description/src/story-template.jsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/components/form-field-error-message/src/_mixin.scss
+++ b/components/form-field-error-message/src/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-form-field-error-message {

--- a/components/form-field-error-message/src/index.scss
+++ b/components/form-field-error-message/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/form-field/src/_mixin.scss
+++ b/components/form-field/src/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin reset-p {

--- a/components/form-field/src/index.scss
+++ b/components/form-field/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/form-field/src/story-template.jsx
+++ b/components/form-field/src/story-template.jsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/components/form-fieldset/src/_mixin.scss
+++ b/components/form-fieldset/src/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./reset";

--- a/components/form-fieldset/src/_reset.scss
+++ b/components/form-fieldset/src/_reset.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin reset-fieldset {

--- a/components/form-fieldset/src/html/_mixin.scss
+++ b/components/form-fieldset/src/html/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/form-fieldset/src/html/index.scss
+++ b/components/form-fieldset/src/html/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/form-fieldset/src/index.scss
+++ b/components/form-fieldset/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/form-fieldset/src/story-template.jsx
+++ b/components/form-fieldset/src/story-template.jsx
@@ -1,7 +1,7 @@
-/*
+/**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/components/form-label/src/_mixin.scss
+++ b/components/form-label/src/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-form-label {

--- a/components/form-label/src/html/_mixin.scss
+++ b/components/form-label/src/html/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/form-label/src/html/index.scss
+++ b/components/form-label/src/html/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/form-label/src/index.scss
+++ b/components/form-label/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/form-label/src/story-template.jsx
+++ b/components/form-label/src/story-template.jsx
@@ -1,7 +1,7 @@
-/*
+/**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/components/form-toggle/src/_mixin.scss
+++ b/components/form-toggle/src/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/focus-ring-css/src/mixin";

--- a/components/form-toggle/src/index.scss
+++ b/components/form-toggle/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/form/src/_mixin.scss
+++ b/components/form/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-form {

--- a/components/form/src/html/_mixin.scss
+++ b/components/form/src/html/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/form/src/html/index.scss
+++ b/components/form/src/html/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/form/src/index.scss
+++ b/components/form/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/heading-1/src/_mixin.scss
+++ b/components/heading-1/src/_mixin.scss
@@ -1,8 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
- * Copyright (c) 2021 The Knights Who Say NIH! B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/heading-css/src/mixin";

--- a/components/heading-1/src/html/_mixin.scss
+++ b/components/heading-1/src/html/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/heading-1/src/html/index.scss
+++ b/components/heading-1/src/html/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/heading-1/src/index.scss
+++ b/components/heading-1/src/index.scss
@@ -1,8 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
- * Copyright (c) 2021 The Knights Who Say NIH! B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/heading-1/src/story-template.jsx
+++ b/components/heading-1/src/story-template.jsx
@@ -1,7 +1,7 @@
-/*
+/**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/components/heading-2/src/_mixin.scss
+++ b/components/heading-2/src/_mixin.scss
@@ -1,8 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
- * Copyright (c) 2021 The Knights Who Say NIH! B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/heading-css/src/mixin";

--- a/components/heading-2/src/html/_mixin.scss
+++ b/components/heading-2/src/html/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/heading-2/src/html/index.scss
+++ b/components/heading-2/src/html/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/heading-2/src/index.scss
+++ b/components/heading-2/src/index.scss
@@ -1,8 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
- * Copyright (c) 2021 The Knights Who Say NIH! B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/heading-2/src/story-template.jsx
+++ b/components/heading-2/src/story-template.jsx
@@ -1,7 +1,7 @@
-/*
+/**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/components/heading-3/src/_mixin.scss
+++ b/components/heading-3/src/_mixin.scss
@@ -1,8 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
- * Copyright (c) 2021 The Knights Who Say NIH! B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/heading-css/src/mixin";

--- a/components/heading-3/src/html/_mixin.scss
+++ b/components/heading-3/src/html/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/heading-3/src/html/index.scss
+++ b/components/heading-3/src/html/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/heading-3/src/index.scss
+++ b/components/heading-3/src/index.scss
@@ -1,8 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
- * Copyright (c) 2021 The Knights Who Say NIH! B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/heading-3/src/story-template.jsx
+++ b/components/heading-3/src/story-template.jsx
@@ -1,7 +1,7 @@
-/*
+/**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/components/heading-4/src/_mixin.scss
+++ b/components/heading-4/src/_mixin.scss
@@ -1,8 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
- * Copyright (c) 2021 The Knights Who Say NIH! B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/heading-css/src/mixin";

--- a/components/heading-4/src/html/_mixin.scss
+++ b/components/heading-4/src/html/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/heading-4/src/html/index.scss
+++ b/components/heading-4/src/html/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/heading-4/src/index.scss
+++ b/components/heading-4/src/index.scss
@@ -1,8 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
- * Copyright (c) 2021 The Knights Who Say NIH! B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/heading-4/src/story-template.jsx
+++ b/components/heading-4/src/story-template.jsx
@@ -1,7 +1,7 @@
-/*
+/**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/components/heading-5/src/_mixin.scss
+++ b/components/heading-5/src/_mixin.scss
@@ -1,8 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
- * Copyright (c) 2021 The Knights Who Say NIH! B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/heading-css/src/mixin";

--- a/components/heading-5/src/html/_mixin.scss
+++ b/components/heading-5/src/html/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/heading-5/src/html/index.scss
+++ b/components/heading-5/src/html/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/heading-5/src/index.scss
+++ b/components/heading-5/src/index.scss
@@ -1,8 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
- * Copyright (c) 2021 The Knights Who Say NIH! B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/heading-5/src/story-template.jsx
+++ b/components/heading-5/src/story-template.jsx
@@ -1,7 +1,7 @@
-/*
+/**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/components/heading-6/src/_mixin.scss
+++ b/components/heading-6/src/_mixin.scss
@@ -1,8 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
- * Copyright (c) 2021 The Knights Who Say NIH! B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/heading-css/src/mixin";

--- a/components/heading-6/src/html/_mixin.scss
+++ b/components/heading-6/src/html/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/heading-6/src/html/index.scss
+++ b/components/heading-6/src/html/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/heading-6/src/index.scss
+++ b/components/heading-6/src/index.scss
@@ -1,8 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
- * Copyright (c) 2021 The Knights Who Say NIH! B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/heading-6/src/story-template.jsx
+++ b/components/heading-6/src/story-template.jsx
@@ -1,7 +1,7 @@
-/*
+/**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/components/heading-group/src/_mixin.scss
+++ b/components/heading-group/src/_mixin.scss
@@ -1,8 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2022 Gemeente Utrecht
- * Copyright (c) 2022 Robbert Broersma
- * Copyright (c) 2022 The Knights Who Say NIH! B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-heading-group {

--- a/components/heading-group/src/html/_mixin.scss
+++ b/components/heading-group/src/html/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/heading-group/src/html/index.scss
+++ b/components/heading-group/src/html/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/heading-group/src/index.scss
+++ b/components/heading-group/src/index.scss
@@ -1,8 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2022 Gemeente Utrecht
- * Copyright (c) 2022 Robbert Broersma
- * Copyright (c) 2022 The Knights Who Say NIH! B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/heading/src/_mixin.scss
+++ b/components/heading/src/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-heading {

--- a/components/html-content/src/_mixin.scss
+++ b/components/html-content/src/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 /* Collection of all semantic HTML styles in the component library */

--- a/components/html-content/src/html/index.scss
+++ b/components/html-content/src/html/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 /* Collection of all semantic HTML styles in the component library */

--- a/components/html-content/src/index.scss
+++ b/components/html-content/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/iban-data/src/_mixin.scss
+++ b/components/iban-data/src/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-iban-data {

--- a/components/iban-data/src/index.scss
+++ b/components/iban-data/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/icon/src/_mixin.scss
+++ b/components/icon/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021-2022 Gemeente Utrecht
- * Copyright (c) 2021-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-icon {

--- a/components/icon/src/index.scss
+++ b/components/icon/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021-2022 Gemeente Utrecht
- * Copyright (c) 2021-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/img/src/_mixin.scss
+++ b/components/img/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-img {

--- a/components/img/src/index.scss
+++ b/components/img/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/index-char-nav/src/_mixin.scss
+++ b/components/index-char-nav/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-index-char-nav {

--- a/components/index-char-nav/src/index.scss
+++ b/components/index-char-nav/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/index.scss
+++ b/components/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 /* Collection of all BEM class names in the component library */

--- a/components/link-button/src/_mixin.scss
+++ b/components/link-button/src/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2022 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/link-css/src/mixin";

--- a/components/link-button/src/index.scss
+++ b/components/link-button/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2022 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/link-list/src/_mixin.scss
+++ b/components/link-list/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin reset-ul() {

--- a/components/link-list/src/index.scss
+++ b/components/link-list/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/link-social/src/index.scss
+++ b/components/link-social/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2022 The Knights Who Say NIH! B.V.
- * Copyright (c) 2022 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 /* stylelint-disable scss/no-global-function-names */

--- a/components/link/src/_mixin.scss
+++ b/components/link/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 The Knights Who Say NIH! B.V.
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 // Avoid false positive for new CSS function `max()`

--- a/components/link/src/html/_mixin.scss
+++ b/components/link/src/html/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/link/src/html/index.scss
+++ b/components/link/src/html/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/link/src/index.scss
+++ b/components/link/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 The Knights Who Say NIH! B.V.
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 // Avoid false positive for new CSS function `max()`

--- a/components/list-social/src/index.scss
+++ b/components/list-social/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 The Knights Who Say NIH! B.V.
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/logo-button/src/index.scss
+++ b/components/logo-button/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 .utrecht-logo-button {

--- a/components/logo-image/src/index.scss
+++ b/components/logo-image/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 /* stylelint-disable-next-line block-no-empty */

--- a/components/logo/src/_mixin.scss
+++ b/components/logo/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 $utrecht-support-prince-xml: false !default;

--- a/components/logo/src/index.scss
+++ b/components/logo/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/map-marker/src/_mixin.scss
+++ b/components/map-marker/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2022 Gemeente Utrecht
- * Copyright (c) 2022 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-map-marker {

--- a/components/map-marker/src/index.scss
+++ b/components/map-marker/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2022 Gemeente Utrecht
- * Copyright (c) 2022 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/mapcontrolbutton/src/index.scss
+++ b/components/mapcontrolbutton/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/focus-ring-css/src/mixin";

--- a/components/mark/src/_mixin.scss
+++ b/components/mark/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-mark--print {

--- a/components/mark/src/html/_mixin.scss
+++ b/components/mark/src/html/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/mark/src/html/index.scss
+++ b/components/mark/src/html/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/mark/src/index.scss
+++ b/components/mark/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 The Knights Who Say NIH! B.V.
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/menulijst/src/index.scss
+++ b/components/menulijst/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../../focus-ring/src/mixin";

--- a/components/multiline-data/src/_mixin.scss
+++ b/components/multiline-data/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-multiline-data {

--- a/components/multiline-data/src/index.scss
+++ b/components/multiline-data/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 The Knights Who Say NIH! B.V.
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/nav-bar/src/index.scss
+++ b/components/nav-bar/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 .utrecht-nav-bar {

--- a/components/nav-list/src/index.scss
+++ b/components/nav-list/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin reset-ul() {

--- a/components/navigatie sidenav/src/index.scss
+++ b/components/navigatie sidenav/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 The Knights Who Say NIH! B.V.
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../../focus-ring/src/mixin";

--- a/components/navigatie sidenav/src/story-template.jsx
+++ b/components/navigatie sidenav/src/story-template.jsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/components/navigatie topnav/src/index.scss
+++ b/components/navigatie topnav/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../../focus-ring/src/mixin";

--- a/components/number-badge/src/_mixin.scss
+++ b/components/number-badge/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-number-badge {

--- a/components/number-badge/src/index.scss
+++ b/components/number-badge/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/number-data/src/_mixin.scss
+++ b/components/number-data/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-number-data {

--- a/components/number-data/src/index.scss
+++ b/components/number-data/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/ordered-list/src/_mixin.scss
+++ b/components/ordered-list/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-ordered-list {

--- a/components/ordered-list/src/html/_mixin.scss
+++ b/components/ordered-list/src/html/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/ordered-list/src/html/index.scss
+++ b/components/ordered-list/src/html/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/ordered-list/src/index.scss
+++ b/components/ordered-list/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/page-content/src/_mixin.scss
+++ b/components/page-content/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-page-content {

--- a/components/page-content/src/index.scss
+++ b/components/page-content/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/page-footer/src/_mixin.scss
+++ b/components/page-footer/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin reset-address {

--- a/components/page-footer/src/index.scss
+++ b/components/page-footer/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/page-header/src/_mixin.scss
+++ b/components/page-header/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-page-header {

--- a/components/page-header/src/index.scss
+++ b/components/page-header/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/page/src/_mixin.scss
+++ b/components/page/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-page {

--- a/components/page/src/index.scss
+++ b/components/page/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/pagination/src/_mixin.scss
+++ b/components/pagination/src/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-pagination {

--- a/components/pagination/src/index.scss
+++ b/components/pagination/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/focus-ring-css/src/mixin";

--- a/components/paragraph/src/_mixin.scss
+++ b/components/paragraph/src/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 The Knights Who Say NIH! B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-paragraph {

--- a/components/paragraph/src/html/_mixin.scss
+++ b/components/paragraph/src/html/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/paragraph/src/html/index.scss
+++ b/components/paragraph/src/html/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/paragraph/src/index.scss
+++ b/components/paragraph/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 The Knights Who Say NIH! B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/pre-heading/src/_mixin.scss
+++ b/components/pre-heading/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-pre-heading {

--- a/components/pre-heading/src/index.scss
+++ b/components/pre-heading/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/preserve-data/src/_mixin.scss
+++ b/components/preserve-data/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-preserve-data {

--- a/components/preserve-data/src/index.scss
+++ b/components/preserve-data/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/radio-button/src/_mixin.scss
+++ b/components/radio-button/src/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/focus-ring-css/src/mixin";

--- a/components/radio-button/src/html/_mixin.scss
+++ b/components/radio-button/src/html/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/radio-button/src/html/index.scss
+++ b/components/radio-button/src/html/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/radio-button/src/index.scss
+++ b/components/radio-button/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/radio-button/src/story-template.jsx
+++ b/components/radio-button/src/story-template.jsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/components/search-bar/src/_mixin.scss
+++ b/components/search-bar/src/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/focus-ring-css/src/mixin";

--- a/components/search-bar/src/index.scss
+++ b/components/search-bar/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/select/src/_mixin.scss
+++ b/components/select/src/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/focus-ring-css/src/mixin";

--- a/components/select/src/html/_mixin.scss
+++ b/components/select/src/html/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/select/src/html/index.scss
+++ b/components/select/src/html/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/select/src/index.scss
+++ b/components/select/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/focus-ring-css/src/mixin";

--- a/components/separator/src/_mixin.scss
+++ b/components/separator/src/_mixin.scss
@@ -1,8 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
- * Copyright (c) 2021 The Knights Who Say NIH! B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-separator {

--- a/components/separator/src/html/_mixin.scss
+++ b/components/separator/src/html/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/separator/src/html/index.scss
+++ b/components/separator/src/html/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/separator/src/index.scss
+++ b/components/separator/src/index.scss
@@ -1,8 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
- * Copyright (c) 2021 The Knights Who Say NIH! B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/skip-link/src/_mixin.scss
+++ b/components/skip-link/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/focus-ring-css/src/mixin";

--- a/components/skip-link/src/index.scss
+++ b/components/skip-link/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/spotlight-section/src/_mixin.scss
+++ b/components/spotlight-section/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-spotlight-section {

--- a/components/spotlight-section/src/index.scss
+++ b/components/spotlight-section/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/subscript/src/_mixin.scss
+++ b/components/subscript/src/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 /* stylelint-disable-next-line block-no-empty */

--- a/components/subscript/src/html/_mixin.scss
+++ b/components/subscript/src/html/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/subscript/src/html/index.scss
+++ b/components/subscript/src/html/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/subscript/src/index.scss
+++ b/components/subscript/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/superscript/src/_mixin.scss
+++ b/components/superscript/src/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 /* stylelint-disable-next-line block-no-empty */

--- a/components/superscript/src/html/_mixin.scss
+++ b/components/superscript/src/html/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/superscript/src/html/index.scss
+++ b/components/superscript/src/html/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/superscript/src/index.scss
+++ b/components/superscript/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/surface/src/_mixin.scss
+++ b/components/surface/src/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin reset-body {

--- a/components/surface/src/index.scss
+++ b/components/surface/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/table-of-contents/src/_mixin.scss
+++ b/components/table-of-contents/src/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 $utrecht-support-prince-xml: false !default;

--- a/components/table-of-contents/src/index.scss
+++ b/components/table-of-contents/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/table/src/_mixin.scss
+++ b/components/table/src/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-table {

--- a/components/table/src/html/_mixin.scss
+++ b/components/table/src/html/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/table/src/html/index.scss
+++ b/components/table/src/html/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/table/src/index.scss
+++ b/components/table/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/templates/contact-card-template/css/index.scss
+++ b/components/templates/contact-card-template/css/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 .utrecht-contact-card {

--- a/components/textarea/src/_mixin.scss
+++ b/components/textarea/src/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/focus-ring-css/src/mixin";

--- a/components/textarea/src/html/_mixin.scss
+++ b/components/textarea/src/html/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/textarea/src/html/index.scss
+++ b/components/textarea/src/html/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/textarea/src/index.scss
+++ b/components/textarea/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/focus-ring-css/src/mixin";

--- a/components/textbox/src/_mixin.scss
+++ b/components/textbox/src/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/focus-ring-css/src/mixin";

--- a/components/textbox/src/html/_mixin.scss
+++ b/components/textbox/src/html/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/textbox/src/html/index.scss
+++ b/components/textbox/src/html/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/textbox/src/index.scss
+++ b/components/textbox/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/focus-ring-css/src/mixin";

--- a/components/toptask-link/src/index.scss
+++ b/components/toptask-link/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/focus-ring-css/src/mixin";

--- a/components/toptask-nav/src/index.scss
+++ b/components/toptask-nav/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 .utrecht-toptask-nav {

--- a/components/unordered-list/src/_mixin.scss
+++ b/components/unordered-list/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-unordered-list {

--- a/components/unordered-list/src/html/_mixin.scss
+++ b/components/unordered-list/src/html/_mixin.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "../mixin";

--- a/components/unordered-list/src/html/index.scss
+++ b/components/unordered-list/src/html/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/unordered-list/src/index.scss
+++ b/components/unordered-list/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/components/url-data/src/_mixin.scss
+++ b/components/url-data/src/_mixin.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @mixin utrecht-url-data {

--- a/components/url-data/src/index.scss
+++ b/components/url-data/src/index.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./mixin";

--- a/documentation/components/CopyButton.jsx
+++ b/documentation/components/CopyButton.jsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import PropTypes from 'prop-types';

--- a/documentation/components/Markdown.jsx
+++ b/documentation/components/Markdown.jsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Markdown as StorybookMarkdown } from '@storybook/blocks';

--- a/packages/component-library-css/src/html.scss
+++ b/packages/component-library-css/src/html.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 /* Collection of all semantic HTML styles in the component library */

--- a/packages/component-library-css/src/index.scss
+++ b/packages/component-library-css/src/index.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 /* Collection of all BEM class names in the component library */

--- a/packages/component-library-css/src/prince-xml.scss
+++ b/packages/component-library-css/src/prince-xml.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 /**

--- a/packages/component-library-react/src/Alert.tsx
+++ b/packages/component-library-react/src/Alert.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/AlertDialog.tsx
+++ b/packages/component-library-react/src/AlertDialog.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/Article.tsx
+++ b/packages/component-library-react/src/Article.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/Backdrop.tsx
+++ b/packages/component-library-react/src/Backdrop.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/BadgeList.tsx
+++ b/packages/component-library-react/src/BadgeList.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/Blockquote.tsx
+++ b/packages/component-library-react/src/Blockquote.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/BreadcrumbNav.tsx
+++ b/packages/component-library-react/src/BreadcrumbNav.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Link as UtrechtLink } from '@utrecht/link-react';

--- a/packages/component-library-react/src/Button.tsx
+++ b/packages/component-library-react/src/Button.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2025 Frameless B.V.
- * Copyright (c) 2021-2025 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 export { type ButtonProps } from '@utrecht/button-react';

--- a/packages/component-library-react/src/ButtonGroup.tsx
+++ b/packages/component-library-react/src/ButtonGroup.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/ButtonLink.tsx
+++ b/packages/component-library-react/src/ButtonLink.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/Calendar.tsx
+++ b/packages/component-library-react/src/Calendar.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 export type { CalendarProps } from '@utrecht/calendar-react';

--- a/packages/component-library-react/src/Code.tsx
+++ b/packages/component-library-react/src/Code.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/CodeBlock.tsx
+++ b/packages/component-library-react/src/CodeBlock.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/ColorSample.tsx
+++ b/packages/component-library-react/src/ColorSample.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/ColumnLayout.tsx
+++ b/packages/component-library-react/src/ColumnLayout.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/CurrencyData.tsx
+++ b/packages/component-library-react/src/CurrencyData.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/DataBadge.tsx
+++ b/packages/component-library-react/src/DataBadge.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/DataPlaceholder.tsx
+++ b/packages/component-library-react/src/DataPlaceholder.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/Document.tsx
+++ b/packages/component-library-react/src/Document.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/Drawer.tsx
+++ b/packages/component-library-react/src/Drawer.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/Emphasis.tsx
+++ b/packages/component-library-react/src/Emphasis.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/HTMLContent.tsx
+++ b/packages/component-library-react/src/HTMLContent.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/Heading.tsx
+++ b/packages/component-library-react/src/Heading.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/Heading1.tsx
+++ b/packages/component-library-react/src/Heading1.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/Heading2.tsx
+++ b/packages/component-library-react/src/Heading2.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/Heading3.tsx
+++ b/packages/component-library-react/src/Heading3.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/Heading4.tsx
+++ b/packages/component-library-react/src/Heading4.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/Heading5.tsx
+++ b/packages/component-library-react/src/Heading5.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/Heading6.tsx
+++ b/packages/component-library-react/src/Heading6.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/HeadingGroup.tsx
+++ b/packages/component-library-react/src/HeadingGroup.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2022 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/IBANData.test.tsx
+++ b/packages/component-library-react/src/IBANData.test.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2022 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { render } from '@testing-library/react';

--- a/packages/component-library-react/src/IBANData.tsx
+++ b/packages/component-library-react/src/IBANData.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/Icon.tsx
+++ b/packages/component-library-react/src/Icon.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/Image.tsx
+++ b/packages/component-library-react/src/Image.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/IndexCharNav.tsx
+++ b/packages/component-library-react/src/IndexCharNav.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Button } from '@utrecht/button-react';

--- a/packages/component-library-react/src/LinkButton.tsx
+++ b/packages/component-library-react/src/LinkButton.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/LinkSocial.tsx
+++ b/packages/component-library-react/src/LinkSocial.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/ListSocial.tsx
+++ b/packages/component-library-react/src/ListSocial.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/Listbox.tsx
+++ b/packages/component-library-react/src/Listbox.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2023 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 export type { ListboxOptionGroupProps, ListboxProps, ListboxOptionProps } from '@utrecht/listbox-react';

--- a/packages/component-library-react/src/Logo.tsx
+++ b/packages/component-library-react/src/Logo.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/LogoImage.tsx
+++ b/packages/component-library-react/src/LogoImage.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { ForwardedRef, forwardRef, HTMLAttributes } from 'react';

--- a/packages/component-library-react/src/Mark.tsx
+++ b/packages/component-library-react/src/Mark.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/MultilineData.tsx
+++ b/packages/component-library-react/src/MultilineData.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/NumberData.tsx
+++ b/packages/component-library-react/src/NumberData.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/OrderedList.tsx
+++ b/packages/component-library-react/src/OrderedList.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/OrderedListItem.tsx
+++ b/packages/component-library-react/src/OrderedListItem.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/Page.tsx
+++ b/packages/component-library-react/src/Page.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/PageContent.tsx
+++ b/packages/component-library-react/src/PageContent.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/PageFooter.tsx
+++ b/packages/component-library-react/src/PageFooter.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/PageHeader.tsx
+++ b/packages/component-library-react/src/PageHeader.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/Paragraph.tsx
+++ b/packages/component-library-react/src/Paragraph.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/PreHeading.tsx
+++ b/packages/component-library-react/src/PreHeading.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/PreserveData.tsx
+++ b/packages/component-library-react/src/PreserveData.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/Separator.tsx
+++ b/packages/component-library-react/src/Separator.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/SpotlightSection.tsx
+++ b/packages/component-library-react/src/SpotlightSection.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/Strong.tsx
+++ b/packages/component-library-react/src/Strong.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/Subscript.tsx
+++ b/packages/component-library-react/src/Subscript.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/Superscript.tsx
+++ b/packages/component-library-react/src/Superscript.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/Surface.tsx
+++ b/packages/component-library-react/src/Surface.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/Table.tsx
+++ b/packages/component-library-react/src/Table.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2022 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/TableBody.tsx
+++ b/packages/component-library-react/src/TableBody.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2022 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/TableCaption.tsx
+++ b/packages/component-library-react/src/TableCaption.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2022 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/TableCell.tsx
+++ b/packages/component-library-react/src/TableCell.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2022 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/TableContainer.tsx
+++ b/packages/component-library-react/src/TableContainer.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2022 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/TableFooter.tsx
+++ b/packages/component-library-react/src/TableFooter.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2022 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/TableHeader.tsx
+++ b/packages/component-library-react/src/TableHeader.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2022 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/TableHeaderCell.tsx
+++ b/packages/component-library-react/src/TableHeaderCell.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2022 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/TableOfContents.tsx
+++ b/packages/component-library-react/src/TableOfContents.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2022 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Link, LinkProps } from '@utrecht/link-react';

--- a/packages/component-library-react/src/TableRow.tsx
+++ b/packages/component-library-react/src/TableRow.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2022 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/Textbox.tsx
+++ b/packages/component-library-react/src/Textbox.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2025 Frameless B.V.
- * Copyright (c) 2021-2025 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 export type { TextboxProps, TextboxTypes } from '@utrecht/textbox-react';

--- a/packages/component-library-react/src/URLData.tsx
+++ b/packages/component-library-react/src/URLData.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/UnorderedList.tsx
+++ b/packages/component-library-react/src/UnorderedList.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/UnorderedListItem.tsx
+++ b/packages/component-library-react/src/UnorderedListItem.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/VegaVisualization.tsx
+++ b/packages/component-library-react/src/VegaVisualization.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2023 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/component-library-react/src/css-module/Accordion.tsx
+++ b/packages/component-library-react/src/css-module/Accordion.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/accordion-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/Alert.tsx
+++ b/packages/component-library-react/src/css-module/Alert.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/alert-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/AlertDialog.tsx
+++ b/packages/component-library-react/src/css-module/AlertDialog.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/alert-dialog-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/Article.tsx
+++ b/packages/component-library-react/src/css-module/Article.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/article-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/Backdrop.tsx
+++ b/packages/component-library-react/src/css-module/Backdrop.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/backdrop-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/BadgeCounter.tsx
+++ b/packages/component-library-react/src/css-module/BadgeCounter.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/badge-counter-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/BadgeList.tsx
+++ b/packages/component-library-react/src/css-module/BadgeList.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/badge-list-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/Blockquote.tsx
+++ b/packages/component-library-react/src/css-module/Blockquote.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/blockquote-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/BreadcrumbNav.tsx
+++ b/packages/component-library-react/src/css-module/BreadcrumbNav.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/breadcrumb-nav-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/Button.tsx
+++ b/packages/component-library-react/src/css-module/Button.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 export * from '@utrecht/button-react/dist/css';

--- a/packages/component-library-react/src/css-module/ButtonGroup.tsx
+++ b/packages/component-library-react/src/css-module/ButtonGroup.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/button-group-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/ButtonLink.tsx
+++ b/packages/component-library-react/src/css-module/ButtonLink.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/button-link-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/Calendar.tsx
+++ b/packages/component-library-react/src/css-module/Calendar.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 export type { CalendarProps } from '@utrecht/calendar-react/dist/css';

--- a/packages/component-library-react/src/css-module/Code.tsx
+++ b/packages/component-library-react/src/css-module/Code.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/code-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/CodeBlock.tsx
+++ b/packages/component-library-react/src/css-module/CodeBlock.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/code-block-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/ColorSample.tsx
+++ b/packages/component-library-react/src/css-module/ColorSample.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/color-sample-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/ColumnLayout.tsx
+++ b/packages/component-library-react/src/css-module/ColumnLayout.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/column-layout-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/CurrencyData.tsx
+++ b/packages/component-library-react/src/css-module/CurrencyData.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/currency-data-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/DataBadge.tsx
+++ b/packages/component-library-react/src/css-module/DataBadge.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/badge-data-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/DataList.tsx
+++ b/packages/component-library-react/src/css-module/DataList.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/data-list-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/DataPlaceholder.tsx
+++ b/packages/component-library-react/src/css-module/DataPlaceholder.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/data-placeholder-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/Document.tsx
+++ b/packages/component-library-react/src/css-module/Document.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/document-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/Drawer.tsx
+++ b/packages/component-library-react/src/css-module/Drawer.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/drawer-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/Emphasis.tsx
+++ b/packages/component-library-react/src/css-module/Emphasis.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/emphasis-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/Figure.tsx
+++ b/packages/component-library-react/src/css-module/Figure.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/figure-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/FigureCaption.tsx
+++ b/packages/component-library-react/src/css-module/FigureCaption.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/figure-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/FormField.tsx
+++ b/packages/component-library-react/src/css-module/FormField.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 export * from '@utrecht/form-field-react/dist/css';

--- a/packages/component-library-react/src/css-module/FormFieldTextarea.tsx
+++ b/packages/component-library-react/src/css-module/FormFieldTextarea.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 // Inject CSS from components used in `FormFieldTextarea`

--- a/packages/component-library-react/src/css-module/FormFieldTextbox.tsx
+++ b/packages/component-library-react/src/css-module/FormFieldTextbox.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 // Inject CSS from components used in `FormFieldTextbox`

--- a/packages/component-library-react/src/css-module/FormLabel.tsx
+++ b/packages/component-library-react/src/css-module/FormLabel.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 export * from '@utrecht/form-label-react/dist/css';

--- a/packages/component-library-react/src/css-module/FormToggle.tsx
+++ b/packages/component-library-react/src/css-module/FormToggle.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/form-toggle-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/HTMLContent.tsx
+++ b/packages/component-library-react/src/css-module/HTMLContent.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/html-content-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/Heading.tsx
+++ b/packages/component-library-react/src/css-module/Heading.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/heading-1-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/Heading1.tsx
+++ b/packages/component-library-react/src/css-module/Heading1.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/heading-1-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/Heading2.tsx
+++ b/packages/component-library-react/src/css-module/Heading2.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/heading-2-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/Heading3.tsx
+++ b/packages/component-library-react/src/css-module/Heading3.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/heading-3-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/Heading4.tsx
+++ b/packages/component-library-react/src/css-module/Heading4.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/heading-4-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/Heading5.tsx
+++ b/packages/component-library-react/src/css-module/Heading5.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/heading-5-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/Heading6.tsx
+++ b/packages/component-library-react/src/css-module/Heading6.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/heading-6-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/HeadingGroup.tsx
+++ b/packages/component-library-react/src/css-module/HeadingGroup.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/heading-group-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/IBANData.tsx
+++ b/packages/component-library-react/src/css-module/IBANData.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/iban-data-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/Icon.tsx
+++ b/packages/component-library-react/src/css-module/Icon.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/icon/src/index.scss';

--- a/packages/component-library-react/src/css-module/Image.tsx
+++ b/packages/component-library-react/src/css-module/Image.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/img-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/IndexCharNav.tsx
+++ b/packages/component-library-react/src/css-module/IndexCharNav.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/index-char-nav-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/LinkButton.tsx
+++ b/packages/component-library-react/src/css-module/LinkButton.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/link-button-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/LinkList.tsx
+++ b/packages/component-library-react/src/css-module/LinkList.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/link-list-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/LinkSocial.tsx
+++ b/packages/component-library-react/src/css-module/LinkSocial.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/link-social-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/ListSocial.tsx
+++ b/packages/component-library-react/src/css-module/ListSocial.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/list-social-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/Listbox.tsx
+++ b/packages/component-library-react/src/css-module/Listbox.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 export * from '@utrecht/listbox-react/dist/css';

--- a/packages/component-library-react/src/css-module/Logo.tsx
+++ b/packages/component-library-react/src/css-module/Logo.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2023 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/logo-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/LogoImage.tsx
+++ b/packages/component-library-react/src/css-module/LogoImage.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2023 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 export * from '../LogoImage';

--- a/packages/component-library-react/src/css-module/Mark.tsx
+++ b/packages/component-library-react/src/css-module/Mark.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/mark-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/MultilineData.tsx
+++ b/packages/component-library-react/src/css-module/MultilineData.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/multiline-data-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/NavBar.tsx
+++ b/packages/component-library-react/src/css-module/NavBar.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/nav-bar-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/NavList.tsx
+++ b/packages/component-library-react/src/css-module/NavList.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/nav-list-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/NumberBadge.tsx
+++ b/packages/component-library-react/src/css-module/NumberBadge.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/number-badge-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/NumberData.tsx
+++ b/packages/component-library-react/src/css-module/NumberData.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/number-data-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/OrderedList.tsx
+++ b/packages/component-library-react/src/css-module/OrderedList.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/ordered-list-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/OrderedListItem.tsx
+++ b/packages/component-library-react/src/css-module/OrderedListItem.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/ordered-list-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/Page.tsx
+++ b/packages/component-library-react/src/css-module/Page.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/page-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/PageContent.tsx
+++ b/packages/component-library-react/src/css-module/PageContent.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/page-content-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/PageFooter.tsx
+++ b/packages/component-library-react/src/css-module/PageFooter.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/page-footer-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/PageHeader.tsx
+++ b/packages/component-library-react/src/css-module/PageHeader.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/page-header-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/Paragraph.tsx
+++ b/packages/component-library-react/src/css-module/Paragraph.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/paragraph-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/PreHeading.tsx
+++ b/packages/component-library-react/src/css-module/PreHeading.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/pre-heading-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/PreserveData.tsx
+++ b/packages/component-library-react/src/css-module/PreserveData.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/preserve-data-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/ScrollLink.tsx
+++ b/packages/component-library-react/src/css-module/ScrollLink.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 // Inject CSS from ButtonLink dependency

--- a/packages/component-library-react/src/css-module/Select.tsx
+++ b/packages/component-library-react/src/css-module/Select.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/select-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/Separator.tsx
+++ b/packages/component-library-react/src/css-module/Separator.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/separator-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/SkipLink.tsx
+++ b/packages/component-library-react/src/css-module/SkipLink.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/skip-link-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/SpotlightSection.tsx
+++ b/packages/component-library-react/src/css-module/SpotlightSection.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/spotlight-section-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/Strong.tsx
+++ b/packages/component-library-react/src/css-module/Strong.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/emphasis-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/Subscript.tsx
+++ b/packages/component-library-react/src/css-module/Subscript.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/subscript-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/Superscript.tsx
+++ b/packages/component-library-react/src/css-module/Superscript.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/superscript-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/Surface.tsx
+++ b/packages/component-library-react/src/css-module/Surface.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/surface-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/Table.tsx
+++ b/packages/component-library-react/src/css-module/Table.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/table-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/TableBody.tsx
+++ b/packages/component-library-react/src/css-module/TableBody.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 // CSS is already included by `Table` component

--- a/packages/component-library-react/src/css-module/TableCaption.tsx
+++ b/packages/component-library-react/src/css-module/TableCaption.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 // CSS is already included by `Table` component

--- a/packages/component-library-react/src/css-module/TableCell.tsx
+++ b/packages/component-library-react/src/css-module/TableCell.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 // CSS is already included by `Table` component

--- a/packages/component-library-react/src/css-module/TableFooter.tsx
+++ b/packages/component-library-react/src/css-module/TableFooter.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 // CSS is already included by `Table` component

--- a/packages/component-library-react/src/css-module/TableHeader.tsx
+++ b/packages/component-library-react/src/css-module/TableHeader.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 // CSS is already included by `Table` component

--- a/packages/component-library-react/src/css-module/TableHeaderCell.tsx
+++ b/packages/component-library-react/src/css-module/TableHeaderCell.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 // CSS is already included by `Table` component

--- a/packages/component-library-react/src/css-module/TableOfContents.tsx
+++ b/packages/component-library-react/src/css-module/TableOfContents.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/table-of-contents-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/TableRow.tsx
+++ b/packages/component-library-react/src/css-module/TableRow.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 // CSS is already included by `Table` component

--- a/packages/component-library-react/src/css-module/Textarea.tsx
+++ b/packages/component-library-react/src/css-module/Textarea.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/textarea-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/Textbox.tsx
+++ b/packages/component-library-react/src/css-module/Textbox.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 export * from '@utrecht/textbox-react/dist/css';

--- a/packages/component-library-react/src/css-module/URLData.tsx
+++ b/packages/component-library-react/src/css-module/URLData.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/url-data-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/UnorderedList.tsx
+++ b/packages/component-library-react/src/css-module/UnorderedList.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/unordered-list-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/UnorderedListItem.tsx
+++ b/packages/component-library-react/src/css-module/UnorderedListItem.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/unordered-list-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/VegaVisualization.tsx
+++ b/packages/component-library-react/src/css-module/VegaVisualization.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2023 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/vega-visualization-css/src/index.scss';

--- a/packages/component-library-react/src/css-module/index.ts
+++ b/packages/component-library-react/src/css-module/index.ts
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2022 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 export { Accordion, AccordionProvider, AccordionSection } from './Accordion';

--- a/packages/component-library-react/src/disabled.SearchBar
+++ b/packages/component-library-react/src/disabled.SearchBar
@@ -1,7 +1,8 @@
 // /**
-//  * @license EUPL-1.2
-//  * Copyright (c) 2023 Robbert Broersma
-//  */
+// * @license EUPL-1.2
+// * Copyright (c) 2020-2024 Frameless B.V.
+// * Copyright (c) 2021-2024 Gemeente Utrecht
+// */
 
 // import clsx from 'clsx';
 // import Downshift, { DownshiftProps } from 'downshift';

--- a/packages/component-library-react/src/index.ts
+++ b/packages/component-library-react/src/index.ts
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2022 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 export type {

--- a/packages/components-react/button-react/src/css.tsx
+++ b/packages/components-react/button-react/src/css.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2025 Frameless B.V.
- * Copyright (c) 2021-2025 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/button-css/src/index.scss';

--- a/packages/components-react/button-react/src/index.test.tsx
+++ b/packages/components-react/button-react/src/index.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2025 Frameless B.V.
- * Copyright (c) 2021-2025 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { render, screen } from '@testing-library/react';

--- a/packages/components-react/button-react/src/index.tsx
+++ b/packages/components-react/button-react/src/index.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2025 Frameless B.V.
- * Copyright (c) 2021-2025 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/components-react/calendar-react/src/css.tsx
+++ b/packages/components-react/calendar-react/src/css.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/calendar-css/src/index.scss';

--- a/packages/components-react/checkbox-group-react/src/css.tsx
+++ b/packages/components-react/checkbox-group-react/src/css.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 // Inject CSS from components used in this component

--- a/packages/components-react/checkbox-react/src/css.tsx
+++ b/packages/components-react/checkbox-react/src/css.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/custom-checkbox-css/src/index.scss';

--- a/packages/components-react/combobox-react/src/css.tsx
+++ b/packages/components-react/combobox-react/src/css.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2025 Frameless B.V.
- * Copyright (c) 2021-2025 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/combobox-css/src/index.scss';

--- a/packages/components-react/combobox-react/src/index.tsx
+++ b/packages/components-react/combobox-react/src/index.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2023 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/components-react/fieldset-react/src/css.tsx
+++ b/packages/components-react/fieldset-react/src/css.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2025 Frameless B.V.
- * Copyright (c) 2021-2025 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/form-fieldset-css/src/index.scss';

--- a/packages/components-react/form-field-checkbox-react/src/css.tsx
+++ b/packages/components-react/form-field-checkbox-react/src/css.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 // Inject CSS from components used in `FormFieldCheckbox`

--- a/packages/components-react/form-field-description-react/src/css.tsx
+++ b/packages/components-react/form-field-description-react/src/css.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2025 Frameless B.V.
- * Copyright (c) 2021-2025 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/form-field-description-css/src/index.scss';

--- a/packages/components-react/form-field-error-message-react/src/css.tsx
+++ b/packages/components-react/form-field-error-message-react/src/css.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2025 Frameless B.V.
- * Copyright (c) 2021-2025 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/form-field-error-message-css/src/index.scss';

--- a/packages/components-react/form-field-react/src/css.tsx
+++ b/packages/components-react/form-field-react/src/css.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2025 Frameless B.V.
- * Copyright (c) 2021-2025 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/form-field-css/src/index.scss';

--- a/packages/components-react/form-label-react/src/css.tsx
+++ b/packages/components-react/form-label-react/src/css.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2025 Frameless B.V.
- * Copyright (c) 2021-2025 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/form-label-css/src/index.scss';

--- a/packages/components-react/form-label-react/src/index.tsx
+++ b/packages/components-react/form-label-react/src/index.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2025 Frameless B.V.
- * Copyright (c) 2021-2025 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/components-react/link-react/src/css.tsx
+++ b/packages/components-react/link-react/src/css.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2025 Frameless B.V.
- * Copyright (c) 2021-2025 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/link-css/src/index.scss';

--- a/packages/components-react/link-react/src/index.tsx
+++ b/packages/components-react/link-react/src/index.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/components-react/listbox-react/src/css.tsx
+++ b/packages/components-react/listbox-react/src/css.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2025 Frameless B.V.
- * Copyright (c) 2021-2025 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/listbox-css/src/index.scss';

--- a/packages/components-react/listbox-react/src/index.tsx
+++ b/packages/components-react/listbox-react/src/index.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2023 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/components-react/radio-button-react/src/css.tsx
+++ b/packages/components-react/radio-button-react/src/css.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/radio-button-css/src/index.scss';

--- a/packages/components-react/radio-group-react/src/css.tsx
+++ b/packages/components-react/radio-group-react/src/css.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 // Inject CSS from components used in this component

--- a/packages/components-react/select-combobox-react/src/css.tsx
+++ b/packages/components-react/select-combobox-react/src/css.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2025 Frameless B.V.
- * Copyright (c) 2021-2025 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/combobox-react/dist/css';

--- a/packages/components-react/textbox-react/src/css.tsx
+++ b/packages/components-react/textbox-react/src/css.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2025 Frameless B.V.
- * Copyright (c) 2021-2025 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import '@utrecht/textbox-css/src/index.scss';

--- a/packages/docusaurus/src/theme/Heading.js
+++ b/packages/docusaurus/src/theme/Heading.js
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2022 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Heading1, Heading2, Heading3, Heading4, Heading5, Heading6 } from '@utrecht/component-library-react';

--- a/packages/storybook-css/src/AlternateLangNav.tsx
+++ b/packages/storybook-css/src/AlternateLangNav.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { ButtonGroup, Link, LinkButton } from '@utrecht/component-library-react';

--- a/packages/storybook-css/src/ArticleLink.scss
+++ b/packages/storybook-css/src/ArticleLink.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 .example-article {

--- a/packages/storybook-css/src/BreadcrumbNav.tsx
+++ b/packages/storybook-css/src/BreadcrumbNav.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Link as UtrechtLink } from '@utrecht/component-library-react';

--- a/packages/storybook-css/src/FormFieldsetDiv.tsx
+++ b/packages/storybook-css/src/FormFieldsetDiv.tsx
@@ -1,7 +1,7 @@
-/*
+/**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/storybook-css/src/Heading2.tsx
+++ b/packages/storybook-css/src/Heading2.tsx
@@ -1,7 +1,7 @@
-/*
+/**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/storybook-css/src/LogoButton.tsx
+++ b/packages/storybook-css/src/LogoButton.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Button } from '@utrecht/component-library-react';

--- a/packages/storybook-css/src/MapControlButton.tsx
+++ b/packages/storybook-css/src/MapControlButton.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/storybook-css/src/MapMarker.tsx
+++ b/packages/storybook-css/src/MapMarker.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import React, { PropsWithChildren } from 'react';

--- a/packages/storybook-css/src/Menulijst.tsx
+++ b/packages/storybook-css/src/Menulijst.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/storybook-css/src/SideNav.tsx
+++ b/packages/storybook-css/src/SideNav.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/storybook-css/src/TopNav.tsx
+++ b/packages/storybook-css/src/TopNav.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import clsx from 'clsx';

--- a/packages/storybook-css/src/accordion/Accordion.tsx
+++ b/packages/storybook-css/src/accordion/Accordion.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import {

--- a/packages/web-component-library-stencil/src/components.d.ts
+++ b/packages/web-component-library-stencil/src/components.d.ts
@@ -649,25 +649,29 @@ export namespace Components {
     }
     /**
      * @license EUPL-1.2
-     * Copyright (c) 2021 Gemeente Utrecht
+     * Copyright (c) 2020-2024 Frameless B.V.
+     * Copyright (c) 2021-2024 Gemeente Utrecht
      */
     interface UtrechtPage {
     }
     /**
      * @license EUPL-1.2
-     * Copyright (c) 2021 Gemeente Utrecht
+     * Copyright (c) 2020-2024 Frameless B.V.
+     * Copyright (c) 2021-2024 Gemeente Utrecht
      */
     interface UtrechtPageContent {
     }
     /**
      * @license EUPL-1.2
-     * Copyright (c) 2021 Gemeente Utrecht
+     * Copyright (c) 2020-2024 Frameless B.V.
+     * Copyright (c) 2021-2024 Gemeente Utrecht
      */
     interface UtrechtPageFooter {
     }
     /**
      * @license EUPL-1.2
-     * Copyright (c) 2021 Gemeente Utrecht
+     * Copyright (c) 2020-2024 Frameless B.V.
+     * Copyright (c) 2021-2024 Gemeente Utrecht
      */
     interface UtrechtPageHeader {
     }
@@ -2451,7 +2455,8 @@ declare global {
     };
     /**
      * @license EUPL-1.2
-     * Copyright (c) 2021 Gemeente Utrecht
+     * Copyright (c) 2020-2024 Frameless B.V.
+     * Copyright (c) 2021-2024 Gemeente Utrecht
      */
     interface HTMLUtrechtPageElement extends Components.UtrechtPage, HTMLStencilElement {
     }
@@ -2461,7 +2466,8 @@ declare global {
     };
     /**
      * @license EUPL-1.2
-     * Copyright (c) 2021 Gemeente Utrecht
+     * Copyright (c) 2020-2024 Frameless B.V.
+     * Copyright (c) 2021-2024 Gemeente Utrecht
      */
     interface HTMLUtrechtPageContentElement extends Components.UtrechtPageContent, HTMLStencilElement {
     }
@@ -2471,7 +2477,8 @@ declare global {
     };
     /**
      * @license EUPL-1.2
-     * Copyright (c) 2021 Gemeente Utrecht
+     * Copyright (c) 2020-2024 Frameless B.V.
+     * Copyright (c) 2021-2024 Gemeente Utrecht
      */
     interface HTMLUtrechtPageFooterElement extends Components.UtrechtPageFooter, HTMLStencilElement {
     }
@@ -2481,7 +2488,8 @@ declare global {
     };
     /**
      * @license EUPL-1.2
-     * Copyright (c) 2021 Gemeente Utrecht
+     * Copyright (c) 2020-2024 Frameless B.V.
+     * Copyright (c) 2021-2024 Gemeente Utrecht
      */
     interface HTMLUtrechtPageHeaderElement extends Components.UtrechtPageHeader, HTMLStencilElement {
     }
@@ -3605,25 +3613,29 @@ declare namespace LocalJSX {
     }
     /**
      * @license EUPL-1.2
-     * Copyright (c) 2021 Gemeente Utrecht
+     * Copyright (c) 2020-2024 Frameless B.V.
+     * Copyright (c) 2021-2024 Gemeente Utrecht
      */
     interface UtrechtPage {
     }
     /**
      * @license EUPL-1.2
-     * Copyright (c) 2021 Gemeente Utrecht
+     * Copyright (c) 2020-2024 Frameless B.V.
+     * Copyright (c) 2021-2024 Gemeente Utrecht
      */
     interface UtrechtPageContent {
     }
     /**
      * @license EUPL-1.2
-     * Copyright (c) 2021 Gemeente Utrecht
+     * Copyright (c) 2020-2024 Frameless B.V.
+     * Copyright (c) 2021-2024 Gemeente Utrecht
      */
     interface UtrechtPageFooter {
     }
     /**
      * @license EUPL-1.2
-     * Copyright (c) 2021 Gemeente Utrecht
+     * Copyright (c) 2020-2024 Frameless B.V.
+     * Copyright (c) 2021-2024 Gemeente Utrecht
      */
     interface UtrechtPageHeader {
     }
@@ -4280,22 +4292,26 @@ declare module "@stencil/core" {
             "utrecht-number-data": LocalJSX.UtrechtNumberData & JSXBase.HTMLAttributes<HTMLUtrechtNumberDataElement>;
             /**
              * @license EUPL-1.2
-             * Copyright (c) 2021 Gemeente Utrecht
+             * Copyright (c) 2020-2024 Frameless B.V.
+             * Copyright (c) 2021-2024 Gemeente Utrecht
              */
             "utrecht-page": LocalJSX.UtrechtPage & JSXBase.HTMLAttributes<HTMLUtrechtPageElement>;
             /**
              * @license EUPL-1.2
-             * Copyright (c) 2021 Gemeente Utrecht
+             * Copyright (c) 2020-2024 Frameless B.V.
+             * Copyright (c) 2021-2024 Gemeente Utrecht
              */
             "utrecht-page-content": LocalJSX.UtrechtPageContent & JSXBase.HTMLAttributes<HTMLUtrechtPageContentElement>;
             /**
              * @license EUPL-1.2
-             * Copyright (c) 2021 Gemeente Utrecht
+             * Copyright (c) 2020-2024 Frameless B.V.
+             * Copyright (c) 2021-2024 Gemeente Utrecht
              */
             "utrecht-page-footer": LocalJSX.UtrechtPageFooter & JSXBase.HTMLAttributes<HTMLUtrechtPageFooterElement>;
             /**
              * @license EUPL-1.2
-             * Copyright (c) 2021 Gemeente Utrecht
+             * Copyright (c) 2020-2024 Frameless B.V.
+             * Copyright (c) 2021-2024 Gemeente Utrecht
              */
             "utrecht-page-header": LocalJSX.UtrechtPageHeader & JSXBase.HTMLAttributes<HTMLUtrechtPageHeaderElement>;
             "utrecht-pagination": LocalJSX.UtrechtPagination & JSXBase.HTMLAttributes<HTMLUtrechtPaginationElement>;

--- a/packages/web-component-library-stencil/src/components/alert.scss
+++ b/packages/web-component-library-stencil/src/components/alert.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/alert-css/src";

--- a/packages/web-component-library-stencil/src/components/alert.tsx
+++ b/packages/web-component-library-stencil/src/components/alert.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h, Prop } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/article.scss
+++ b/packages/web-component-library-stencil/src/components/article.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/article-css/src";

--- a/packages/web-component-library-stencil/src/components/article.tsx
+++ b/packages/web-component-library-stencil/src/components/article.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/backdrop.scss
+++ b/packages/web-component-library-stencil/src/components/backdrop.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/backdrop-css/src";

--- a/packages/web-component-library-stencil/src/components/backdrop.tsx
+++ b/packages/web-component-library-stencil/src/components/backdrop.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h, Prop } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/badge-counter.scss
+++ b/packages/web-component-library-stencil/src/components/badge-counter.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/badge-counter-css/src";

--- a/packages/web-component-library-stencil/src/components/badge-counter.tsx
+++ b/packages/web-component-library-stencil/src/components/badge-counter.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h, Prop } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/badge-data.scss
+++ b/packages/web-component-library-stencil/src/components/badge-data.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/badge-data-css/src/index";

--- a/packages/web-component-library-stencil/src/components/badge-data.tsx
+++ b/packages/web-component-library-stencil/src/components/badge-data.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/badge-list.scss
+++ b/packages/web-component-library-stencil/src/components/badge-list.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/badge-list-css/src";

--- a/packages/web-component-library-stencil/src/components/badge-list.tsx
+++ b/packages/web-component-library-stencil/src/components/badge-list.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/badge-status.scss
+++ b/packages/web-component-library-stencil/src/components/badge-status.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/badge-status-css/src";

--- a/packages/web-component-library-stencil/src/components/badge-status.tsx
+++ b/packages/web-component-library-stencil/src/components/badge-status.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h, Prop } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/breadcrumb-nav.scss
+++ b/packages/web-component-library-stencil/src/components/breadcrumb-nav.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/breadcrumb-nav-css/src";

--- a/packages/web-component-library-stencil/src/components/breadcrumb-nav.tsx
+++ b/packages/web-component-library-stencil/src/components/breadcrumb-nav.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 import { Component, h, Prop } from '@stencil/core';
 import clsx from 'clsx';

--- a/packages/web-component-library-stencil/src/components/button-group.scss
+++ b/packages/web-component-library-stencil/src/components/button-group.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/button-group-css/src";

--- a/packages/web-component-library-stencil/src/components/button-group.tsx
+++ b/packages/web-component-library-stencil/src/components/button-group.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h, Prop } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/button-link.scss
+++ b/packages/web-component-library-stencil/src/components/button-link.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/button-link-css/src";

--- a/packages/web-component-library-stencil/src/components/button-link.tsx
+++ b/packages/web-component-library-stencil/src/components/button-link.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h, Prop } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/button.scss
+++ b/packages/web-component-library-stencil/src/components/button.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/button-css/src";

--- a/packages/web-component-library-stencil/src/components/checkbox.scss
+++ b/packages/web-component-library-stencil/src/components/checkbox.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/checkbox-css/src";

--- a/packages/web-component-library-stencil/src/components/checkbox.tsx
+++ b/packages/web-component-library-stencil/src/components/checkbox.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, Event, EventEmitter, h, Prop } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/code-block.scss
+++ b/packages/web-component-library-stencil/src/components/code-block.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/code-block-css/src";

--- a/packages/web-component-library-stencil/src/components/code-block.tsx
+++ b/packages/web-component-library-stencil/src/components/code-block.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/code.scss
+++ b/packages/web-component-library-stencil/src/components/code.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/code-css/src";

--- a/packages/web-component-library-stencil/src/components/code.tsx
+++ b/packages/web-component-library-stencil/src/components/code.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/color-sample.scss
+++ b/packages/web-component-library-stencil/src/components/color-sample.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/color-sample-css/src/mixin";

--- a/packages/web-component-library-stencil/src/components/color-sample.tsx
+++ b/packages/web-component-library-stencil/src/components/color-sample.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h, Host, Prop } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/column-layout.scss
+++ b/packages/web-component-library-stencil/src/components/column-layout.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/column-layout-css/src/mixin";

--- a/packages/web-component-library-stencil/src/components/column-layout.tsx
+++ b/packages/web-component-library-stencil/src/components/column-layout.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h, Prop } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/contact-card-template.scss
+++ b/packages/web-component-library-stencil/src/components/contact-card-template.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/link-css/src/index";

--- a/packages/web-component-library-stencil/src/components/custom-checkbox.scss
+++ b/packages/web-component-library-stencil/src/components/custom-checkbox.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/custom-checkbox-css/src";

--- a/packages/web-component-library-stencil/src/components/custom-checkbox.tsx
+++ b/packages/web-component-library-stencil/src/components/custom-checkbox.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h, Prop } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/data-list-actions.scss
+++ b/packages/web-component-library-stencil/src/components/data-list-actions.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/data-list-css/src/mixin";

--- a/packages/web-component-library-stencil/src/components/data-list-actions.tsx
+++ b/packages/web-component-library-stencil/src/components/data-list-actions.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/data-list-item.scss
+++ b/packages/web-component-library-stencil/src/components/data-list-item.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/data-list-css/src/mixin";

--- a/packages/web-component-library-stencil/src/components/data-list-item.tsx
+++ b/packages/web-component-library-stencil/src/components/data-list-item.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/data-list-key.scss
+++ b/packages/web-component-library-stencil/src/components/data-list-key.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/data-list-css/src/mixin";

--- a/packages/web-component-library-stencil/src/components/data-list-key.tsx
+++ b/packages/web-component-library-stencil/src/components/data-list-key.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/data-list-value.scss
+++ b/packages/web-component-library-stencil/src/components/data-list-value.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/data-list-css/src/mixin";

--- a/packages/web-component-library-stencil/src/components/data-list-value.tsx
+++ b/packages/web-component-library-stencil/src/components/data-list-value.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/data-list.scss
+++ b/packages/web-component-library-stencil/src/components/data-list.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/data-list-css/src/mixin";

--- a/packages/web-component-library-stencil/src/components/data-list.tsx
+++ b/packages/web-component-library-stencil/src/components/data-list.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/digid-button.scss
+++ b/packages/web-component-library-stencil/src/components/digid-button.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/digid-button-css/src";

--- a/packages/web-component-library-stencil/src/components/digid-button.tsx
+++ b/packages/web-component-library-stencil/src/components/digid-button.tsx
@@ -1,7 +1,8 @@
 /**
  * @license EUPL-1.2
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  * Copyright (c) 2021 Rijksoverheid
- * Copyright (c) 2021 Robbert Broersma
  */
 
 import { Component, h, Prop } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/digid-logo.scss
+++ b/packages/web-component-library-stencil/src/components/digid-logo.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 @import "~@utrecht/icon/src";
 

--- a/packages/web-component-library-stencil/src/components/digid-logo.tsx
+++ b/packages/web-component-library-stencil/src/components/digid-logo.tsx
@@ -1,7 +1,8 @@
 /**
  * @license EUPL-1.2
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  * Copyright (c) 2021 Rijksoverheid
- * Copyright (c) 2021 Robbert Broersma
  */
 
 import { Component, h } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/document.scss
+++ b/packages/web-component-library-stencil/src/components/document.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/document-css/src";

--- a/packages/web-component-library-stencil/src/components/drawer.scss
+++ b/packages/web-component-library-stencil/src/components/drawer.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/drawer-css/src";

--- a/packages/web-component-library-stencil/src/components/drawer.tsx
+++ b/packages/web-component-library-stencil/src/components/drawer.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h, Method, Prop } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/eherkenning-logo.scss
+++ b/packages/web-component-library-stencil/src/components/eherkenning-logo.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/icon/src";

--- a/packages/web-component-library-stencil/src/components/eherkenning-logo.tsx
+++ b/packages/web-component-library-stencil/src/components/eherkenning-logo.tsx
@@ -1,7 +1,8 @@
 /**
  * @license EUPL-1.2
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  * Copyright (c) 2021 Rijksoverheid
- * Copyright (c) 2021 Robbert Broersma
  */
 
 import { Component, h } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/eidas-logo.scss
+++ b/packages/web-component-library-stencil/src/components/eidas-logo.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/icon/src";

--- a/packages/web-component-library-stencil/src/components/eidas-logo.tsx
+++ b/packages/web-component-library-stencil/src/components/eidas-logo.tsx
@@ -1,7 +1,8 @@
 /**
  * @license EUPL-1.2
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  * Copyright (c) 2021 Rijksoverheid
- * Copyright (c) 2021 Robbert Broersma
  */
 
 import { Component, h } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/emphasis.scss
+++ b/packages/web-component-library-stencil/src/components/emphasis.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/emphasis-css/src";

--- a/packages/web-component-library-stencil/src/components/emphasis.tsx
+++ b/packages/web-component-library-stencil/src/components/emphasis.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/flex-wrap-fallback.scss
+++ b/packages/web-component-library-stencil/src/components/flex-wrap-fallback.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 :host {

--- a/packages/web-component-library-stencil/src/components/flex-wrap-fallback.tsx
+++ b/packages/web-component-library-stencil/src/components/flex-wrap-fallback.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, Element, h, Prop, State } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/form-field-checkbox.scss
+++ b/packages/web-component-library-stencil/src/components/form-field-checkbox.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/form-field-css/src";

--- a/packages/web-component-library-stencil/src/components/form-field-checkbox.tsx
+++ b/packages/web-component-library-stencil/src/components/form-field-checkbox.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, Element, Event, EventEmitter, h, Prop } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/form-field-description.scss
+++ b/packages/web-component-library-stencil/src/components/form-field-description.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/form-field-description-css/src";

--- a/packages/web-component-library-stencil/src/components/form-field-description.tsx
+++ b/packages/web-component-library-stencil/src/components/form-field-description.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h, Prop } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/form-field-error-message.scss
+++ b/packages/web-component-library-stencil/src/components/form-field-error-message.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/form-field-error-message-css/src";

--- a/packages/web-component-library-stencil/src/components/form-field-error-message.tsx
+++ b/packages/web-component-library-stencil/src/components/form-field-error-message.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/form-field-textarea.scss
+++ b/packages/web-component-library-stencil/src/components/form-field-textarea.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/form-field-css/src";

--- a/packages/web-component-library-stencil/src/components/form-field-textarea.tsx
+++ b/packages/web-component-library-stencil/src/components/form-field-textarea.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, Element, Event, EventEmitter, h, Prop } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/form-field-textbox.scss
+++ b/packages/web-component-library-stencil/src/components/form-field-textbox.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/form-field-css/src";

--- a/packages/web-component-library-stencil/src/components/form-field-textbox.tsx
+++ b/packages/web-component-library-stencil/src/components/form-field-textbox.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, Element, Event, EventEmitter, h, Prop } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/form-toggle.scss
+++ b/packages/web-component-library-stencil/src/components/form-toggle.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/form-toggle-css/src";

--- a/packages/web-component-library-stencil/src/components/form-toggle.tsx
+++ b/packages/web-component-library-stencil/src/components/form-toggle.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, Event, EventEmitter, h, Prop } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/form.scss
+++ b/packages/web-component-library-stencil/src/components/form.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/form-css/src";

--- a/packages/web-component-library-stencil/src/components/form.tsx
+++ b/packages/web-component-library-stencil/src/components/form.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h, Prop } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/heading-1.scss
+++ b/packages/web-component-library-stencil/src/components/heading-1.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/heading-1-css/src/mixin";

--- a/packages/web-component-library-stencil/src/components/heading-2.scss
+++ b/packages/web-component-library-stencil/src/components/heading-2.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/heading-2-css/src/mixin";

--- a/packages/web-component-library-stencil/src/components/heading-3.scss
+++ b/packages/web-component-library-stencil/src/components/heading-3.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/heading-3-css/src/mixin";

--- a/packages/web-component-library-stencil/src/components/heading-4.scss
+++ b/packages/web-component-library-stencil/src/components/heading-4.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/heading-4-css/src/mixin";

--- a/packages/web-component-library-stencil/src/components/heading-5.scss
+++ b/packages/web-component-library-stencil/src/components/heading-5.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/heading-5-css/src/mixin";

--- a/packages/web-component-library-stencil/src/components/heading-6.scss
+++ b/packages/web-component-library-stencil/src/components/heading-6.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/heading-6-css/src/mixin";

--- a/packages/web-component-library-stencil/src/components/heading-group.scss
+++ b/packages/web-component-library-stencil/src/components/heading-group.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/heading-group-css/src/mixin";

--- a/packages/web-component-library-stencil/src/components/heading-group.tsx
+++ b/packages/web-component-library-stencil/src/components/heading-group.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/heading.scss
+++ b/packages/web-component-library-stencil/src/components/heading.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/heading-1-css/src";

--- a/packages/web-component-library-stencil/src/components/html-content.scss
+++ b/packages/web-component-library-stencil/src/components/html-content.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 // TODO: Use npm package import

--- a/packages/web-component-library-stencil/src/components/html-content.tsx
+++ b/packages/web-component-library-stencil/src/components/html-content.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 import { Component, h } from '@stencil/core';
 

--- a/packages/web-component-library-stencil/src/components/iban-data.scss
+++ b/packages/web-component-library-stencil/src/components/iban-data.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/iban-data-css/src";

--- a/packages/web-component-library-stencil/src/components/iban-data.tsx
+++ b/packages/web-component-library-stencil/src/components/iban-data.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h, Prop } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/icon.scss
+++ b/packages/web-component-library-stencil/src/components/icon.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021-2022 Gemeente Utrecht
- * Copyright (c) 2021-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/icon/src/mixin";

--- a/packages/web-component-library-stencil/src/components/icon/generated-direction-inherit.scss
+++ b/packages/web-component-library-stencil/src/components/icon/generated-direction-inherit.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021-2022 Gemeente Utrecht
- * Copyright (c) 2021-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "./generated";

--- a/packages/web-component-library-stencil/src/components/icon/generated.scss
+++ b/packages/web-component-library-stencil/src/components/icon/generated.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021-2022 Gemeente Utrecht
- * Copyright (c) 2021-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/icon/src/mixin";

--- a/packages/web-component-library-stencil/src/components/link-button.scss
+++ b/packages/web-component-library-stencil/src/components/link-button.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/link-button-css/src";

--- a/packages/web-component-library-stencil/src/components/link-button.tsx
+++ b/packages/web-component-library-stencil/src/components/link-button.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, Element, h, Prop } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/link.scss
+++ b/packages/web-component-library-stencil/src/components/link.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/link-css/src";

--- a/packages/web-component-library-stencil/src/components/link.tsx
+++ b/packages/web-component-library-stencil/src/components/link.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h, Prop } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/logo-button.scss
+++ b/packages/web-component-library-stencil/src/components/logo-button.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/logo-button-css/src";

--- a/packages/web-component-library-stencil/src/components/logo-button.tsx
+++ b/packages/web-component-library-stencil/src/components/logo-button.tsx
@@ -1,7 +1,8 @@
 /**
  * @license EUPL-1.2
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  * Copyright (c) 2021 Rijksoverheid
- * Copyright (c) 2021 Robbert Broersma
  */
 
 import { Component, h } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/logo-image.tsx
+++ b/packages/web-component-library-stencil/src/components/logo-image.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2023 Gemeente Utrecht
- * Copyright (c) 2020-2023 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/logo.scss
+++ b/packages/web-component-library-stencil/src/components/logo.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/logo-css/src/mixin";

--- a/packages/web-component-library-stencil/src/components/logo.tsx
+++ b/packages/web-component-library-stencil/src/components/logo.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2023 Gemeente Utrecht
- * Copyright (c) 2020-2023 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/map-marker.scss
+++ b/packages/web-component-library-stencil/src/components/map-marker.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021-2022 Gemeente Utrecht
- * Copyright (c) 2021-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/map-marker-css/src/mixin";

--- a/packages/web-component-library-stencil/src/components/mark.scss
+++ b/packages/web-component-library-stencil/src/components/mark.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/mark-css/src";

--- a/packages/web-component-library-stencil/src/components/mark.tsx
+++ b/packages/web-component-library-stencil/src/components/mark.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/multiline-data.scss
+++ b/packages/web-component-library-stencil/src/components/multiline-data.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/multiline-data-css/src";

--- a/packages/web-component-library-stencil/src/components/multiline-data.tsx
+++ b/packages/web-component-library-stencil/src/components/multiline-data.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/number-badge.scss
+++ b/packages/web-component-library-stencil/src/components/number-badge.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/number-badge-css/src";

--- a/packages/web-component-library-stencil/src/components/number-badge.tsx
+++ b/packages/web-component-library-stencil/src/components/number-badge.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h, Prop } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/number-data.scss
+++ b/packages/web-component-library-stencil/src/components/number-data.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/number-data-css/src";

--- a/packages/web-component-library-stencil/src/components/number-data.tsx
+++ b/packages/web-component-library-stencil/src/components/number-data.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h, Prop } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/page-content.scss
+++ b/packages/web-component-library-stencil/src/components/page-content.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/page-content-css/src";

--- a/packages/web-component-library-stencil/src/components/page-content.tsx
+++ b/packages/web-component-library-stencil/src/components/page-content.tsx
@@ -2,7 +2,8 @@ import { Component, h } from '@stencil/core';
 
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @Component({

--- a/packages/web-component-library-stencil/src/components/page-footer.scss
+++ b/packages/web-component-library-stencil/src/components/page-footer.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/page-footer-css/src";

--- a/packages/web-component-library-stencil/src/components/page-footer.tsx
+++ b/packages/web-component-library-stencil/src/components/page-footer.tsx
@@ -2,7 +2,8 @@ import { Component, h } from '@stencil/core';
 
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @Component({

--- a/packages/web-component-library-stencil/src/components/page-header.scss
+++ b/packages/web-component-library-stencil/src/components/page-header.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/page-header-css/src";

--- a/packages/web-component-library-stencil/src/components/page-header.tsx
+++ b/packages/web-component-library-stencil/src/components/page-header.tsx
@@ -2,7 +2,8 @@ import { Component, h } from '@stencil/core';
 
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @Component({

--- a/packages/web-component-library-stencil/src/components/page.scss
+++ b/packages/web-component-library-stencil/src/components/page.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/page-css/src";

--- a/packages/web-component-library-stencil/src/components/page.tsx
+++ b/packages/web-component-library-stencil/src/components/page.tsx
@@ -2,7 +2,8 @@ import { Component, h } from '@stencil/core';
 
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Gemeente Utrecht
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @Component({

--- a/packages/web-component-library-stencil/src/components/pagination.scss
+++ b/packages/web-component-library-stencil/src/components/pagination.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/pagination-css/src";

--- a/packages/web-component-library-stencil/src/components/pagination.tsx
+++ b/packages/web-component-library-stencil/src/components/pagination.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h, Prop } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/paragraph.scss
+++ b/packages/web-component-library-stencil/src/components/paragraph.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/paragraph-css/src/index";

--- a/packages/web-component-library-stencil/src/components/pre-heading.scss
+++ b/packages/web-component-library-stencil/src/components/pre-heading.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/pre-heading-css/src/mixin";

--- a/packages/web-component-library-stencil/src/components/pre-heading.tsx
+++ b/packages/web-component-library-stencil/src/components/pre-heading.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/progress-list-item.tsx
+++ b/packages/web-component-library-stencil/src/components/progress-list-item.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h, Prop, State } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/progress-list.scss
+++ b/packages/web-component-library-stencil/src/components/progress-list.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@gemeente-denhaag/process-steps/dist/index.css";

--- a/packages/web-component-library-stencil/src/components/progress-list.tsx
+++ b/packages/web-component-library-stencil/src/components/progress-list.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/progress-sublist-item.tsx
+++ b/packages/web-component-library-stencil/src/components/progress-sublist-item.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h, Prop } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/separator.scss
+++ b/packages/web-component-library-stencil/src/components/separator.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/separator-css/src";

--- a/packages/web-component-library-stencil/src/components/sidenav.scss
+++ b/packages/web-component-library-stencil/src/components/sidenav.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/components/navigatie sidenav/src";

--- a/packages/web-component-library-stencil/src/components/sidenav.tsx
+++ b/packages/web-component-library-stencil/src/components/sidenav.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h, Prop } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/skip-link.scss
+++ b/packages/web-component-library-stencil/src/components/skip-link.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/skip-link-css/src";

--- a/packages/web-component-library-stencil/src/components/skip-link.tsx
+++ b/packages/web-component-library-stencil/src/components/skip-link.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h, Prop } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/spotlight-section.scss
+++ b/packages/web-component-library-stencil/src/components/spotlight-section.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/spotlight-section-css/src";

--- a/packages/web-component-library-stencil/src/components/spotlight-section.tsx
+++ b/packages/web-component-library-stencil/src/components/spotlight-section.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h, Prop } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/surface.scss
+++ b/packages/web-component-library-stencil/src/components/surface.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/surface-css/src";

--- a/packages/web-component-library-stencil/src/components/surface.tsx
+++ b/packages/web-component-library-stencil/src/components/surface.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/table-body.scss
+++ b/packages/web-component-library-stencil/src/components/table-body.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/table-css/src/mixin";

--- a/packages/web-component-library-stencil/src/components/table-caption.scss
+++ b/packages/web-component-library-stencil/src/components/table-caption.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/table-css/src/mixin";

--- a/packages/web-component-library-stencil/src/components/table-cell.scss
+++ b/packages/web-component-library-stencil/src/components/table-cell.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/table-css/src/mixin";

--- a/packages/web-component-library-stencil/src/components/table-footer.scss
+++ b/packages/web-component-library-stencil/src/components/table-footer.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/table-css/src/mixin";

--- a/packages/web-component-library-stencil/src/components/table-header-cell.scss
+++ b/packages/web-component-library-stencil/src/components/table-header-cell.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/table-css/src/mixin";

--- a/packages/web-component-library-stencil/src/components/table-header.scss
+++ b/packages/web-component-library-stencil/src/components/table-header.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/table-css/src/mixin";

--- a/packages/web-component-library-stencil/src/components/table-row.scss
+++ b/packages/web-component-library-stencil/src/components/table-row.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/table-css/src/mixin";

--- a/packages/web-component-library-stencil/src/components/table.scss
+++ b/packages/web-component-library-stencil/src/components/table.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/table-css/src/mixin";

--- a/packages/web-component-library-stencil/src/components/textarea.scss
+++ b/packages/web-component-library-stencil/src/components/textarea.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/textarea-css/src";

--- a/packages/web-component-library-stencil/src/components/textarea.tsx
+++ b/packages/web-component-library-stencil/src/components/textarea.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, Event, EventEmitter, h, Prop } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/textbox.scss
+++ b/packages/web-component-library-stencil/src/components/textbox.scss
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/textbox-css/src";

--- a/packages/web-component-library-stencil/src/components/textbox.tsx
+++ b/packages/web-component-library-stencil/src/components/textbox.tsx
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, Event, EventEmitter, h, Prop } from '@stencil/core';

--- a/packages/web-component-library-stencil/src/components/url-data.scss
+++ b/packages/web-component-library-stencil/src/components/url-data.scss
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 @import "~@utrecht/url-data-css/src";

--- a/packages/web-component-library-stencil/src/components/url-data.tsx
+++ b/packages/web-component-library-stencil/src/components/url-data.tsx
@@ -1,7 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2020-2022 Gemeente Utrecht
- * Copyright (c) 2020-2022 Frameless B.V.
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 import { Component, h } from '@stencil/core';

--- a/proprietary/design-tokens/src/css-property-formatter.mjs
+++ b/proprietary/design-tokens/src/css-property-formatter.mjs
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 const stringSort = (a, b) => (a === b ? 0 : a > b ? 1 : -1);

--- a/proprietary/design-tokens/src/json-list-formatter.js
+++ b/proprietary/design-tokens/src/json-list-formatter.js
@@ -1,6 +1,7 @@
 /**
  * @license EUPL-1.2
- * Copyright (c) 2021 Robbert Broersma
+ * Copyright (c) 2020-2024 Frameless B.V.
+ * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
 const stringSort = (a, b) => (a === b ? 0 : a > b ? 1 : -1);


### PR DESCRIPTION
Copyright from "Robbert Broersma" and "The Knights Who Say NIH B.V." has been transferred to "Frameless B.V.".

De nieuwe copyright notice:

```js
/**
 * @license EUPL-1.2
 * Copyright (c) 2020-2024 Frameless B.V.
 * Copyright (c) 2021-2024 Gemeente Utrecht
 */
```