### PR TITLE
fix: data-badge-react does not have exports field

### DIFF
--- a/.changeset/eighty-days-kiss.md
+++ b/.changeset/eighty-days-kiss.md
@@ -1,0 +1,5 @@
+---
+"@utrecht/build-utils-react": minor
+---
+
+Include `.md` and `.jest-test-results.json` in `package.json` `exports`.

--- a/.changeset/seven-toys-jam.md
+++ b/.changeset/seven-toys-jam.md
@@ -1,0 +1,31 @@
+---
+"@utrecht/form-field-error-message-react": patch
+"@utrecht/form-field-description-react": patch
+"@utrecht/form-field-checkbox-react": patch
+"@utrecht/select-combobox-react": patch
+"@utrecht/checkbox-group-react": patch
+"@utrecht/radio-button-react": patch
+"@utrecht/page-footer-react": patch
+"@utrecht/page-header-react": patch
+"@utrecht/page-layout-react": patch
+"@utrecht/radio-group-react": patch
+"@utrecht/data-badge-react": patch
+"@utrecht/form-field-react": patch
+"@utrecht/form-label-react": patch
+"@utrecht/page-body-react": patch
+"@utrecht/calendar-react": patch
+"@utrecht/checkbox-react": patch
+"@utrecht/combobox-react": patch
+"@utrecht/fieldset-react": patch
+"@utrecht/listbox-react": patch
+"@utrecht/nav-bar-react": patch
+"@utrecht/textbox-react": patch
+"@utrecht/button-react": patch
+"@utrecht/body-react": patch
+"@utrecht/link-react": patch
+"@utrecht/root-react": patch
+"@utrecht/component-library-react": patch
+---
+
+Fix `exports` to include `.md` files and consistently support the main import.
+Note: the `.md` files are for development purposes only, they are not supported as part of the public API.

--- a/packages/component-library-react/package.json
+++ b/packages/component-library-react/package.json
@@ -23,12 +23,33 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"
     },
+    "./VegaVisualization": {
+      "types": "./dist/VegaVisualization.d.ts",
+      "import": "./dist/VegaVisualization.mjs"
+    },
+    "./Calendar": {
+      "types": "./dist/Calendar.d.ts",
+      "import": "./dist/Calendar.mjs"
+    },
+    "./css-module": {
+      "types": "./dist/css-module/index.d.ts",
+      "import": "./dist/css-module/index.mjs"
+    },
+    "./css-module/VegaVisualization": {
+      "types": "./dist/css-module/VegaVisualization.d.ts",
+      "import": "./dist/css-module/VegaVisualization.mjs"
+    },
+    "./css-module/Calendar": {
+      "types": "./dist/css-module/Calendar.d.ts",
+      "import": "./dist/css-module/Calendar.mjs"
+    },
     "./dist/.jest-test-results.json": "./dist/.jest-test-results.json",
+    "./tsconfig.md": "./tsconfig.md",
+    "./TESTING.md": "./TESTING.md",
+    "./README.nl.md": "./README.nl.md",
+    "./README.md": "./README.md",
     "./CONTRIBUTING.md": "./CONTRIBUTING.md",
     "./CHANGELOG.md": "./CHANGELOG.md",
-    "./README.md": "./README.md",
-    "./README.nl.md": "./README.nl.md",
-    "./TESTING.md": "./TESTING.md",
     "./dist": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"

--- a/packages/components-react/body-react/package.json
+++ b/packages/components-react/body-react/package.json
@@ -26,6 +26,7 @@
       "types": "./dist/css.d.ts",
       "import": "./dist/css.mjs"
     },
+    "./CHANGELOG.md": "./CHANGELOG.md",
     "./dist": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"

--- a/packages/components-react/button-react/package.json
+++ b/packages/components-react/button-react/package.json
@@ -26,8 +26,18 @@
       "types": "./dist/css.d.ts",
       "import": "./dist/css.mjs"
     },
