### PR TITLE
feat(calendar-react): add functionality for not showing weekends and year navigation buttons

### DIFF
--- a/packages/components-react/calendar-react/src/index.test.tsx
+++ b/packages/components-react/calendar-react/src/index.test.tsx
@@ -98,7 +98,7 @@ describe('Calendar', () => {
   it('hides weekends', () => {
     const currentDate = new Date(2023, 5, 15); // 15 June 2023 (Thu)
 
-    render(<Calendar onCalendarClick={() => {}} locale={nl} currentDate={currentDate} showWeekends={false} />);
+    render(<Calendar onCalendarClick={() => {}} locale={nl} currentDate={currentDate} displayWeekend={false} />);
 
     const currentDayButton = screen.getByRole('button', {
       name: 'donderdag 15 juni 2023',
@@ -141,10 +141,19 @@ describe('Calendar', () => {
     expect(currentDateLabel).toContainHTML('maart 2024');
   });
 
+  it('renders year navigation buttons by default', () => {
+    const currentDate = new Date(2023, 5, 15);
+
+    render(<Calendar onCalendarClick={() => {}} locale={nl} currentDate={currentDate} />);
+
+    expect(screen.queryByRole('button', { name: 'vorig jaar' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'volgend jaar' })).toBeInTheDocument();
+  });
+
   it('does not render year navigation buttons', () => {
     const currentDate = new Date(2023, 5, 15);
 
-    render(<Calendar onCalendarClick={() => {}} locale={nl} currentDate={currentDate} hideYearControls />);
+    render(<Calendar onCalendarClick={() => {}} locale={nl} currentDate={currentDate} displayYearNavigation={false} />);
 
     expect(screen.queryByRole('button', { name: 'vorig jaar' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'volgend jaar' })).not.toBeInTheDocument();

--- a/packages/components-react/calendar-react/src/index.tsx
+++ b/packages/components-react/calendar-react/src/index.tsx
@@ -37,14 +37,14 @@ import { IconArrowLeftDouble } from './IconArrowLeftDouble';
 import { IconArrowRight } from './IconArrowRight';
 import { IconArrowRightDouble } from './IconArrowRightDouble';
 
-function createCalendar(today: Date, showWeekends: boolean): Date[] {
+function createCalendar(today: Date, displayWeekend: boolean): Date[] {
   const start = startOfWeek(startOfMonth(today), {
     weekStartsOn: 1 /* Monday */,
   });
   const end = endOfWeek(addWeeks(start, 5), {
     weekStartsOn: 1 /* Monday */,
   });
-  return eachDayOfInterval({ start, end }).filter((date) => showWeekends || !isWeekend(date));
+  return eachDayOfInterval({ start, end }).filter((date) => displayWeekend || !isWeekend(date));
 }
 
 export type Events = {
@@ -82,8 +82,8 @@ export interface CalendarProps {
   nextMonthButtonTitle?: string;
   minDate?: Date;
   maxDate?: Date;
-  showWeekends: boolean;
-  hideYearControls: boolean;
+  displayWeekend?: boolean;
+  displayYearNavigation?: boolean;
 }
 
 /**
@@ -100,18 +100,18 @@ export const Calendar = ({
   nextYearButtonTitle = 'Next year',
   previousMonthButtonTitle = 'Previous month',
   nextMonthButtonTitle = 'Next month',
-  showWeekends = true,
-  hideYearControls = false,
+  displayWeekend = true,
+  displayYearNavigation = true,
   minDate,
   maxDate,
 }: CalendarProps) => {
   const [visibleMonth, setVisibleMonth] = useState(currentDate || new Date());
   const [selectedDate, setSelectedDate] = useState(currentDate);
-  const calendar = createCalendar(visibleMonth, showWeekends);
+  const calendar = createCalendar(visibleMonth, displayWeekend);
   const start = startOfWeek(visibleMonth, { weekStartsOn: 1 });
   const end = endOfWeek(visibleMonth, { weekStartsOn: 1 });
 
-  const currentWeek = eachDayOfInterval({ start, end }).filter((day) => showWeekends || !isWeekend(day));
+  const currentWeek = eachDayOfInterval({ start, end }).filter((day) => displayWeekend || !isWeekend(day));
   const chunksWeeks = chunk(calendar, calendar.length / 6);
 
   const weeks = chunksWeeks.map((week) =>
@@ -152,7 +152,7 @@ export const Calendar = ({
   return (
     <div className="utrecht-calendar">
       <CalendarNavigation>
-        {hideYearControls ? (
+        {!displayYearNavigation ? (
           monthNavigation
         ) : (
           <CalendarNavigationButtons

--- a/packages/storybook-react/src/stories/Calendar.stories.tsx
+++ b/packages/storybook-react/src/stories/Calendar.stories.tsx
@@ -32,8 +32,8 @@ const meta = {
     nextYearButtonTitle: 'volgend jaar',
     previousMonthButtonTitle: 'Vorige maand',
     nextMonthButtonTitle: 'volgende maand',
-    showWeekends: true,
-    hideYearControls: false,
+    displayWeekend: true,
+    displayYearNavigation: true,
     minDate: new Date(),
     maxDate: addYears(new Date(), 1),
   },
@@ -95,18 +95,18 @@ const meta = {
         defaultValue: { summary: 'Next month' },
       },
     },
-    showWeekends: {
-      name: 'showWeekends',
+    displayWeekend: {
+      name: 'displayWeekend',
       table: {
         category: 'API',
-        defaultValue: { summary: 'Show weekends' },
+        defaultValue: { summary: 'Show weekend' },
       },
     },
-    hideYearControls: {
-      name: 'hideYearControls',
+    displayYearNavigation: {
+      name: 'displayYearNavigation',
       table: {
         category: 'API',
-        defaultValue: { summary: 'Hide year controls' },
+        defaultValue: { summary: 'Hide year navigation' },
       },
     },
     minDate: {
@@ -161,7 +161,7 @@ export const WithoutWeekends: Story = {
     },
     currentDate: new Date(),
     events,
-    showWeekends: false,
+    displayWeekend: false,
   },
 };
 
@@ -172,7 +172,7 @@ export const HideYearControls: Story = {
     },
     currentDate: new Date(),
     events,
-    hideYearControls: true,
+    displayYearNavigation: false,
   },
 };
 


### PR DESCRIPTION
Related issue: https://github.com/nl-design-system/utrecht/issues/2939
Closes open-formulieren/open-forms#5692 partly