### PR TITLE
chore: add @utrecht/design-tokens to storybook-pdf dev dependencies to prevent race condition

### DIFF
--- a/packages/storybook-pdf/package.json
+++ b/packages/storybook-pdf/package.json
@@ -43,6 +43,7 @@
     "@utrecht/code-css": "workspace:*",
     "@utrecht/component-library-pdf": "workspace:*",
     "@utrecht/data-list-css": "workspace:*",
+    "@utrecht/design-tokens": "workspace:*",
     "@utrecht/heading-1-css": "workspace:*",
     "@utrecht/heading-2-css": "workspace:*",
     "@utrecht/heading-3-css": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5385,7 +5385,7 @@ importers:
         version: 1.5.0
       css-loader:
         specifier: 6.8.1
-        version: 6.8.1(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.19.11))
+        version: 6.8.1(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       firacode:
         specifier: 6.2.0
         version: 6.2.0
@@ -5505,16 +5505,16 @@ importers:
         version: 9.1.4(react@18.3.1)(storybook@9.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@7.1.5(@types/node@24.3.1)(jiti@1.21.0)(less@4.2.0)(sass@1.69.5)(terser@5.44.0)(tsx@4.19.0)(yaml@2.8.1)))
       '@storybook/addon-webpack5-compiler-swc':
         specifier: 4.0.1
-        version: 4.0.1(@swc/helpers@0.5.17)(storybook@9.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@7.1.5(@types/node@24.3.1)(jiti@1.21.0)(less@4.2.0)(sass@1.69.5)(terser@5.44.0)(tsx@4.19.0)(yaml@2.8.1)))(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9))
+        version: 4.0.1(@swc/helpers@0.5.17)(storybook@9.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@7.1.5(@types/node@24.3.1)(jiti@1.21.0)(less@4.2.0)(sass@1.69.5)(terser@5.44.0)(tsx@4.19.0)(yaml@2.8.1)))(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       '@storybook/cli':
         specifier: 9.1.4
         version: 9.1.4(@babel/preset-env@7.24.7(@babel/core@7.24.7))(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@7.1.5(@types/node@24.3.1)(jiti@1.21.0)(less@4.2.0)(sass@1.69.5)(terser@5.44.0)(tsx@4.19.0)(yaml@2.8.1))
       '@storybook/preset-scss':
         specifier: 1.0.3
-        version: 1.0.3(css-loader@6.8.1(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)))(sass-loader@13.3.2(sass@1.69.5)(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)))(style-loader@3.3.3(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)))
+        version: 1.0.3(css-loader@6.8.1(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))))(sass-loader@13.3.2(sass@1.69.5)(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))))(style-loader@3.3.3(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))))
       '@storybook/react-webpack5':
         specifier: 9.1.4
-        version: 9.1.4(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@7.1.5(@types/node@24.3.1)(jiti@1.21.0)(less@4.2.0)(sass@1.69.5)(terser@5.44.0)(tsx@4.19.0)(yaml@2.8.1)))(typescript@4.9.5)
+        version: 9.1.4(@swc/core@1.13.5(@swc/helpers@0.5.17))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@7.1.5(@types/node@24.3.1)(jiti@1.21.0)(less@4.2.0)(sass@1.69.5)(terser@5.44.0)(tsx@4.19.0)(yaml@2.8.1)))(typescript@4.9.5)
       '@tabler/icons-react':
         specifier: 2.44.0
         version: 2.44.0(react@18.3.1)
@@ -5643,7 +5643,7 @@ importers:
         version: 8.0.2(storybook@9.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@7.1.5(@types/node@24.3.1)(jiti@1.21.0)(less@4.2.0)(sass@1.69.5)(terser@5.44.0)(tsx@4.19.0)(yaml@2.8.1)))
       babel-loader:
         specifier: 9.1.3
-        version: 9.1.3(@babel/core@7.24.7)(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9))
+        version: 9.1.3(@babel/core@7.24.7)(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       clsx:
         specifier: 2.1.1
         version: 2.1.1
@@ -5652,7 +5652,7 @@ importers:
         version: 1.5.0
       css-loader:
         specifier: 6.8.1
-        version: 6.8.1(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9))
+        version: 6.8.1(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       eslint-plugin-storybook:
         specifier: 9.1.4
         version: 9.1.4(eslint@8.57.0)(storybook@9.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@7.1.5(@types/node@24.3.1)(jiti@1.21.0)(less@4.2.0)(sass@1.69.5)(terser@5.44.0)(tsx@4.19.0)(yaml@2.8.1)))(typescript@4.9.5)