-    "./dist": "./dist/index.mjs",
-    "./dist/index": "./dist/index.mjs",
+    "./dist": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs"
+    },
+    "./dist/index": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs"
+    },
+    "./dist/index.mjs": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs"
+    },
     "./dist/css": {
       "types": "./dist/css.d.ts",
       "import": "./dist/css.mjs"

--- a/packages/components-react/button-react/package.json
+++ b/packages/components-react/button-react/package.json
@@ -26,6 +26,7 @@
       "types": "./dist/css.d.ts",
       "import": "./dist/css.mjs"
     },
+    "./CHANGELOG.md": "./CHANGELOG.md",
     "./dist": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"

--- a/packages/components-react/calendar-react/package.json
+++ b/packages/components-react/calendar-react/package.json
@@ -26,6 +26,7 @@
       "types": "./dist/css.d.ts",
       "import": "./dist/css.mjs"
     },
+    "./CHANGELOG.md": "./CHANGELOG.md",
     "./dist": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"

--- a/packages/components-react/checkbox-group-react/package.json
+++ b/packages/components-react/checkbox-group-react/package.json
@@ -37,14 +37,6 @@
     "./dist/index.mjs": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"
-    },
-    "./dist/css": {
-      "types": "./dist/css.d.ts",
-      "import": "./dist/css.mjs"
-    },
-    "./dist/css.mjs": {
-      "types": "./dist/css.d.ts",
-      "import": "./dist/css.mjs"
     }
   },
   "files": [

--- a/packages/components-react/checkbox-group-react/package.json
+++ b/packages/components-react/checkbox-group-react/package.json
@@ -26,6 +26,7 @@
       "types": "./dist/css.d.ts",
       "import": "./dist/css.mjs"
     },
+    "./CHANGELOG.md": "./CHANGELOG.md",
     "./dist": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"
@@ -37,6 +38,14 @@
     "./dist/index.mjs": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"
+    },
+    "./dist/css": {
+      "types": "./dist/css.d.ts",
+      "import": "./dist/css.mjs"
+    },
+    "./dist/css.mjs": {
+      "types": "./dist/css.d.ts",
+      "import": "./dist/css.mjs"
     }
   },
   "files": [

--- a/packages/components-react/checkbox-react/package.json
+++ b/packages/components-react/checkbox-react/package.json
@@ -26,6 +26,7 @@
       "types": "./dist/css.d.ts",
       "import": "./dist/css.mjs"
     },
+    "./CHANGELOG.md": "./CHANGELOG.md",
     "./dist": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"

--- a/packages/components-react/combobox-react/package.json
+++ b/packages/components-react/combobox-react/package.json
@@ -26,6 +26,7 @@
       "types": "./dist/css.d.ts",
       "import": "./dist/css.mjs"
     },
+    "./CHANGELOG.md": "./CHANGELOG.md",
     "./dist": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"

--- a/packages/components-react/data-badge-react/package.json
+++ b/packages/components-react/data-badge-react/package.json
@@ -27,6 +27,7 @@
       "types": "./dist/css.d.ts",
       "import": "./dist/css.mjs"
     },
+    "./CHANGELOG.md": "./CHANGELOG.md",
     "./dist": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"

--- a/packages/components-react/data-badge-react/package.json
+++ b/packages/components-react/data-badge-react/package.json
@@ -1,23 +1,67 @@
 {
   "name": "@utrecht/data-badge-react",
   "version": "1.0.2",
-  "author": "Community for NL Design System",
   "description": "Data Badge component for the Municipality of Utrecht based on the NL Design System architecture",
+  "keywords": [
+    "nl-design-system"
+  ],
+  "homepage": "https://github.com/nl-design-system/utrecht/tree/main/packages/components-react/data-badge-react#readme",
+  "bugs": {
+    "url": "https://github.com/nl-design-system/utrecht/issues"
+  },
+  "repository": {
+    "type": "git+ssh",
+    "url": "git+https://github.com/nl-design-system/utrecht.git",
+    "directory": "packages/components-react/data-badge-react"
+  },
   "license": "EUPL-1.2",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "author": "Community for NL Design System",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs"
+    },
+    "./css": {
+      "types": "./dist/css.d.ts",
+      "import": "./dist/css.mjs"
+    },
+    "./dist": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs"
+    },
+    "./dist/index": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs"
+    },
+    "./dist/index.mjs": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs"
+    },
+    "./dist/css": {
+      "types": "./dist/css.d.ts",
+      "import": "./dist/css.mjs"
+    },
+    "./dist/css.mjs": {
+      "types": "./dist/css.d.ts",
+      "import": "./dist/css.mjs"
+    }
+  },
   "files": [
     "dist/",
     "src/"
   ],
