### PR TITLE
chore: upgrade pnpm to 10.28.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "engines": {
     "node": ">=20 <=24",
-    "pnpm": ">=9 <=10 "
+    "pnpm": "^10.17.0"
   },
   "devDependencies": {
     "@changesets/cli": "2.27.6",


### PR DESCRIPTION
This PR:
- Upgrades pnpm to the latest version
- Ensures that the minimum version (10.17.0) is properly set in package.json; this minimum version is required for security features, to be exact, minimumReleaseAgeExclude patterns