@@ -5694,7 +5694,7 @@ importers:
         version: 1.69.5
       sass-loader:
         specifier: 13.3.2
-        version: 13.3.2(sass@1.69.5)(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9))
+        version: 13.3.2(sass@1.69.5)(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       storybook:
         specifier: 9.1.4
         version: 9.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@7.1.5(@types/node@24.3.1)(jiti@1.21.0)(less@4.2.0)(sass@1.69.5)(terser@5.44.0)(tsx@4.19.0)(yaml@2.8.1))
@@ -5703,13 +5703,13 @@ importers:
         version: 9.1.4(storybook@9.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@7.1.5(@types/node@24.3.1)(jiti@1.21.0)(less@4.2.0)(sass@1.69.5)(terser@5.44.0)(tsx@4.19.0)(yaml@2.8.1)))
       style-loader:
         specifier: 3.3.3
-        version: 3.3.3(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9))
+        version: 3.3.3(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       typescript:
         specifier: 4.9.5
         version: 4.9.5
       webpack:
         specifier: 5.89.0
-        version: 5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)
+        version: 5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.19.11)
 
   packages/storybook-pdf:
     devDependencies:
@@ -5800,6 +5800,9 @@ importers:
       '@utrecht/data-list-css':
         specifier: workspace:*
         version: link:../../components/data-list
+      '@utrecht/design-tokens':
+        specifier: workspace:*
+        version: link:../../proprietary/design-tokens
       '@utrecht/heading-1-css':
         specifier: workspace:*
         version: link:../../components/heading-1
@@ -5865,7 +5868,7 @@ importers:
         version: 1.5.0
       css-loader:
         specifier: 6.8.1