-  "sideEffects": false,
   "scripts": {
     "build": "rollup --config ./rollup.config.mjs",
     "clean": "rimraf dist *.tsbuildinfo .rollup.cache coverage",
     "init": "init-react-package",
     "test": "mkdir -p pages && jest --coverage --verbose",
     "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@utrecht/data-badge-css": "workspace:*",
+    "clsx": "2.1.1"
   },
   "devDependencies": {
     "@testing-library/dom": "8.20.1",
@@ -34,24 +78,12 @@
     "rollup": "4.23.0",
     "typescript": "5.6.2"
   },
-  "keywords": [
-    "nl-design-system"
-  ],
-  "publishConfig": {
-    "access": "public"
-  },
-  "repository": {
-    "type": "git+ssh",
-    "url": "git@github.com:nl-design-system/utrecht.git",
-    "directory": "packages/components-react/data-badge-react"
-  },
   "peerDependencies": {
     "@babel/runtime": "*",
     "react": "18",
     "react-dom": "18"
   },
-  "dependencies": {
-    "@utrecht/data-badge-css": "workspace:*",
-    "clsx": "2.1.1"
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/components-react/fieldset-react/package.json
+++ b/packages/components-react/fieldset-react/package.json
@@ -26,6 +26,7 @@
       "types": "./dist/css.d.ts",
       "import": "./dist/css.mjs"
     },
+    "./CHANGELOG.md": "./CHANGELOG.md",
     "./dist": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"

--- a/packages/components-react/form-field-checkbox-react/package.json
+++ b/packages/components-react/form-field-checkbox-react/package.json
@@ -26,6 +26,7 @@
       "types": "./dist/css.d.ts",
       "import": "./dist/css.mjs"
     },
+    "./CHANGELOG.md": "./CHANGELOG.md",
     "./dist": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"

--- a/packages/components-react/form-field-description-react/package.json
+++ b/packages/components-react/form-field-description-react/package.json
@@ -26,6 +26,7 @@
       "types": "./dist/css.d.ts",
       "import": "./dist/css.mjs"
     },
+    "./CHANGELOG.md": "./CHANGELOG.md",
     "./dist": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"

--- a/packages/components-react/form-field-error-message-react/package.json
+++ b/packages/components-react/form-field-error-message-react/package.json
@@ -26,6 +26,7 @@
       "types": "./dist/css.d.ts",
       "import": "./dist/css.mjs"
     },
+    "./CHANGELOG.md": "./CHANGELOG.md",
     "./dist": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"

--- a/packages/components-react/form-field-react/package.json
+++ b/packages/components-react/form-field-react/package.json
@@ -26,6 +26,7 @@
       "types": "./dist/css.d.ts",
       "import": "./dist/css.mjs"
     },
+    "./CHANGELOG.md": "./CHANGELOG.md",
     "./dist": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"

--- a/packages/components-react/form-label-react/package.json
+++ b/packages/components-react/form-label-react/package.json
@@ -26,6 +26,7 @@
       "types": "./dist/css.d.ts",
       "import": "./dist/css.mjs"
     },
+    "./CHANGELOG.md": "./CHANGELOG.md",
     "./dist": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"

--- a/packages/components-react/link-react/package.json
+++ b/packages/components-react/link-react/package.json
@@ -26,6 +26,7 @@
       "types": "./dist/css.d.ts",
       "import": "./dist/css.mjs"
     },
+    "./CHANGELOG.md": "./CHANGELOG.md",
     "./dist": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"

--- a/packages/components-react/listbox-react/package.json
+++ b/packages/components-react/listbox-react/package.json
@@ -26,6 +26,7 @@
       "types": "./dist/css.d.ts",
       "import": "./dist/css.mjs"
     },
