### PR TITLE
ci: ensure that the lockfile is present and up-to-date

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Install dependencies
         run: |
           pnpm install --frozen-lockfile
-          pnpm ls --recursive
 
   lint:
     runs-on: ubuntu-latest
@@ -273,7 +272,6 @@ jobs:
       - name: "Continuous Deployment: install"
         run: |
           pnpm install --frozen-lockfile
-          pnpm ls --recursive
 
       - name: "Continuous Deployment: build"
         run: |


### PR DESCRIPTION
Frozen lockfiles are a [best practice](https://medium.com/dev-simplified/frozen-lockfile-in-projects-why-you-shouldnt-ignore-it-2d6b7a9ebf2e).

Even though pnpm tries to pass the right value for `--frozen-lockfile` in CI, there are still situations where this is bypassed (setting CI to false or removing the lockfile), so passing the argument explicitly is just safer in general.