-        version: 6.8.1(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.19.11))
+        version: 6.8.1(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       firacode:
         specifier: 6.2.0
         version: 6.2.0
@@ -6864,7 +6867,7 @@ importers:
         version: 1.5.0
       css-loader:
         specifier: 6.8.1
-        version: 6.8.1(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.19.11))
+        version: 6.8.1(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       eslint-plugin-storybook:
         specifier: 9.1.5
         version: 9.1.5(eslint@8.57.0)(storybook@9.1.5(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@7.1.5(@types/node@22.18.1)(jiti@1.21.0)(less@4.2.0)(sass@1.69.5)(terser@5.44.0)(tsx@4.19.0)(yaml@2.8.1)))(typescript@5.9.2)
@@ -26476,8 +26479,8 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
-  vue-component-type-helpers@3.0.7:
-    resolution: {integrity: sha512-TvyUcFXmjZcXUvU+r1MOyn4/vv4iF+tPwg5Ig33l/FJ3myZkxeQpzzQMLMFWcQAjr6Xs7BRwVy/TwbmNZUA/4w==}
+  vue-component-type-helpers@3.0.8:
+    resolution: {integrity: sha512-WyR30Eq15Y/+odrUUMax6FmPbZwAp/HnC7qgR1r3lVFAcqwQ4wUoV79Mbh4SxDy3NiqDa+G4TOKD5xXSgBHo5A==}
 
   vue-docgen-api@4.75.1:
     resolution: {integrity: sha512-MECZ3uExz+ssmhD/2XrFoQQs93y17IVO1KDYTp8nr6i9GNrk67AAto6QAtilW1H/pTDPMkQxJ7w/25ZIqVtfAA==}
@@ -27352,7 +27355,7 @@ snapshots:
       browserslist: 4.24.2
       copy-webpack-plugin: 11.0.0(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       critters: 0.0.20
-      css-loader: 6.8.1(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.19.11))
+      css-loader: 6.8.1(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       esbuild-wasm: 0.19.11
       fast-glob: 3.3.2
       http-proxy-middleware: 2.0.6(@types/express@4.17.21)
@@ -27444,7 +27447,7 @@ snapshots:
       browserslist: 4.24.2
       copy-webpack-plugin: 11.0.0(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       critters: 0.0.20
-      css-loader: 6.8.1(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.19.11))
+      css-loader: 6.8.1(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       esbuild-wasm: 0.19.11
       fast-glob: 3.3.2
       http-proxy-middleware: 2.0.6(@types/express@4.17.21)
@@ -31469,7 +31472,7 @@ snapshots:
       commander: 5.1.0
       copy-webpack-plugin: 11.0.0(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       core-js: 3.34.0
-      css-loader: 6.8.1(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.19.11))
+      css-loader: 6.8.1(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       css-minimizer-webpack-plugin: 4.2.2(clean-css@5.3.3)(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       cssnano: 5.1.15(postcss@8.4.38)
       del: 6.1.1
@@ -31480,7 +31483,7 @@ snapshots:
       fs-extra: 11.2.0
       html-minifier-terser: 7.2.0
       html-tags: 3.3.1
-      html-webpack-plugin: 5.5.4(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.19.11))
+      html-webpack-plugin: 5.5.4(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       leven: 3.1.0
       lodash: 4.17.21
       mini-css-extract-plugin: 2.7.6(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17)))
@@ -36286,11 +36289,11 @@ snapshots:
     dependencies:
       memoizerific: 1.11.3
 
-  '@storybook/addon-webpack5-compiler-swc@4.0.1(@swc/helpers@0.5.17)(storybook@9.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@7.1.5(@types/node@24.3.1)(jiti@1.21.0)(less@4.2.0)(sass@1.69.5)(terser@5.44.0)(tsx@4.19.0)(yaml@2.8.1)))(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9))':
+  '@storybook/addon-webpack5-compiler-swc@4.0.1(@swc/helpers@0.5.17)(storybook@9.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@7.1.5(@types/node@24.3.1)(jiti@1.21.0)(less@4.2.0)(sass@1.69.5)(terser@5.44.0)(tsx@4.19.0)(yaml@2.8.1)))(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17)))':
     dependencies:
       '@swc/core': 1.13.5(@swc/helpers@0.5.17)
       storybook: 9.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@7.1.5(@types/node@24.3.1)(jiti@1.21.0)(less@4.2.0)(sass@1.69.5)(terser@5.44.0)(tsx@4.19.0)(yaml@2.8.1))
-      swc-loader: 0.2.6(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9))
+      swc-loader: 0.2.6(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17)))
     transitivePeerDependencies:
       - '@swc/helpers'
       - webpack
@@ -36667,22 +36670,22 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/builder-webpack5@9.1.4(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)(storybook@9.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@7.1.5(@types/node@24.3.1)(jiti@1.21.0)(less@4.2.0)(sass@1.69.5)(terser@5.44.0)(tsx@4.19.0)(yaml@2.8.1)))(typescript@4.9.5)':
+  '@storybook/builder-webpack5@9.1.4(@swc/core@1.13.5(@swc/helpers@0.5.17))(storybook@9.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@7.1.5(@types/node@24.3.1)(jiti@1.21.0)(less@4.2.0)(sass@1.69.5)(terser@5.44.0)(tsx@4.19.0)(yaml@2.8.1)))(typescript@4.9.5)':
     dependencies:
       '@storybook/core-webpack': 9.1.4(storybook@9.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@7.1.5(@types/node@24.3.1)(jiti@1.21.0)(less@4.2.0)(sass@1.69.5)(terser@5.44.0)(tsx@4.19.0)(yaml@2.8.1)))
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.2.3
-      css-loader: 6.8.1(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9))
+      css-loader: 6.8.1(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       es-module-lexer: 1.7.0
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@4.9.5)(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9))
-      html-webpack-plugin: 5.5.4(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9))
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@4.9.5)(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17)))
+      html-webpack-plugin: 5.5.4(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       magic-string: 0.30.18
       storybook: 9.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@7.1.5(@types/node@24.3.1)(jiti@1.21.0)(less@4.2.0)(sass@1.69.5)(terser@5.44.0)(tsx@4.19.0)(yaml@2.8.1))