+    "./CHANGELOG.md": "./CHANGELOG.md",
     "./dist": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"

--- a/packages/components-react/nav-bar-react/package.json
+++ b/packages/components-react/nav-bar-react/package.json
@@ -26,6 +26,7 @@
       "types": "./dist/css.d.ts",
       "import": "./dist/css.mjs"
     },
+    "./CHANGELOG.md": "./CHANGELOG.md",
     "./dist": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"

--- a/packages/components-react/page-body-react/package.json
+++ b/packages/components-react/page-body-react/package.json
@@ -26,6 +26,7 @@
       "types": "./dist/css.d.ts",
       "import": "./dist/css.mjs"
     },
+    "./CHANGELOG.md": "./CHANGELOG.md",
     "./dist": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"

--- a/packages/components-react/page-footer-react/package.json
+++ b/packages/components-react/page-footer-react/package.json
@@ -26,6 +26,7 @@
       "types": "./dist/css.d.ts",
       "import": "./dist/css.mjs"
     },
+    "./CHANGELOG.md": "./CHANGELOG.md",
     "./dist": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"

--- a/packages/components-react/page-header-react/package.json
+++ b/packages/components-react/page-header-react/package.json
@@ -26,6 +26,7 @@
       "types": "./dist/css.d.ts",
       "import": "./dist/css.mjs"
     },
+    "./CHANGELOG.md": "./CHANGELOG.md",
     "./dist": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"

--- a/packages/components-react/page-layout-react/package.json
+++ b/packages/components-react/page-layout-react/package.json
@@ -26,6 +26,7 @@
       "types": "./dist/css.d.ts",
       "import": "./dist/css.mjs"
     },
+    "./CHANGELOG.md": "./CHANGELOG.md",
     "./dist": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"

--- a/packages/components-react/radio-button-react/package.json
+++ b/packages/components-react/radio-button-react/package.json
@@ -26,6 +26,7 @@
       "types": "./dist/css.d.ts",
       "import": "./dist/css.mjs"
     },
+    "./CHANGELOG.md": "./CHANGELOG.md",
     "./dist": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"

--- a/packages/components-react/radio-group-react/package.json
+++ b/packages/components-react/radio-group-react/package.json
@@ -26,6 +26,7 @@
       "types": "./dist/css.d.ts",
       "import": "./dist/css.mjs"
     },
+    "./CHANGELOG.md": "./CHANGELOG.md",
     "./dist": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"

--- a/packages/components-react/root-react/package.json
+++ b/packages/components-react/root-react/package.json
@@ -26,6 +26,7 @@
       "types": "./dist/css.d.ts",
       "import": "./dist/css.mjs"
     },
+    "./CHANGELOG.md": "./CHANGELOG.md",
     "./dist": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"

--- a/packages/components-react/select-combobox-react/package.json
+++ b/packages/components-react/select-combobox-react/package.json
@@ -45,8 +45,7 @@
     "./dist/css.mjs": {
       "types": "./dist/css.d.ts",
       "import": "./dist/css.mjs"
-    },
-    "./README.md": "./README.md"
+    }
   },
   "files": [
     "dist/",

--- a/packages/components-react/select-combobox-react/package.json
+++ b/packages/components-react/select-combobox-react/package.json
@@ -26,6 +26,8 @@
       "types": "./dist/css.d.ts",
       "import": "./dist/css.mjs"
     },
+    "./README.md": "./README.md",
+    "./CHANGELOG.md": "./CHANGELOG.md",
     "./dist": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"

--- a/packages/components-react/textbox-react/package.json
+++ b/packages/components-react/textbox-react/package.json
@@ -26,6 +26,7 @@
       "types": "./dist/css.d.ts",
       "import": "./dist/css.mjs"
     },
+    "./CHANGELOG.md": "./CHANGELOG.md",
     "./dist": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs"


### PR DESCRIPTION
While working on https://github.com/nl-design-system/rijkshuisstijl-community/issues/1094 I was running into vitest issues, because data-badge-react didn't have the exports field filled. 

I reran "pnpm run --recursive init", which added back the field and made some more changes. (I did not include whatever that command changed for packages/component-library-react, though.)

