### PR TITLE
ci: add `pnpm run build-vercel`

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,14 @@ The scripts above use `nx` to automatically run all scripts that are a prerequis
 | `pnpm run publish`  | Publish each package to the npm registry                                  |
 | `pnpm run release`  | Determine new version number automatically and update each `package.json` |
 
+## Other scripts
+
+### `pnpm run build-vercel`
+
+Run the build processes, but excluding the following builds that do not currently work on Vercel:
+
+- The build for `storybook-angular` crashes randomly.
+
 ## Code of Conduct
 
 We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community. Read [our Code of Conduct](CODE_OF_CONDUCT.md) if you haven't already.

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "add-repository-directory": "node ./add-repository-directory.mjs",
     "build": "pnpm run --aggregate-output --recursive build",
     "build:css": "pnpm run --dir components/ --filter '@utrecht/*-css' build",
+    "build-vercel": "pnpm run --recursive build-vercel && pnpm run --filter=\"!{packages/storybook-angular}\" --filter=\"!{packages/component-library-angular}\" --recursive build",
     "clean": "pnpm run --recursive clean",
     "docs": "pnpm run --workspace packages/docusaurus start",
     "find-undocumented-tokens": "pnpm run --dir proprietary/design-tokens/ build:stylelint && pnpm run lint:css --config ./.tokens.stylelintrc.json",

--- a/packages/storybook-angular/package.json
+++ b/packages/storybook-angular/package.json
@@ -78,6 +78,7 @@
   "scripts": {
     "clean": "rimraf .angular/ dist/ tmp/",
     "build": "ng run storybook-angular:build-storybook",
+    "build-vercel": "mkdir -p dist/",
     "lint-build": "tsc --noEmit --project tsconfig.json",
     "storybook": "ng run storybook-angular:storybook --port 6009"
   }


### PR DESCRIPTION
Same as #2637, but without the lodash-es refactoring which gives (to me) unexplainable import errors in CI but not locally.