-      style-loader: 3.3.3(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9))
-      terser-webpack-plugin: 5.3.9(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9))
+      style-loader: 3.3.3(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17)))
+      terser-webpack-plugin: 5.3.9(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       ts-dedent: 2.2.0
-      webpack: 5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)
-      webpack-dev-middleware: 6.1.3(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9))
+      webpack: 5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))
+      webpack-dev-middleware: 6.1.3(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       webpack-hot-middleware: 2.25.4
       webpack-virtual-modules: 0.6.1
     optionalDependencies:
@@ -37366,10 +37369,10 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/preset-react-webpack@9.1.4(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@7.1.5(@types/node@24.3.1)(jiti@1.21.0)(less@4.2.0)(sass@1.69.5)(terser@5.44.0)(tsx@4.19.0)(yaml@2.8.1)))(typescript@4.9.5)':
+  '@storybook/preset-react-webpack@9.1.4(@swc/core@1.13.5(@swc/helpers@0.5.17))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@7.1.5(@types/node@24.3.1)(jiti@1.21.0)(less@4.2.0)(sass@1.69.5)(terser@5.44.0)(tsx@4.19.0)(yaml@2.8.1)))(typescript@4.9.5)':
     dependencies:
       '@storybook/core-webpack': 9.1.4(storybook@9.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@7.1.5(@types/node@24.3.1)(jiti@1.21.0)(less@4.2.0)(sass@1.69.5)(terser@5.44.0)(tsx@4.19.0)(yaml@2.8.1)))
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@4.9.5)(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@4.9.5)(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       '@types/semver': 7.5.6
       find-up: 7.0.0
       magic-string: 0.30.18
@@ -37380,7 +37383,7 @@ snapshots:
       semver: 7.6.2
       storybook: 9.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@7.1.5(@types/node@24.3.1)(jiti@1.21.0)(less@4.2.0)(sass@1.69.5)(terser@5.44.0)(tsx@4.19.0)(yaml@2.8.1))
       tsconfig-paths: 4.2.0
-      webpack: 5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)
+      webpack: 5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))
     optionalDependencies:
       typescript: 4.9.5
     transitivePeerDependencies:
@@ -37426,15 +37429,9 @@ snapshots:
       sass-loader: 13.3.2(sass@1.69.5)(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.18.20))
       style-loader: 3.3.3(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.18.20))
 
-  '@storybook/preset-scss@1.0.3(css-loader@6.8.1(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)))(sass-loader@13.3.2(sass@1.69.5)(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)))(style-loader@3.3.3(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)))':
-    dependencies:
-      css-loader: 6.8.1(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9))
-      sass-loader: 13.3.2(sass@1.69.5)(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9))
-      style-loader: 3.3.3(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9))
-
   '@storybook/preset-scss@1.0.3(css-loader@6.8.1(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))))(sass-loader@13.3.2(sass@1.69.5)(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))))(style-loader@3.3.3(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))))':
     dependencies:
-      css-loader: 6.8.1(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.19.11))
+      css-loader: 6.8.1(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       sass-loader: 13.3.2(sass@1.69.5)(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       style-loader: 3.3.3(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17)))
 
@@ -37476,20 +37473,6 @@ snapshots:
       tslib: 2.6.2
       typescript: 4.9.5
       webpack: 5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.18.20)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@4.9.5)(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9))':
-    dependencies:
-      debug: 4.4.1
-      endent: 2.1.0
-      find-cache-dir: 3.3.2
-      flat-cache: 3.2.0
-      micromatch: 4.0.7
-      react-docgen-typescript: 2.2.2(typescript@4.9.5)
-      tslib: 2.6.2
-      typescript: 4.9.5
-      webpack: 5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)
     transitivePeerDependencies:
       - supports-color
 
@@ -37628,10 +37611,10 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/react-webpack5@9.1.4(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@7.1.5(@types/node@24.3.1)(jiti@1.21.0)(less@4.2.0)(sass@1.69.5)(terser@5.44.0)(tsx@4.19.0)(yaml@2.8.1)))(typescript@4.9.5)':
+  '@storybook/react-webpack5@9.1.4(@swc/core@1.13.5(@swc/helpers@0.5.17))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@7.1.5(@types/node@24.3.1)(jiti@1.21.0)(less@4.2.0)(sass@1.69.5)(terser@5.44.0)(tsx@4.19.0)(yaml@2.8.1)))(typescript@4.9.5)':
     dependencies:
