### PR TITLE
fix: remove background image from custom checkbox focus styles

### DIFF
--- a/.changeset/clean-sloths-lick.md
+++ b/.changeset/clean-sloths-lick.md
@@ -1,0 +1,5 @@
+---
+"@utrecht/custom-checkbox-css": minor
+---
+
+Remove SVG checkmark background image from checkbox :focus and :active states.

--- a/.changeset/clean-sloths-lick.md
+++ b/.changeset/clean-sloths-lick.md
@@ -1,5 +1,5 @@
 ---
-"@utrecht/custom-checkbox-css": minor
+"@utrecht/custom-checkbox-css": patch
 ---
 
 Remove SVG checkmark background image from checkbox :focus and :active states.

--- a/components/custom-checkbox/src/_mixin.scss
+++ b/components/custom-checkbox/src/_mixin.scss
@@ -84,7 +84,6 @@
   @include utrecht-focus;
 
   background-color: var(--utrecht-checkbox-focus-background-color, var(--utrecht-checkbox-background-color));
-  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3e%3cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='m6 10 3 3 6-6'/%3e%3c/svg%3e");
   border-color: var(--utrecht-checkbox-focus-border-color, var(--utrecht-checkbox-border-color));
   border-width: var(--utrecht-checkbox-focus-border-width, var(--utrecht-checkbox-border-width));
 }

--- a/components/custom-checkbox/src/_mixin.scss
+++ b/components/custom-checkbox/src/_mixin.scss
@@ -68,7 +68,6 @@
 
 @mixin utrecht-custom-checkbox--active {
   background-color: var(--utrecht-checkbox-active-background-color, var(--utrecht-checkbox-background-color));
-  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3e%3cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='m6 10 3 3 6-6'/%3e%3c/svg%3e");
   border-color: var(--utrecht-checkbox-active-border-color, var(--utrecht-checkbox-border-color));
   border-width: var(--utrecht-checkbox-active-border-width, var(--utrecht-checkbox-border-width));
   color: var(--utrecht-checkbox-active-color, var(--utrecht-checkbox-color));


### PR DESCRIPTION
Het  voorkomt dat de checked image al inlaad zodat als je erop focused en de background color veranderd naar een donkere kleur dat de checkmark verschijnt zoals in purmerend 
![image](https://github.com/user-attachments/assets/9b11e247-692e-4d76-9f0e-755ab27d8075)
