### PR TITLE
chore: remove commit linting workflow

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,9 +1,0 @@
-name: Lint Commit Messages
-on: [pull_request]
-
-jobs:
-  commitlint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1


### PR DESCRIPTION
Die commit-lint is niet meer nodig, omdat we nu changeset files gebruiken voor de releases.