-      '@storybook/builder-webpack5': 9.1.4(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)(storybook@9.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@7.1.5(@types/node@24.3.1)(jiti@1.21.0)(less@4.2.0)(sass@1.69.5)(terser@5.44.0)(tsx@4.19.0)(yaml@2.8.1)))(typescript@4.9.5)
-      '@storybook/preset-react-webpack': 9.1.4(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@7.1.5(@types/node@24.3.1)(jiti@1.21.0)(less@4.2.0)(sass@1.69.5)(terser@5.44.0)(tsx@4.19.0)(yaml@2.8.1)))(typescript@4.9.5)
+      '@storybook/builder-webpack5': 9.1.4(@swc/core@1.13.5(@swc/helpers@0.5.17))(storybook@9.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@7.1.5(@types/node@24.3.1)(jiti@1.21.0)(less@4.2.0)(sass@1.69.5)(terser@5.44.0)(tsx@4.19.0)(yaml@2.8.1)))(typescript@4.9.5)
+      '@storybook/preset-react-webpack': 9.1.4(@swc/core@1.13.5(@swc/helpers@0.5.17))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@7.1.5(@types/node@24.3.1)(jiti@1.21.0)(less@4.2.0)(sass@1.69.5)(terser@5.44.0)(tsx@4.19.0)(yaml@2.8.1)))(typescript@4.9.5)
       '@storybook/react': 9.1.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(vite@7.1.5(@types/node@24.3.1)(jiti@1.21.0)(less@4.2.0)(sass@1.69.5)(terser@5.44.0)(tsx@4.19.0)(yaml@2.8.1)))(typescript@4.9.5)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -37869,7 +37852,7 @@ snapshots:
       storybook: 9.1.4(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.4(@types/node@22.7.4)(jiti@1.21.0)(less@4.2.0)(sass@1.92.0)(terser@5.44.0)(tsx@4.19.0)(yaml@2.8.1))
       type-fest: 2.19.0
       vue: 3.5.21(typescript@4.9.5)
-      vue-component-type-helpers: 3.0.7
+      vue-component-type-helpers: 3.0.8
 
   '@svgr/babel-plugin-add-jsx-attribute@6.5.1(@babel/core@7.24.7)':
     dependencies:
@@ -41030,13 +41013,6 @@ snapshots:
       schema-utils: 4.2.0
       webpack: 5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.18.20)
 
-  babel-loader@9.1.3(@babel/core@7.24.7)(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)):
-    dependencies:
-      '@babel/core': 7.24.7
-      find-cache-dir: 4.0.0
-      schema-utils: 4.2.0
-      webpack: 5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)
-
   babel-loader@9.1.3(@babel/core@7.24.7)(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))):
     dependencies:
       '@babel/core': 7.24.7
@@ -42697,7 +42673,7 @@ snapshots:
       semver: 7.6.2
       webpack: 5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.18.20)
 
-  css-loader@6.8.1(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.19.11)):
+  css-loader@6.8.1(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.38)
       postcss: 8.4.38
@@ -42708,18 +42684,6 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.2
       webpack: 5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.19.11)
-
-  css-loader@6.8.1(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)):
-    dependencies:
-      icss-utils: 5.1.0(postcss@8.4.38)
-      postcss: 8.4.38
-      postcss-modules-extract-imports: 3.0.0(postcss@8.4.38)
-      postcss-modules-local-by-default: 4.0.3(postcss@8.4.38)
-      postcss-modules-scope: 3.0.0(postcss@8.4.38)
-      postcss-modules-values: 4.0.0(postcss@8.4.38)
-      postcss-value-parser: 4.2.0
-      semver: 7.6.2
-      webpack: 5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)
 
   css-minimizer-webpack-plugin@2.0.0(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))):
     dependencies:
@@ -45094,23 +45058,6 @@ snapshots:
       typescript: 4.9.5
       webpack: 5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.18.20)
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@4.9.5)(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)):
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      chalk: 4.1.2
-      chokidar: 3.5.3
-      cosmiconfig: 7.1.0
-      deepmerge: 4.3.1
-      fs-extra: 10.1.0
-      memfs: 3.5.3
-      minimatch: 3.1.2
-      node-abort-controller: 3.1.1
-      schema-utils: 3.3.0
-      semver: 7.7.2
-      tapable: 2.2.1
-      typescript: 4.9.5
-      webpack: 5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)
-
   fork-ts-checker-webpack-plugin@8.0.0(typescript@4.9.5)(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))):
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -46475,7 +46422,7 @@ snapshots:
       webpack: 5.76.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.17.8)
     optional: true
 
