### PR TITLE
fix: social icon component gebruikt en instructie

### DIFF
--- a/packages/storybook-react/src/stories/prototype-src/contactformulier/ScenarioContactFormulier.tsx
+++ b/packages/storybook-react/src/stories/prototype-src/contactformulier/ScenarioContactFormulier.tsx
@@ -20,21 +20,10 @@ const ScenarioContact: React.FC = () => {
         aangegeven omleiding klopt niet met je navigatie, en door al het bouwverkeer is er veel geluidshinder - vooral
         &apos;s morgens vroeg en &apos;s avonds laat.
       </Paragraph>
-      <Paragraph>
-        Je wilt graag meer duidelijkheid over:
-        <UnorderedList>
-          <UnorderedListItem>Hoe lang de overlast nog gaat duren</UnorderedListItem>
-          <UnorderedListItem>Of er iets gedaan kan worden aan de geluidshinder in de avonduren</UnorderedListItem>
-        </UnorderedList>
-      </Paragraph>
-      <Paragraph>
-        Je vindt op de website van de gemeente niet direct een antwoord op je vragen. Dus heb je besloten om de gemeente
-        een vraag te stellen, omdat je een antwoord wilt op je vragen.
-      </Paragraph>
       <Heading2>Instructie</Heading2>
       <Paragraph>
-        Ga nu naar de informatie-pagina over de werkzaamheden op de Amsterdamsestraatweg en gebruik het contactformulier
-        om je vragen in te dienen. Doe dit zoals je dat in het echte leven zou doen.
+        Klik op de knop Start. Bekijk de informatie-pagina over de werkzaamheden op de Amsterdamsestraatweg. Daarna
+        vertellen we je de volgende stap.
       </Paragraph>
     </>
   );

--- a/packages/storybook-react/src/stories/prototype-src/webpaginablokken/HulpEnContact.tsx
+++ b/packages/storybook-react/src/stories/prototype-src/webpaginablokken/HulpEnContact.tsx
@@ -4,6 +4,7 @@ import {
   FormFieldTextbox,
   Heading2,
   Heading3,
+  LinkSocial,
   Separator,
 } from '@utrecht/component-library-react/dist/css-module';
 import {
@@ -116,17 +117,29 @@ const HulpEnContact: React.FC<HulpEnContactProps> = ({ onSubmit }) => {
 
         <div className="utrecht-help-contact-right">
           <Heading3 style={{ fontWeight: 'normal' }}>Volg ons</Heading3>
-          <div className="utrecht-social-media-icons">
-            <a href="#" className="utrecht-social-media-icon" aria-label="Facebook">
-              <UtrechtIconFacebook />
-            </a>
-            <a href="#" className="utrecht-social-media-icon" aria-label="X">
-              <UtrechtIconX />
-            </a>
-            <a href="#" className="utrecht-social-media-icon" aria-label="YouTube">
-              <UtrechtIconYoutube />
-            </a>
-          </div>
+          <LinkSocial
+            external
+            href="https://www.facebook.com/GemeenteUtrecht"
+            title="facebook"
+            style={{ marginRight: '0.5em' }}
+          >
+            <UtrechtIconFacebook />
+          </LinkSocial>
+          <LinkSocial
+            external
+            href="https://x.com/Straatweg"
+            title="Amsterdamsestraatweg op Twitter"
+            style={{ marginRight: '0.5em' }}
+          >
+            <UtrechtIconX />
+          </LinkSocial>
+          <LinkSocial
+            external
+            href="https://www.youtube.com/channel/UCel6O4Zyizeg9rAW94QNAhQ/videos"
+            title="Amsterdamsestraatweg op Youtube"
+          >
+            <UtrechtIconYoutube />
+          </LinkSocial>
         </div>
       </div>
 

--- a/packages/storybook-react/src/stories/prototype-src/webpaginablokken/HulpEnContact2.tsx
+++ b/packages/storybook-react/src/stories/prototype-src/webpaginablokken/HulpEnContact2.tsx
@@ -3,6 +3,7 @@ import {
   Heading2,
   Heading3,
   Heading4,
+  LinkSocial,
   Paragraph,
   Separator,
   SpotlightSection,
@@ -36,17 +37,29 @@ const HulpEnContact2: React.FC = () => {
 
         <div className="utrecht-help-contact-right">
           <Heading3 style={{ fontWeight: 'normal' }}>Volg ons</Heading3>
-          <div className="utrecht-social-media-icons">
-            <a href="#" className="utrecht-social-media-icon" aria-label="Facebook">
-              <UtrechtIconFacebook />
-            </a>
-            <a href="#" className="utrecht-social-media-icon" aria-label="X">
-              <UtrechtIconX />
-            </a>
-            <a href="#" className="utrecht-social-media-icon" aria-label="YouTube">
-              <UtrechtIconYoutube />
-            </a>
-          </div>
+          <LinkSocial
+            external
+            href="https://www.facebook.com/GemeenteUtrecht"
+            title="facebook"
+            style={{ marginRight: '0.5em' }}
+          >
+            <UtrechtIconFacebook />
+          </LinkSocial>
+          <LinkSocial
+            external
+            href="https://x.com/Straatweg"
+            title="Amsterdamsestraatweg op Twitter"
+            style={{ marginRight: '0.5em' }}
+          >
+            <UtrechtIconX />
+          </LinkSocial>
+          <LinkSocial
+            external
+            href="https://www.youtube.com/channel/UCel6O4Zyizeg9rAW94QNAhQ/videos"
+            title="Amsterdamsestraatweg op Youtube"
+          >
+            <UtrechtIconYoutube />
+          </LinkSocial>
         </div>
       </div>
 


### PR DESCRIPTION
In het contact formulier prototype gebruiken we nu netjes de social media icons, zodat we kunnen meegenieten van de nieuwe kleur van die icons. Ook is de instructie voor de gebruikerstest wat verbeterd, wat er voor zou moeten zorgen dat de inwoner minder is afgeleid door de inhoud van de testpagina en meer kan focussen op het invullen van het contactformulier.