### PR TITLE
feat: add tokens for NL Design System Candidate Link

### DIFF
--- a/.changeset/fuzzy-points-report.md
+++ b/.changeset/fuzzy-points-report.md
@@ -1,0 +1,5 @@
+---
+"@utrecht/design-tokens": minor
+---
+
+Add design tokens for NL Design System Candidate Link component

--- a/proprietary/design-tokens/src/component/nl/link.tokens.json
+++ b/proprietary/design-tokens/src/component/nl/link.tokens.json
@@ -1,0 +1,50 @@
+{
+  "nl": {
+    "link": {
+      "active": {
+        "color": {
+          "value": "{utrecht.link.active.color}"
+        }
+      },
+      "color": {
+        "value": "{utrecht.link.color}"
+      },
+      "current": {
+        "cursor": {},
+        "font-weight": {
+          "value": "{utrecht.link.current.font-weight}"
+        }
+      },
+      "hover": {
+        "color": {
+          "value": "{utrecht.link.hover.color}"
+        },
+        "text-decoration-line": {
+          "value": "{utrecht.link.hover.text-decoration}"
+        },
+        "text-decoration-thickness": {
+          "value": "{utrecht.link.hover.text-decoration-thickness}"
+        }
+      },
+      "placeholder": {
+        "color": {
+          "value": "{utrecht.link.hover.color}"
+        },
+        "cursor": {},
+        "font-weight": {}
+      },
+      "text-decoration-line": {
+        "value": "{utrecht.link.text-decoration}"
+      },
+      "text-decoration-color": {
+        "value": "{utrecht.link.text-decoration-color}"
+      },
+      "text-decoration-thickness": {
+        "value": "{utrecht.link.text-decoration-thickness}"
+      },
+      "text-underline-offset": {
+        "value": "{utrecht.link.text-underline-offset}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Map existing utrecht tokens for the utrecht-link to the new nl-clink Candidate component.

Note: This works after https://github.com/nl-design-system/candidate/pull/389 is merged