### PR TITLE
docs: rename overlooked button group story to action group

### DIFF
--- a/packages/storybook-angular/src/stories/ActionGroup.stories.ts
+++ b/packages/storybook-angular/src/stories/ActionGroup.stories.ts
@@ -3,7 +3,7 @@ import { Meta, moduleMetadata, Story } from '@storybook/angular';
 import { UtrechtActionGroup, UtrechtButtonAttr } from '@utrecht/component-library-angular';
 
 export default {
-  title: 'Angular Component/Button Group',
+  title: 'Angular Component/Action Group',
   id: 'angular-component-action-group',
   decorators: [
     moduleMetadata({


### PR DESCRIPTION
Gerelateerd aan de wijzigingen gemaakt in https://github.com/nl-design-system/utrecht/issues/2471. Een story was over het hoofd gezien.