### PR TITLE
fix: astro base url

### DIFF
--- a/packages/astro/astro.config.ts
+++ b/packages/astro/astro.config.ts
@@ -1,11 +1,16 @@
 import react from '@astrojs/react';
 import sitemap from '@astrojs/sitemap';
 import { defineConfig } from 'astro/config';
+import path from 'node:path';
+import process from 'node:process';
 import { nldsComponentsPlugin } from './plugins/rehype-nlds-components/index.js';
+
+const deploymentBaseUrl = process.env.BASE_URL ?? '/';
+const baseUrl = path.posix.join(deploymentBaseUrl, 'astro');
 
 // https://astro.build/config
 export default defineConfig({
-  base: '/astro',
+  base: baseUrl,
   trailingSlash: 'always',
   build: {
     inlineStylesheets: 'never',


### PR DESCRIPTION
# Description

The main branch deployment adds `/utrecht/` to its base url. The astro config was unable to handle that before. This should fix it.

## How I tested it
1. Run `pnpm astro dev` to ensure it still works when running astro locally. Keeping in mind that resource URLs are all correct and loading (svgs, styles)
2. Run `BASE_URL=/utrecht/ pnpm astro dev` to test if all resource URLs are correct if there is a base URL like on the main branch deployment