### PR TITLE
docs: apply alphabetical sorting to storybooks with components

### DIFF
--- a/packages/storybook-angular/config/preview.ts
+++ b/packages/storybook-angular/config/preview.ts
@@ -32,6 +32,7 @@ const preview: Preview = {
     },
     options: {
       storySort: {
+        method: 'alphabetical',
         order: ['Angular Component', ['README', 'Changelog']],
       },
     },

--- a/packages/storybook-css/config/preview.tsx
+++ b/packages/storybook-css/config/preview.tsx
@@ -61,6 +61,7 @@ const preview: Preview = {
 
     options: {
       storySort: {
+        method: 'alphabetical',
         order: ['CSS Component', ['README', 'Changelog']],
       },
     },

--- a/packages/storybook-html/config/preview.tsx
+++ b/packages/storybook-html/config/preview.tsx
@@ -57,6 +57,7 @@ const preview: Preview = {
 
     options: {
       storySort: {
+        method: 'alphabetical',
         order: [
           'Utrecht',
           [

--- a/packages/storybook-react/config/preview.tsx
+++ b/packages/storybook-react/config/preview.tsx
@@ -46,6 +46,7 @@ const preview: Preview = {
     },
     options: {
       storySort: {
+        method: 'alphabetical',
         order: [
           'React Component',
           ['README', 'README (Nederlands)', 'Changelog', 'Developing components', 'Testing components'],

--- a/packages/storybook-vue/config/preview.tsx
+++ b/packages/storybook-vue/config/preview.tsx
@@ -47,6 +47,7 @@ const preview: Preview = {
     },
     options: {
       storySort: {
+        method: 'alphabetical',
         order: ['Vue.js Component', ['README', 'Changelog']],
       },
     },

--- a/packages/storybook-web-component/config/preview.tsx
+++ b/packages/storybook-web-component/config/preview.tsx
@@ -57,6 +57,7 @@ const preview: Preview = {
 
     options: {
       storySort: {
+        method: 'alphabetical',
         order: [
           'Web Component',
           [


### PR DESCRIPTION
Feedback vanuit de community in designer open hour, dat componenten al moeilijk te vinden zijn in Storybook met de filter functie. Daarom zoeken gebruikers handmatig op alfabetische volgorde naar componenten in de lijst.

Echter, in sommige gevallen waren componenten niet alfabetisch gesorteerd. Bijvoorbeeld Accordion welke onderaan de CSS Components Storybook stond. We moeten `storySort.sorting` expliciet op alfabetisch zetten, ter aanvulling op de custom `storySort.order`.