### PR TITLE
fix: token usage textarea read only variant

### DIFF
--- a/.changeset/twenty-lizards-fix.md
+++ b/.changeset/twenty-lizards-fix.md
@@ -1,0 +1,5 @@
+---
+"@utrecht/textarea-css": patch
+---
+
+Fix incorrect CSS variable name for Textbox (read-only variant)

--- a/components/textarea/src/_mixin.scss
+++ b/components/textarea/src/_mixin.scss
@@ -154,17 +154,17 @@ $utrecht-support-prince-xml: false !default;
 
 @mixin utrecht-textarea--read-only {
   background-color: var(
-    --utrecht-textarea-read-only-border,
+    --utrecht-textarea-read-only-background-color,
     var(
       --utrecht-form-control-read-only-background-color,
-      var(--utrecht-textarea-border, var(--utrecht-form-control-background-color))
+      var(--utrecht-textarea-background-color, var(--utrecht-form-control-background-color))
     )
   );
   border-color: var(
-    --utrecht-textarea-read-only-border,
+    --utrecht-textarea-read-only-border-color,
     var(
       --utrecht-form-control-read-only-border-color,
-      var(--utrecht-textarea-border, var(--utrecht-form-control-border-color))
+      var(--utrecht-textarea-border-color, var(--utrecht-form-control-border-color))
     )
   );
   color: var(


### PR DESCRIPTION
Currently incorrect tokens are applied, see screenshot:

![image](https://github.com/user-attachments/assets/f4c75686-9dce-45b3-8bf6-2a734792430f)

Fixed an issue where the first CSS variable for the `background-color` and `border-color` was not applied due to an incorrect variable name. As a result, the browser was falling back to the next defined variables. This has now been corrected by fixing the variable name, and the intended values for `background-color` and `border-color` are applied properly.