### PR TITLE
fix: make the empty state reactive in DataListValue.vue

### DIFF
--- a/.changeset/angry-carpets-arrive.md
+++ b/.changeset/angry-carpets-arrive.md
@@ -1,0 +1,5 @@
+---
+"@utrecht/component-library-vue": patch
+---
+
+Make the empty state reactive in DataListValue.vue

--- a/packages/component-library-vue/src/DataListValue.vue
+++ b/packages/component-library-vue/src/DataListValue.vue
@@ -9,10 +9,10 @@ export default defineComponent({
     multiline: { type: Boolean, required: false },
     notranslate: { type: Boolean, required: false },
   },
-  data() {
-    return {
-      empty: this.$props.value === '' || this.$props.value === undefined,
-    };
+  computed: {
+    empty() {
+      return this.value === '' || this.value === undefined;
+    },
   },
 });
 </script>


### PR DESCRIPTION
The DataListValue vue component checks if the value specified is empy, and if so shows a dash (-) to signify that there is no content. But because this check is only done on the initial render of the component, the empty state is not toggled whenever the value changes. By making the empty property computed, it is re-calculated whenever the value changes