### PR TITLE
fix: name of blockquote margin tokens

### DIFF
--- a/components/blockquote/src/tokens.json
+++ b/components/blockquote/src/tokens.json
@@ -81,7 +81,7 @@
         },
         "type": "spacing"
       },
-      "margin-inline-block-start": {
+      "margin-block-start": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<length>",
@@ -91,7 +91,7 @@
         },
         "type": "spacing"
       },
-      "margin-inline-block-end": {
+      "margin-block-end": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {
             "syntax": "<length>",


### PR DESCRIPTION
Het lijkt erop dat er een foutje is gemaakt bij de naamgeving van de block-margin tokens van Blockquote. De term 'inline' zit er ook in.