### PR TITLE
fix: rounded corners contactblok weggehaald

### DIFF
--- a/packages/storybook-react/src/stories/prototype-src/index.css
+++ b/packages/storybook-react/src/stories/prototype-src/index.css
@@ -390,7 +390,6 @@ input:checked:hover + .utrecht-font-tester-toggle-slider {
   /* Hulp en contact blok styling - FIXED */
   .utrecht-help-contact-block {
     background-color: #d4e4f1;
-    border-radius: 4px;
     margin-block: 3rem;
     padding-block-end: 3rem;
     padding-block-start: 1rem;


### PR DESCRIPTION
Mini fix, het contactblok had rounded corners en dat is niet conform onze stijl. CSS waarde aangepast.

Kleine fix in het prototype, dus ik denk geen changeset nodig?