### PR TITLE
fix: use alert text color token

### DIFF
--- a/components/alert/src/_mixin.scss
+++ b/components/alert/src/_mixin.scss
@@ -34,6 +34,9 @@
 
 /* stylelint-disable-next-line block-no-empty */
 @mixin utrecht-alert__message {
+  --utrecht-heading-color: var(--utrecht-alert-color);
+  --utrecht-paragraph-color: var(--utrecht-alert-color);
+
   row-gap: var(--utrecht-alert-message-row-gap);
 }
 

--- a/packages/component-library-react/src/Alert.tsx
+++ b/packages/component-library-react/src/Alert.tsx
@@ -47,10 +47,7 @@ export const Alert = forwardRef(
         className={clsx(
           'utrecht-alert',
           {
-            'utrecht-alert--error': computedType === 'error',
-            'utrecht-alert--info': computedType === 'info',
-            'utrecht-alert--ok': computedType === 'ok',
-            'utrecht-alert--warning': computedType === 'warning',
+            [`utrecht-alert--${type}`]: isAlertType(type),
           },
           className,
         )}

--- a/packages/component-library-react/src/Alert.tsx
+++ b/packages/component-library-react/src/Alert.tsx
@@ -41,17 +41,7 @@ export const Alert = forwardRef(
     const computedType = isAlertType(type) ? (type as AlertType) : 'info';
     const computedRole = role || typeToRole[computedType];
     return (
-      <div
-        {...restProps}
-        ref={ref}
-        className={clsx(
-          'utrecht-alert',
-          {
-            [`utrecht-alert--${type}`]: isAlertType(type),
-          },
-          className,
-        )}
-      >
+      <div {...restProps} ref={ref} className={clsx('utrecht-alert', `utrecht-alert--${computedType}`, className)}>
         {icon && <div className="utrecht-alert__icon">{icon}</div>}
         <div className="utrecht-alert__content">
           <div className="utrecht-alert__message" role={computedRole}>

--- a/packages/storybook-css/src/Alert.tsx
+++ b/packages/storybook-css/src/Alert.tsx
@@ -33,14 +33,7 @@ export const Alert = ({ children, icon, type, role }: PropsWithChildren<AlertPro
   const computedType = isAlertType(type) ? (type as AlertType) : 'info';
   const computedRole = role || typeToRole[computedType];
   return (
-    <div
-      className={clsx('utrecht-alert', {
-        'utrecht-alert--error': computedType === 'error',
-        'utrecht-alert--info': computedType === 'info',
-        'utrecht-alert--ok': computedType === 'ok',
-        'utrecht-alert--warning': computedType === 'warning',
-      })}
-    >
+    <div className={clsx('utrecht-alert', `utrecht-alert--${computedType}`)}>
       {icon && <div className="utrecht-alert__icon">{icon}</div>}
       <div className="utrecht-alert__content">
         <div className="utrecht-alert__message" role={computedRole}>

--- a/packages/web-component-library-stencil/src/components/alert.tsx
+++ b/packages/web-component-library-stencil/src/components/alert.tsx
@@ -38,14 +38,7 @@ export class Alert {
     const computedType = isAlertType(this.type) ? (this.type as AlertType) : 'info';
     const computedRole = typeToRole[computedType];
     return (
-      <div
-        class={clsx('utrecht-alert', {
-          'utrecht-alert--error': computedType === 'error',
-          'utrecht-alert--info': computedType === 'info',
-          'utrecht-alert--ok': computedType === 'ok',
-          'utrecht-alert--warning': computedType === 'warning',
-        })}
-      >
+      <div class={clsx('utrecht-alert', `utrecht-alert--${computedType}`)}>
         <div class="utrecht-alert__icon">
           <slot name="icon"></slot>
         </div>


### PR DESCRIPTION
Previously, headers and paragraphs inserted into `<Alert>` components would not receive the `--utrecht-alert-color` token for their color properties. According to Figma designs, they should, so this PR fixes that.

See also; https://github.com/nl-design-system/rijkshuisstijl-community/issues/1692