### PR TITLE
feat(page-content): correct the CSS variables

### DIFF
--- a/.changeset/stale-llamas-drop.md
+++ b/.changeset/stale-llamas-drop.md
@@ -1,0 +1,5 @@
+---
+"@utrecht/page-content-css": patch
+---
+
+Fix the page-content CSS variables

--- a/components/page-content/src/_mixin.scss
+++ b/components/page-content/src/_mixin.scss
@@ -7,8 +7,8 @@
 @mixin utrecht-page-content {
   padding-block-end: var(--utrecht-page-content-padding-block-end);
   padding-block-start: var(--utrecht-page-content-padding-block-start);
-  padding-inline-end: var(--utrecht-page-padding-inline-end);
-  padding-inline-start: var(--utrecht-page-padding-inline-start);
+  padding-inline-end: var(--utrecht-page-content-padding-inline-end);
+  padding-inline-start: var(--utrecht-page-content-padding-inline-start);
 }
 
 @mixin utrecht-page-content__main {


### PR DESCRIPTION
- `--utrecht-page-padding-inline-start` => `--utrecht-page-content-padding-inline-start` 
- `--utrecht-page-padding-inline-end` => `--utrecht-page-content-padding-inline-end`