### PR TITLE
ci: add name to job, so it can be properly marked as skipped

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -181,6 +181,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   visual-regression-test:
+    name: UI Tests
     runs-on: ubuntu-latest
     needs: install
     env:


### PR DESCRIPTION
PRs generated by Dependabot skip the visual-regression-test job, but it is mandatory as per the branch policy.  By
setting a name, the mandatory check can be marked as skipped instead of permanently waiting for a result.
