### PR TITLE
fix: add flex column layout to alert and spotlight for row-gap support

### DIFF
--- a/.changeset/clean-files-tan.md
+++ b/.changeset/clean-files-tan.md
@@ -1,0 +1,6 @@
+---
+"@utrecht/spotlight-section-css": patch
+"@utrecht/alert-css": patch
+---
+
+Add flex column layout to Alert and Spotlight for row-gap support, add row-gap token to spotlight-section

--- a/components/alert/src/_mixin.scss
+++ b/components/alert/src/_mixin.scss
@@ -29,6 +29,8 @@
 }
 
 @mixin utrecht-alert__content {
+  display: flex;
+  flex-direction: column;
   row-gap: var(--utrecht-alert-content-row-gap);
 }
 
@@ -37,6 +39,8 @@
   --utrecht-heading-color: var(--utrecht-alert-color);
   --utrecht-paragraph-color: var(--utrecht-alert-color);
 
+  display: flex;
+  flex-direction: column;
   row-gap: var(--utrecht-alert-message-row-gap);
 }
 

--- a/components/spotlight-section/src/_mixin.scss
+++ b/components/spotlight-section/src/_mixin.scss
@@ -14,12 +14,15 @@
   border-style: solid;
   border-width: var(--_utrecht-spotlight-section-border-width, var(--utrecht-spotlight-section-border-width, 0));
   color: var(--_utrecht-spotlight-section-color, var(--utrecht-spotlight-section-color));
+  display: flex;
+  flex-direction: column;
   margin-block-end: calc(var(--utrecht-space-around, 0) * var(--utrecht-spotlight-section-margin-block-end, 0));
   margin-block-start: calc(var(--utrecht-space-around, 0) * var(--utrecht-spotlight-section-margin-block-start, 0));
   padding-block-end: var(--utrecht-spotlight-section-padding-block-end);
   padding-block-start: var(--utrecht-spotlight-section-padding-block-start);
   padding-inline-end: var(--utrecht-spotlight-section-padding-inline-end);
   padding-inline-start: var(--utrecht-spotlight-section-padding-inline-start);
+  row-gap: var(--utrecht-spotlight-section-row-gap);
 }
 
 @mixin utrecht-spotlight-section-type($type) {

--- a/components/spotlight-section/src/tokens.json
+++ b/components/spotlight-section/src/tokens.json
@@ -91,6 +91,16 @@
         },
         "type": "spacing"
       },
+      "row-gap": {
+        "$extensions": {
+          "nl.nldesignsystem.css.property": {
+            "syntax": "<length>",
+            "inherits": true
+          },
+          "nl.nldesignsystem.figma.supports-token": false
+        },
+        "type": "spacing"
+      },
       "margin-block-start": {
         "$extensions": {
           "nl.nldesignsystem.css.property": {


### PR DESCRIPTION
## In this PR
Add flex column layout to Alert and Spotlight so `row-gap` can be used.

Note: the `row-gap` tokens are now functional but have no default value. Users of these components can opt in by setting the token to their desired value in their theme.

## Related issue
https://github.com/nl-design-system/mijn-services/issues/346