-  html-webpack-plugin@5.5.4(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.19.11)):
+  html-webpack-plugin@5.5.4(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -53793,13 +53740,6 @@ snapshots:
     optionalDependencies:
       sass: 1.69.5
 
-  sass-loader@13.3.2(sass@1.69.5)(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)):
-    dependencies:
-      neo-async: 2.6.2
-      webpack: 5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)
-    optionalDependencies:
-      sass: 1.69.5
-
   sass-loader@13.3.2(sass@1.69.5)(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))):
     dependencies:
       neo-async: 2.6.2
@@ -55010,10 +54950,6 @@ snapshots:
     dependencies:
       webpack: 5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.18.20)
 
-  style-loader@3.3.3(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)):
-    dependencies:
-      webpack: 5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)
-
   style-loader@3.3.3(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))):
     dependencies:
       webpack: 5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.19.11)
@@ -55232,11 +55168,11 @@ snapshots:
       '@swc/core': 1.13.5(@swc/helpers@0.5.17)
       webpack: 5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))
 
-  swc-loader@0.2.6(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)):
+  swc-loader@0.2.6(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))):
     dependencies:
       '@swc/core': 1.13.5(@swc/helpers@0.5.17)
       '@swc/counter': 0.1.3
-      webpack: 5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)
+      webpack: 5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.19.11)
 
   symbol-observable@4.0.0: {}
 
@@ -55432,30 +55368,6 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.13.5(@swc/helpers@0.5.17)
       esbuild: 0.19.11
-
-  terser-webpack-plugin@5.3.9(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.30
-      jest-worker: 27.5.1
-      schema-utils: 3.3.0
-      serialize-javascript: 6.0.1
-      terser: 5.26.0
-      webpack: 5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)
-    optionalDependencies:
-      '@swc/core': 1.13.5(@swc/helpers@0.5.17)
-      esbuild: 0.25.9
-
-  terser-webpack-plugin@5.3.9(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.30
-      jest-worker: 27.5.1
-      schema-utils: 3.3.0
-      serialize-javascript: 6.0.1
-      terser: 5.26.0
-      webpack: 5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)
-    optionalDependencies:
-      '@swc/core': 1.13.5(@swc/helpers@0.5.17)
-      esbuild: 0.25.9
 
   terser-webpack-plugin@5.3.9(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack@5.101.3(@swc/core@1.13.5(@swc/helpers@0.5.17))):
     dependencies:
@@ -57234,7 +57146,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-component-type-helpers@3.0.7: {}
+  vue-component-type-helpers@3.0.8: {}
 
   vue-docgen-api@4.75.1(vue@3.5.21(typescript@4.9.5)):
     dependencies:
@@ -57623,7 +57535,7 @@ snapshots:
       typed-assert: 1.0.9
       webpack: 5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.19.11)
     optionalDependencies:
-      html-webpack-plugin: 5.5.4(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.19.11))
+      html-webpack-plugin: 5.5.4(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17)))
 
   webpack-virtual-modules@0.5.0: {}
 
@@ -57811,37 +57723,6 @@ snapshots:
       schema-utils: 3.3.0
       tapable: 2.2.1
       terser-webpack-plugin: 5.3.9(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.19.11)(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.19.11))
-      watchpack: 2.4.0
-      webpack-sources: 3.2.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-
-  webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9):
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.8
-      '@webassemblyjs/ast': 1.11.6
-      '@webassemblyjs/wasm-edit': 1.11.6
-      '@webassemblyjs/wasm-parser': 1.11.6
-      acorn: 8.11.2
-      acorn-import-assertions: 1.9.0(acorn@8.11.2)
-      browserslist: 4.24.2
-      chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.15.0
-      es-module-lexer: 1.7.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.0
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 3.3.0
-      tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9)(webpack@5.89.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.9))
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
There is a race condition introduced by storybook-pdf importing @utrecht/design-tokens before it finishes building sometimes. Adding it to the devDependencies should make sure it builds after.