### PR TITLE
fix: change invalid selector to user-invalid in textbox

### DIFF
--- a/.changeset/strong-pumas-draw.md
+++ b/.changeset/strong-pumas-draw.md
@@ -2,4 +2,4 @@
 "@utrecht/textbox-css": major
 ---
 
-No longer applies utrecht-textbox--invalid based on HTML input validation
+Apply utrecht-textbox--invalid on user-invalid instead of invalid

--- a/.changeset/strong-pumas-draw.md
+++ b/.changeset/strong-pumas-draw.md
@@ -1,0 +1,5 @@
+---
+"@utrecht/textbox-css": major
+---
+
+No longer applies utrecht-textbox--invalid based on HTML input validation

--- a/components/textbox/src/_mixin.scss
+++ b/components/textbox/src/_mixin.scss
@@ -247,7 +247,6 @@ $utrecht-support-prince-xml: false !default;
     @include utrecht-textbox--focus-visible;
   }
 
-  &:invalid,
   &[aria-invalid="true"] {
     @include utrecht-textbox--invalid;
   }

--- a/components/textbox/src/_mixin.scss
+++ b/components/textbox/src/_mixin.scss
@@ -247,6 +247,7 @@ $utrecht-support-prince-xml: false !default;
     @include utrecht-textbox--focus-visible;
   }
 
+  &:user-invalid,
   &[aria-invalid="true"] {
     @include utrecht-textbox--invalid;
   }


### PR DESCRIPTION
Ik heb op de textbox de invalid selector veranderd naar user-invalid, zodat de invalid css pas toegepast word als de gebruiker interactie met de textbox heeft gehad.