### PR TITLE
refactor: use different approach for textbox container

### DIFF
--- a/components/textbox/src/_mixin.scss
+++ b/components/textbox/src/_mixin.scss
@@ -30,34 +30,19 @@ $utrecht-support-prince-xml: false !default;
       var(--utrecht-textbox-padding-inline-end, var(--utrecht-form-control-padding-inline-end, 0)) +
       var(--utrecht-textbox-padding-inline-start, var(--utrecht-form-control-padding-inline-start, 0)) +
       var(--utrecht-textbox-border-width, var(--utrecht-form-control-border-width, 0)) +
-      var(--utrecht-textbox-leading-inline-size, 0) + var(--utrecht-textbox-trailing-inline-size, 0) +
       var(--utrecht-textbox-autocomplete-ui-size, 44px)
   );
 
-  inline-size: max(
-    var(--utrecht-pointer-target-min-size, 44px),
-    min(
-      var(--_utrecht-textbox-max-inline-size, 100cqi),
-      var(--utrecht-textbox-max-inline-size, var(--utrecht-form-control-max-inline-size))
-    )
-  );
-
-  /* min-inline-size: var(--utrecht-pointer-target-min-size, 44px);
+  inline-size: var(--utrecht-pointer-target-min-size, 44px);
   max-inline-size: min(
     var(--_utrecht-textbox-max-inline-size, 100%),
     var(--utrecht-textbox-max-inline-size, var(--utrecht-form-control-max-inline-size))
-  ); */
+  );
+  min-block-size: var(--utrecht-pointer-target-min-size, 44px);
 }
 
-/* TODO: Enable ordering properties when the plugin supports logical CSS properties
- * https://github.com/hudochenkov/stylelint-order/pull/162 */
-/* stylelint-disable order/properties-alphabetical-order */
-@mixin utrecht-textbox {
-  @include utrecht-textbox-sizing;
-
+@mixin utrecht-textbox__border {
   background-color: var(--utrecht-textbox-background-color, var(--utrecht-form-control-background-color));
-  block-size: initial; /* harden */
-  border-width: var(--utrecht-textbox-border-width, var(--utrecht-form-control-border-width));
   border-block-end-width: var(
     --utrecht-textbox-border-bottom-width,
     var(--utrecht-textbox-border-width, var(--utrecht-form-control-border-width))
@@ -65,9 +50,22 @@ $utrecht-support-prince-xml: false !default;
   border-color: var(--utrecht-textbox-border-color, var(--utrecht-form-control-border-color));
   border-radius: var(--utrecht-textbox-border-radius, var(--utrecht-form-control-border-radius, 0));
   border-style: solid;
-  box-sizing: border-box;
-  color: var(--utrecht-textbox-color, var(--utrecht-form-control-color));
-  display: block;
+  border-width: var(--utrecht-textbox-border-width, var(--utrecht-form-control-border-width));
+}
+
+@mixin utrecht-textbox__border--disabled {
+  @media screen and (forced-colors: active) {
+    border-color: GrayText;
+  }
+}
+@mixin utrecht-textbox__border--focus-visible {
+  @media screen and (forced-colors: active) {
+    border-color: Highlight;
+    outline-color: Highlight;
+  }
+}
+
+@mixin utrecht-textbox__text {
   font-family: var(--utrecht-textbox-font-family, var(--utrecht-form-control-font-family));
   font-size: var(--utrecht-textbox-font-size, var(--utrecht-form-control-font-size, inherit));
   font-weight: var(
@@ -75,10 +73,34 @@ $utrecht-support-prince-xml: false !default;
     var(--utrecht-form-control-font-weight, initial)
   ); /* harden with `initial` */
 
-  /* inline-size: 100%; */
   line-height: var(--utrecht-textbox-line-height, var(--utrecht-form-control-line-height, initial));
+}
+
+@mixin utrecht-textbox__input {
+  block-size: initial; /* harden */
   min-block-size: var(--utrecht-pointer-target-min-size, 44px);
+
+  /* The `<input>` element does not have text wrapping, and overflowing text is available with scrolling.
+   * Avoid text wrapping too, when rendering using other elements such as `<span>`.
+   * Configure `overflow` and `white-space` to achieve this.
+   */
   overflow: hidden;
+  white-space: nowrap;
+}
+
+/* TODO: Enable ordering properties when the plugin supports logical CSS properties
+ * https://github.com/hudochenkov/stylelint-order/pull/162 */
+/* stylelint-disable order/properties-alphabetical-order */
+@mixin utrecht-textbox {
+  @include utrecht-textbox__border;
+  @include utrecht-textbox__text;
+  @include utrecht-textbox-sizing;
+
+  box-sizing: border-box;
+  color: var(--utrecht-textbox-color, var(--utrecht-form-control-color));
+  display: block;
+
+  /* inline-size: 100%; */
   padding-block-end: var(--utrecht-textbox-padding-block-end, var(--utrecht-form-control-padding-block-end, 0));
   padding-block-start: var(--utrecht-textbox-padding-block-start, var(--utrecht-form-control-padding-block-start, 0));
   padding-inline-start: calc(
@@ -89,7 +111,6 @@ $utrecht-support-prince-xml: false !default;
     var(--utrecht-textbox-padding-inline-end, var(--utrecht-form-control-padding-inline-end, initial)) +
       var(--utrecht-textbox-trailing-inline-size, 0px)
   );
-  white-space: nowrap;
 
   @if $utrecht-support-prince-xml {
     @media print {
@@ -419,41 +440,6 @@ $utrecht-support-prince-xml: false !default;
 @mixin utrecht-textbox--iban-nl-size {
   /* Dutch IBAN: 18 characters, plus 4 spaces (one space after every 4 characters) */
   --utrecht-textbox-value-max-length: 22;
-}
-
-/**
- * New textbox container
- */
-@mixin utrecht-textbox-container__inner {
-  /* @include utrecht-textbox-sizing; */
-
-  --utrecht-icon-size: 1lh;
-  --utrecht-textbox-container-slot-min-inline-size: var(--utrecht-pointer-target-min-size, 44px);
-  --utrecht-textbox-leading-inline-size: max(
-    var(--_utrecht-textbox-leading-inline-size-calculated, 0px),
-    var(--utrecht-textbox-container-slot-min-inline-size)
-  );
-  --utrecht-textbox-trailing-inline-size: max(
-    var(--_utrecht-textbox-trailing-inline-size-calculated, 0px),
-    var(--utrecht-textbox-container-slot-min-inline-size)
-  );
-
-  &:where(:not(:has(.utrecht-textbox-container__leading))) {
-    --utrecht-textbox-leading-inline-size: 0px;
-  }
-  &:where(:not(:has(.utrecht-textbox-container__trailing))) {
-    --utrecht-textbox-trailing-inline-size: 0px;
-  }
-
-  display: inline-grid;
-  grid-template-columns: max-content 1fr max-content;
-  gap: var(
-    --utrecht-textbox-gap,
-    var(--utrecht-textbox-padding-inline-start, var(--utrecht-form-control-padding-inline-start, initial))
-  );
-  block-size: initial; /* harden */
-  box-sizing: border-box;
-  inline-size: fit-content;
 }
 
 @mixin utrecht-textbox-container__input {

--- a/components/textbox/src/_mixin.scss
+++ b/components/textbox/src/_mixin.scss
@@ -99,8 +99,7 @@ $utrecht-support-prince-xml: false !default;
   box-sizing: border-box;
   color: var(--utrecht-textbox-color, var(--utrecht-form-control-color));
   display: block;
-
-  /* inline-size: 100%; */
+  inline-size: 100%;
   padding-block-end: var(--utrecht-textbox-padding-block-end, var(--utrecht-form-control-padding-block-end, 0));
   padding-block-start: var(--utrecht-textbox-padding-block-start, var(--utrecht-form-control-padding-block-start, 0));
   padding-inline-start: calc(

--- a/components/textbox/src/index.scss
+++ b/components/textbox/src/index.scss
@@ -129,40 +129,120 @@
 }
 
 .utrecht-textbox-container {
-  background-color: rgb(0 255 0 / 20%);
-  container: utrecht-textbox-container / inline-size;
-  display: block;
+  @include utrecht-textbox-sizing;
+  @include utrecht-textbox__border;
+
+  cursor: text;
+  display: inline-flex;
+  flex-direction: row;
+  inline-size: 100%;
+
+  // background-color: rgb(0 255 0 / 20%);
+  // container: utrecht-textbox-container / inline-size;
+  // display: block;
 }
 
 .utrecht-textbox-container__inner {
-  @include utrecht-textbox-container__inner;
+  // @include utrecht-textbox-container__inner;
 }
 
-.utrecht-textbox-container__leading,
-.utrecht-textbox-container__trailing {
+.utrecht-textbox-container__text-start,
+.utrecht-textbox-container__text-end,
+.utrecht-textbox-container__icon-start,
+.utrecht-textbox-container__icon-end {
   align-items: center;
   background-color: rgb(255 0 0 / 20%);
   display: flex;
   justify-content: center;
-  min-inline-size: var(--utrecht-textbox-container-slot-min-inline-size, 44px);
+
+  // min-inline-size: var(--utrecht-textbox-container-slot-min-inline-size, 44px);
   position: relative;
   white-space: nowrap;
   z-index: 2;
 
   // TODO: update list of interactive elements
   &:not(:has(button, a)) {
-    pointer-events: none;
+    // pointer-events: none;
   }
 }
 
-.utrecht-textbox-container__leading {
+.utrecht-textbox-container__icon-start {
   grid-area: 1 / 1 / 2 / 2;
 }
 
-.utrecht-textbox-container__trailing {
+.utrecht-textbox-container__icon-end {
   grid-area: 1 / 3 / 2 / 4;
 }
 
+.utrecht-textbox-container__icon-start,
+.utrecht-textbox-container__icon-end {
+  --utrecht-icon-size: var(--utrecht-textbox-container-icon-size, 1em);
+}
+
+.utrecht-textbox-container__icon-start,
+.utrecht-textbox-container__icon-end,
+.utrecht-textbox-container__label-start,
+.utrecht-textbox-container__label-end,
+.utrecht-textbox-container__description-start,
+.utrecht-textbox-container__description-end {
+  @include utrecht-textbox__text;
+
+  align-items: center;
+
+  /* Reset the cursor from the `<label>` element, and inherit the desired cursor.
+   * For example, the `cursor` for the disabled state. */
+  cursor: inherit;
+
+  // background-color: rgb(255 0 0 / 20%);
+  display: flex;
+  justify-content: center;
+}
+
+.utrecht-textbox-container .utrecht-textbox,
 .utrecht-textbox-container__input {
   @include utrecht-textbox-container__input;
+
+  inline-size: 100%;
+}
+
+.utrecht-textbox-container .utrecht-textbox {
+  background-color: transparent;
+  border: 0;
+  color: currentColor;
+}
+.utrecht-textbox-container .utrecht-textbox:focus-visible {
+  background-color: transparent;
+  border: 0;
+  box-shadow: none;
+  color: currentColor;
+
+  /* no focus ring */
+  outline: none;
+}
+
+// .utrecht-textbox-container:has(> .utrecht-textbox:hover, > .utrecht-textbox--hover) {
+//   @include utrecht-textbox--hover;
+// }
+
+.utrecht-textbox-container:has(> .utrecht-textbox:focus-visible, > .utrecht-textbox--focus-visible) {
+  @include utrecht-textbox--focus-visible;
+  @include utrecht-textbox__border--focus-visible;
+}
+
+.utrecht-textbox-container:has(> .utrecht-textbox--invalid) {
+  /* TODO: better selector */
+  @include utrecht-textbox--focus-visible;
+}
+
+.utrecht-textbox-container:has(> .utrecht-textbox:read-only, > .utrecht-textbox--read-only) {
+  /* TODO: better selector */
+  @include utrecht-textbox--read-only;
+}
+
+.utrecht-textbox-container:has(> .utrecht-textbox:disabled, > .utrecht-textbox--disabled) {
+  /* TODO: better selector */
+  @include utrecht-textbox--disabled;
+  @include utrecht-textbox__border--disabled;
+
+  cursor: var(--utrecht-action-disabled-cursor, not-allowed);
 }

--- a/packages/components-react/textbox-react/src/index.tsx
+++ b/packages/components-react/textbox-react/src/index.tsx
@@ -1,15 +1,13 @@
 import clsx from 'clsx';
 import {
-  CSSProperties,
   ForwardedRef,
   forwardRef,
   HTMLAttributes,
   InputHTMLAttributes,
+  PropsWithChildren,
   ReactNode,
-  useEffect,
   useImperativeHandle,
   useRef,
-  useState,
 } from 'react';
 export type TextboxTypes =
   | 'date'
@@ -78,80 +76,80 @@ Textbox.displayName = 'Textbox';
  * Wrapper around a textbox input with optional leading and trailing elements.
  */
 interface TextboxContainerOwnProps {
-  leading?: ReactNode;
-  trailing?: ReactNode;
+  iconStart?: ReactNode;
+  labelStart?: ReactNode;
+  descriptionStart?: ReactNode;
+  actionsStart?: ReactNode;
+  iconEnd?: ReactNode;
+  actionsEnd?: ReactNode;
+  labelEnd?: ReactNode;
+  descriptionEnd?: ReactNode;
+  inputId?: string;
 }
 
 export interface TextboxContainerProps extends HTMLAttributes<HTMLSpanElement>, TextboxContainerOwnProps {}
 
 export const TextboxContainer = forwardRef<HTMLSpanElement, TextboxContainerProps>(
-  ({ children, className, leading, trailing, ...restProps }: TextboxContainerProps, ref) => {
-    const leadingRef = useRef<HTMLSpanElement>(null);
-    const trailingRef = useRef<HTMLSpanElement>(null);
-    const containerInnerRef = useRef<HTMLSpanElement>(null);
-    const resizeTimeoutRef = useRef<number | null>(null);
-    const [leadingInlineSize, setLeadingInlineSize] = useState<string>('0px');
-    const [trailingInlineSize, setTrailingInlineSize] = useState<string>('0px');
-
-    const updateInlineSizes = () => {
-      if (leadingRef.current) {
-        const width = leadingRef.current.getBoundingClientRect().width;
-        setLeadingInlineSize(`${width}px`);
-      }
-      if (trailingRef.current) {
-        const width = trailingRef.current.getBoundingClientRect().width;
-        setTrailingInlineSize(`${width}px`);
-      }
-    };
-
-    const deBouncedOnResize = () => {
-      if (resizeTimeoutRef.current) {
-        clearTimeout(resizeTimeoutRef.current);
-      }
-      resizeTimeoutRef.current = window?.setTimeout(updateInlineSizes, 100);
-    };
-
-    useEffect(() => {
-      updateInlineSizes();
-
-      const resizeObserver = new ResizeObserver(deBouncedOnResize);
-
-      if (containerInnerRef.current) {
-        resizeObserver.observe(containerInnerRef.current);
-      }
-
-      // Cleanup
-      return () => {
-        resizeObserver.disconnect();
-        if (resizeTimeoutRef.current) {
-          clearTimeout(resizeTimeoutRef.current);
-        }
-      };
-    }, [leading, trailing]);
+  (
+    {
+      actionsEnd,
+      actionsStart,
+      children,
+      className,
+      iconStart,
+      iconEnd,
+      labelStart,
+      labelEnd,
+      descriptionStart,
+      descriptionEnd,
+      inputId,
+      ...restProps
+    }: TextboxContainerProps,
+    ref,
+  ) => {
+    /** Use a `<label>` element to make the icons clickable, and clicking them focuses the `<input>`.
+     * Use `<label aria-hidden="true">` to avoid associating the text content of the icon a label.
+     */
+    const ClickableWrapper = ({ children, ...restProps }: PropsWithChildren<{}>) =>
+      inputId ? (
+        <label htmlFor={inputId} {...restProps} aria-hidden="true">
+          {children}
+        </label>
+      ) : (
+        <span {...restProps}>{children}</span>
+      );
+    const LabelWrapper = ({ children, ...restProps }: PropsWithChildren<{}>) =>
+      inputId ? (
+        <label htmlFor={inputId} {...restProps}>
+          {children}
+        </label>
+      ) : (
+        <span {...restProps}>{children}</span>
+      );
 
     return (
-      <span
-        {...restProps}
-        className={clsx('utrecht-textbox-container', className)}
-        style={{
-          ['--_utrecht-textbox-leading-inline-size-calculated' as keyof CSSProperties]: leadingInlineSize,
-          ['--_utrecht-textbox-trailing-inline-size-calculated' as keyof CSSProperties]: trailingInlineSize,
-        }}
-        ref={ref}
-      >
-        <span className="utrecht-textbox-container__inner" ref={containerInnerRef}>
-          {leading ? (
-            <span ref={leadingRef} className="utrecht-textbox-container__leading">
-              {leading}
-            </span>
-          ) : null}
-          {children}
-          {trailing ? (
-            <span ref={trailingRef} className="utrecht-textbox-container__trailing">
-              {trailing}
-            </span>
-          ) : null}
-        </span>
+      <span {...restProps} className={clsx('utrecht-textbox-container', className)} ref={ref}>
+        {iconStart ? (
+          <ClickableWrapper className="utrecht-textbox-container__icon-start">{iconStart}</ClickableWrapper>
+        ) : null}
+        {labelStart ? (
+          <LabelWrapper className="utrecht-textbox-container__label-start">{labelStart}</LabelWrapper>
+        ) : null}
+        {descriptionStart ? (
+          <ClickableWrapper className="utrecht-textbox-container__description-start">
+            {descriptionStart}
+          </ClickableWrapper>
+        ) : null}
+        {actionsStart ? <span className="utrecht-textbox-container__actions-start">{actionsStart}</span> : null}
+        {children}
+        {actionsEnd ? <span className="utrecht-textbox-container__actions-end">{actionsEnd}</span> : null}
+        {labelEnd ? <LabelWrapper className="utrecht-textbox-container__label-end">{labelEnd}</LabelWrapper> : null}
+        {descriptionEnd ? (
+          <ClickableWrapper className="utrecht-textbox-container__description-end">{descriptionEnd}</ClickableWrapper>
+        ) : null}
+        {iconEnd ? (
+          <ClickableWrapper className="utrecht-textbox-container__icon-end">{iconEnd}</ClickableWrapper>
+        ) : null}
       </span>
     );
   },
@@ -169,15 +167,37 @@ export interface Textbox2Props extends InputHTMLAttributes<HTMLInputElement>, Te
 }
 
 export const Textbox2 = forwardRef<HTMLInputElement, Textbox2Props>(
-  ({ className, leading, trailing, ...restProps }: Textbox2Props, ref) => {
+  (
+    {
+      className,
+      actionsEnd,
+      actionsStart,
+      iconStart,
+      iconEnd,
+      labelStart,
+      labelEnd,
+      descriptionStart,
+      descriptionEnd,
+      ...restProps
+    }: Textbox2Props,
+    ref,
+  ) => {
     const inputRef = useRef<HTMLInputElement>(null);
     const containerInnerRef = useRef<HTMLSpanElement>(null);
 
     // Default ref behavior: point to the input element
     useImperativeHandle(ref, () => inputRef.current!, []);
 
-    const renderContainer = leading || trailing;
-
+    const renderContainer = !!(
+      actionsEnd ||
+      actionsStart ||
+      iconStart ||
+      iconEnd ||
+      labelStart ||
+      labelEnd ||
+      descriptionStart ||
+      descriptionEnd
+    );
     // const inputClasses = clsx(
     //   'utrecht-textbox',
     //   'utrecht-textbox--html-input',
@@ -214,7 +234,11 @@ export const Textbox2 = forwardRef<HTMLInputElement, Textbox2Props>(
 
     if (renderContainer) {
       return (
-        <TextboxContainer ref={containerInnerRef} leading={leading} trailing={trailing}>
+        <TextboxContainer
+          ref={containerInnerRef}
+          inputId={restProps.id}
+          {...{ actionsEnd, actionsStart, iconStart, iconEnd, labelStart, labelEnd, descriptionStart, descriptionEnd }}
+        >
           <Textbox {...restProps} className={inputClassesInContainer} ref={inputRef} />
         </TextboxContainer>
       );

--- a/packages/storybook-react/config/main.ts
+++ b/packages/storybook-react/config/main.ts
@@ -10,7 +10,7 @@ const config: StorybookConfig = {
     disableTelemetry: true,
   },
 
-  stories: ['../src/stories/**/*.stories.@(js|jsx|mdx|ts|tsx)'],
+  stories: ['../src/stories/**/Textbox*.stories.@(js|jsx|mdx|ts|tsx)'],
 
   addons: [
     getAbsolutePath('@storybook/addon-links'),

--- a/packages/storybook-react/package.json
+++ b/packages/storybook-react/package.json
@@ -40,6 +40,7 @@
     "@storybook/addon-links": "9.1.17",
     "@storybook/mdx2-csf": "1.1.0",
     "@storybook/react-vite": "9.1.17",
+    "@tabler/icons-react": "3.35.0",
     "@types/lodash.merge": "4.6.9",
     "@types/react": "19.2.14",
     "@utrecht/accordion-css": "workspace:*",

--- a/packages/storybook-react/src/stories/Textbox.stories.tsx
+++ b/packages/storybook-react/src/stories/Textbox.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
-import { Textbox } from '@utrecht/component-library-react/dist/css-module/index';
+import { Textbox } from '@utrecht/component-library-react';
 import tokens from '@utrecht/design-tokens/dist/list.mjs';
 import readme from '@utrecht/textbox-css/README.md?raw';
 import tokensDefinition from '@utrecht/textbox-css/dist/tokens.mjs';

--- a/packages/storybook-react/src/stories/TextboxContainer.css
+++ b/packages/storybook-react/src/stories/TextboxContainer.css
@@ -1,0 +1,8 @@
+@keyframes example-spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/packages/storybook-react/src/stories/TextboxContainer.stories.tsx
+++ b/packages/storybook-react/src/stories/TextboxContainer.stories.tsx
@@ -1,10 +1,28 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 // import tokens from '@utrecht/design-tokens/dist/list.mjs';
-import { Icon } from '@utrecht/component-library-react';
+import {
+  IconCalendar,
+  IconCheck,
+  IconCircleX,
+  IconClearAll,
+  IconCopy,
+  IconEye,
+  IconEyeClosed,
+  IconHourglass,
+  IconSearch,
+} from '@tabler/icons-react';
+import { Button, ColorSample, DataBadge, Icon, Select, SelectOption } from '@utrecht/component-library-react';
 import readme from '@utrecht/textbox-css/README.md?raw';
 import tokensDefinition from '@utrecht/textbox-css/dist/tokens.mjs';
+import { useArgs } from 'storybook/preview-api';
 import { designTokenStory } from './util.js';
 import { Textbox2 } from '../../../components-react/textbox-react/src/index.js';
+import '@utrecht/button-css/src/index.scss';
+import '@utrecht/icon-css/src/index.scss';
+import '@utrecht/textbox-css/src/index.scss';
+import '@utrecht/data-badge-css/src/index.scss';
+import '@utrecht/select-css/src/index.scss';
+import './TextboxContainer.css';
 
 const meta = {
   title: 'React Component/TextboxContainer',
@@ -86,7 +104,7 @@ const meta = {
       control: 'boolean',
       table: {
         category: 'HTML attribute',
-        defaultValue: { summary: false },
+        defaultValue: { summary: 'false' },
       },
     },
     invalid: {
@@ -94,7 +112,7 @@ const meta = {
       control: 'boolean',
       table: {
         category: 'API',
-        defaultValue: { summary: false },
+        defaultValue: { summary: 'false' },
       },
     },
     minLength: {
@@ -102,7 +120,7 @@ const meta = {
       control: 'number',
       table: {
         category: 'HTML attribute',
-        defaultValue: { summary: false },
+        defaultValue: { summary: 'false' },
       },
     },
     placeholder: {
@@ -118,7 +136,7 @@ const meta = {
       control: 'boolean',
       table: {
         category: 'HTML attribute',
-        defaultValue: { summary: false },
+        defaultValue: { summary: 'false' },
       },
     },
     required: {
@@ -126,7 +144,7 @@ const meta = {
       control: 'boolean',
       table: {
         category: 'HTML attribute',
-        defaultValue: { summary: false },
+        defaultValue: { summary: 'false' },
       },
     },
     spellCheck: {
@@ -191,44 +209,435 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     defaultValue: 'The Quick Brown Fox Jumps Over The Lazy Dog',
+    id: 'e102dee1-46ff-405b-b5c9-721e61bbab10',
+    iconStart: 'X',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    defaultValue: 'The Quick Brown Fox Jumps Over The Lazy Dog',
+    disabled: true,
+    iconStart: 'X',
+    id: '6421297c-fd35-46ba-b6a0-ffa709c51bf7',
+  },
+};
+
+export const ReadOnly: Story = {
+  args: {
+    defaultValue: 'The Quick Brown Fox Jumps Over The Lazy Dog',
+    readOnly: true,
+    iconStart: 'X',
+    id: 'd46c766d-a90f-4730-a99a-d86738866b54',
   },
 };
 
 export const WithLeadingAndTrailing: Story = {
   args: {
     defaultValue: 'The Quick Brown Fox Jumps Over The Lazy Dog',
-    leading: <Icon>→</Icon>,
-    trailing: <Icon>📅</Icon>,
+    iconStart: <Icon>→</Icon>,
+    iconEnd: <Icon>📅</Icon>,
+    id: 'b78de0d7-72f6-4f88-adda-1ca7476f028b',
   },
 };
 
-export const WithTrailingButton: Story = {
+export const LabelStart: Story = {
+  args: {
+    labelStart: 'Voornaam: ',
+    id: '7b72c048-2bb1-45e3-8571-11acd399a749',
+  },
+};
+
+export const LabelStartEnd: Story = {
+  args: {
+    labelStart: 'Oppervlakte: ',
+    labelEnd: 'm2',
+    id: '9b96c1ce-fc1b-4992-afe3-3cae9e893ad0',
+  },
+};
+
+export const DescriptionEnd: Story = {
+  args: {
+    labelStart: 'Voornaam: ',
+    descriptionEnd: '(verplicht)',
+    required: true,
+    id: '3d383458-43ed-490d-a1de-5886ba0c29c3',
+  },
+};
+
+export const WithLeadingAndTrailingExpandButton: Story = {
   args: {
     defaultValue: 'The Quick Brown Fox Jumps Over The Lazy Dog',
-    trailing: <button>Calendar</button>,
+    actionsEnd: (
+      <Button appearance="subtle-button">
+        <Icon>⬇</Icon>
+      </Button>
+    ),
+    id: '3d8283f8-0e7f-4376-8afc-41cb2f69246b',
+  },
+};
+
+export const WithLeadingAnLeadingLocate: Story = {
+  args: {
+    defaultValue: '',
+    actionsStart: (
+      <Button
+        appearance="subtle-button"
+        aria-label="Use my current location"
+        onClick={() => {
+          navigator.geolocation.getCurrentPosition((position) => {
+            // TODO: Set Story parameter `value`
+            console.log(position.coords.latitude, position.coords.longitude);
+          });
+        }}
+      >
+        <Icon>📍</Icon>
+      </Button>
+    ),
+    id: '0be51de3-a129-49af-b0ba-bad821019b3a',
+  },
+};
+export const WithLeadingTrailingCopyButton: Story = {
+  args: {
+    defaultValue: '4d0fc018-c631-4b98-bcf5-8f2c917c9df1',
+    readOnly: true,
+    actionsEnd: (
+      <Button
+        appearance="subtle-button"
+        aria-label="Copy value"
+        onClick={() => {
+          // TODO: Copy value
+        }}
+      >
+        <Icon>
+          <IconCopy />
+        </Icon>
+      </Button>
+    ),
+    id: '5e8131ac-ce60-4ebc-b7c1-d94655cd3851',
+  },
+};
+
+export const WithLeadingAndTrailingVeryLong: Story = {
+  args: {
+    defaultValue: 'The Quick Brown Fox Jumps Over The Lazy Dog',
+    textEnd:
+      'The Quick Brown Fox Jumps Over The Lazy Dog The Quick Brown Fox Jumps Over The Lazy Dog The Quick Brown Fox Jumps Over The Lazy Dog The Quick Brown Fox Jumps Over The Lazy Dog The Quick Brown Fox Jumps Over The Lazy Dog The Quick Brown Fox Jumps Over The Lazy Dog The Quick Brown Fox Jumps Over The Lazy Dog.',
+    id: '48acd310-4c31-42a6-959d-930b8774d61a',
+  },
+};
+
+export const WithTrailingSubtleButton: Story = {
+  args: {
+    defaultValue: 'The Quick Brown Fox Jumps Over The Lazy Dog',
+    actionsEnd: (
+      <Button appearance="subtle-button" aria-haspopup="dialog" aria-label="Open/sluit kalender">
+        <Icon>
+          <IconCalendar />
+        </Icon>
+      </Button>
+    ),
+    id: '335fa207-2ded-42fd-bde4-1c622104397b',
   },
 };
 
 export const WithLeadingButton: Story = {
   args: {
     defaultValue: 'The Quick Brown Fox Jumps Over The Lazy Dog',
-    leading: <button>Calendar</button>,
+    actionsStart: <button>Calendar</button>,
+    id: '49adfe67-55d2-4ed5-96d2-c95c0b041dfe',
   },
 };
 
 export const WithJustText: Story = {
   args: {
     defaultValue: 'The Quick Brown Fox Jumps Over The Lazy Dog',
-    trailing: 'mL per hour',
+    labelEnd: 'mL per hour',
+    id: 'b9d2cc90-ee47-490e-94e8-cdb17ed789ad',
   },
 };
 
 export const WithMaxLength: Story = {
   args: {
     defaultValue: 'The Quick Brown Fox Jumps Over The Lazy Dog',
-    leading: 'NL (+31)',
+    labelStart: 'NL (+31)',
     className: 'utrecht-textbox--house-number-size',
+    id: '9ce3cdfc-d7bd-47e4-ac68-0db87592362c',
+  },
+};
+
+export const WitTrailingSelect: Story = {
+  args: {
+    defaultValue: 'The Quick Brown Fox Jumps Over The Lazy Dog',
+    type: 'number',
+    actionsEnd: (
+      <Select>
+        <SelectOption></SelectOption>
+        <SelectOption>px</SelectOption>
+        <SelectOption>rem</SelectOption>
+      </Select>
+    ),
+    className: 'utrecht-textbox--house-number-size',
+    id: '415f32ad-a07a-4b22-8b94-755da5ba4a65',
+  },
+};
+
+export const Search: Story = {
+  args: {
+    iconStart: (
+      <Icon>
+        <IconSearch />
+      </Icon>
+    ),
+    actionsEnd: (
+      <Button appearance="subtle-button">
+        <Icon>
+          <IconCircleX />
+        </Icon>
+      </Button>
+    ),
+    type: 'search',
+    placeholder: 'Zoeken...',
+    id: '527c89b3-9e11-4ce6-a316-e975d1634774',
+  },
+};
+
+export const SubmitSearch: Story = {
+  args: {
+    iconStart: (
+      <Icon>
+        <IconSearch />
+      </Icon>
+    ),
+    actionsEnd: <Button appearance="primary-action-button">Zoeken</Button>,
+    type: 'search',
+    placeholder: 'Zoeken...',
+    id: '527c89b3-9e11-4ce6-a316-e975d1634774',
+  },
+};
+
+export const SearchKeyboard: Story = {
+  args: {
+    iconStart: (
+      <Icon>
+        <IconSearch />
+      </Icon>
+    ),
+    descriptionEnd: (
+      <DataBadge aria-label="Sneltoets: Command+K">
+        <span>⌘</span>
+        <span>F</span>
+      </DataBadge>
+    ),
+    type: 'search',
+    placeholder: 'Zoeken...',
+    id: '527c89b3-9e11-4ce6-a316-e975d1634774',
+  },
+};
+
+export const PostalCode: Story = {
+  args: {
+    descriptionEnd: '(verplicht)',
+    type: 'text',
+    autoComplete: 'postal-code',
+    id: '82009faf-c78f-4d95-95bd-836fcb2f0f57',
+  },
+};
+
+export const ShowPassword: Story = {
+  args: {
+    actionsEnd: (
+      <Button appearance="subtle-button" aria-label="Show password">
+        <Icon>
+          <IconEyeClosed />
+        </Icon>
+      </Button>
+    ),
+    type: 'password',
+    value: '$ecret2024',
+    autoComplete: 'password',
+    id: '5d2b4df8-f1ae-4091-98c3-a336ddd124f8',
+  },
+  render: function Render(args) {
+    const [updatedArgs, updateArgs] = useArgs();
+
+    const onClick = (evt) => {
+      updateArgs({
+        type: updatedArgs.type === 'password' ? 'text' : 'password',
+      });
+    };
+
+    const actionsEnd =
+      updatedArgs.type === 'password' ? (
+        <Button appearance="subtle-button" aria-label="Show password" onClick={onClick}>
+          <Icon>
+            <IconEye />
+          </Icon>
+          Show
+        </Button>
+      ) : (
+        <Button appearance="subtle-button" aria-label="Hide password" onClick={onClick}>
+          <Icon>
+            <IconEyeClosed />
+          </Icon>
+          Hide
+        </Button>
+      );
+
+    return <Textbox2 {...args} {...updatedArgs} actionsEnd={actionsEnd} />;
+  },
+};
+
+export const NewPassword: Story = {
+  args: {
+    descriptionEnd: 'zeer\u00A0veilig',
+    type: 'password',
+    value: 'Fi*sHTsAD6.wiH8_o4QAAitqMvthyjiV',
+    autoComplete: 'new-password',
+    id: '3e643ebf-7ada-4a68-af66-f83ce5f09fa4',
+  },
+};
+
+export const SelectStart: Story = {
+  args: {
+    actionsStart: (
+      <Select aria-label="Search type">
+        <SelectOption>All</SelectOption>
+        <SelectOption>Movies</SelectOption>
+        <SelectOption>TV Episodes</SelectOption>
+        <SelectOption>Actors</SelectOption>
+      </Select>
+    ),
+    type: 'search',
+    defaultValue: 'Pitt',
+    id: '8a7cae44-f801-402b-a8a2-738d1edbf536',
+  },
+};
+
+export const SelectStartPhone: Story = {
+  args: {
+    actionsStart: (
+      <Select aria-label="Contact">
+        <SelectOption value="home phone">Home</SelectOption>
+        <SelectOption value="work phone">Work</SelectOption>
+        <SelectOption value="phone">Other</SelectOption>
+      </Select>
+    ),
+    type: 'text',
+    defaultValue: '',
+    autoComplete: 'phone',
+    id: '482977b2-55d9-4fe3-b586-ba3241d2033c',
+  },
+  render: function Render(args) {
+    const [updatedArgs, updateArgs] = useArgs();
+
+    const actionsStart = (
+      <Select
+        aria-label="Contact"
+        onChange={(evt) => {
+          updateArgs({
+            autoComplete: evt.target.value,
+          });
+        }}
+      >
+        <SelectOption value="home phone">Home</SelectOption>
+        <SelectOption value="work phone">Work</SelectOption>
+        <SelectOption value="mobile phone">Mobile</SelectOption>
+        <SelectOption value="phone">Other</SelectOption>
+      </Select>
+    );
+
+    return <Textbox2 {...args} {...updatedArgs} actionsStart={actionsStart} />;
+  },
+};
+
+export const BusyStatus: Story = {
+  args: {
+    iconEnd: (
+      <Icon style={{ animation: 'example-spin 2s linear infinite' }}>
+        <IconHourglass />
+      </Icon>
+    ),
+    type: 'text',
+    defaultValue: '',
+    autoComplete: 'username',
+    id: '81be1af9-50c0-4e8d-bd35-5a9da396d772',
+    busy: false,
+  },
+  render: function Render(args) {
+    const [updatedArgs, updateArgs] = useArgs();
+
+    const busy = updatedArgs.busy;
+
+    const busyText = 'Bezig met controleren';
+    const successText = 'Gebruikersnaam is nog beschikbaar';
+    const iconEnd = (
+      <span role="alert">
+        {busy ? (
+          <Icon style={{ animation: 'example-spin 2s linear infinite' }} aria-label={busyText}>
+            <IconHourglass />
+          </Icon>
+        ) : (
+          <Icon aria-label={successText}>
+            <IconCheck />
+          </Icon>
+        )}
+      </span>
+    );
+
+    return (
+      <Textbox2
+        {...args}
+        {...updatedArgs}
+        iconEnd={iconEnd}
+        onInput={(evt) => {
+          updateArgs({ busy: true });
+
+          setTimeout(() => {
+            updateArgs({ busy: false });
+          }, 1000);
+        }}
+      />
+    );
   },
 };
 
 // export const DesignTokens = designTokenStory(meta);
+
+export const ColorPicker: Story = {
+  args: {
+    actionsStart: (
+      <Button appearance="subtle-button">
+        <ColorSample value="#007dad"></ColorSample>
+      </Button>
+    ),
+    type: 'text',
+    defaultValue: '#007dad',
+    currentValue: '#007dad',
+    id: 'd7dca59e-a66d-4341-9b92-6021e2dcd3e0',
+  },
+  render: function Render(args) {
+    const [updatedArgs, updateArgs] = useArgs();
+
+    const { currentValue, ...otherArgs } = updatedArgs;
+    const actionsStart = (
+      <Button appearance="subtle-button">
+        <ColorSample color={currentValue} style={{ color: currentValue }}></ColorSample>
+      </Button>
+    );
+
+    return (
+      <Textbox2
+        {...args}
+        {...otherArgs}
+        actionsStart={actionsStart}
+        onInput={(evt) => {
+          console.log(evt.target.value);
+          updateArgs({
+            currentValue: evt.target.value,
+          });
+        }}
+      />
+    );
+  },
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6523,6 +6523,9 @@ importers:
       '@storybook/react-vite':
         specifier: 9.1.17
         version: 9.1.17(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.50.0)(storybook@9.1.17(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.12(@types/node@24.10.4)(jiti@1.21.0)(less@4.2.0)(sass-embedded@1.99.0)(sass@1.92.1)(terser@5.44.0)(tsx@4.19.4)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.1.12(@types/node@24.10.4)(jiti@1.21.0)(less@4.2.0)(sass-embedded@1.99.0)(sass@1.92.1)(terser@5.44.0)(tsx@4.19.4)(yaml@2.8.1))
+      '@tabler/icons-react':
+        specifier: 3.35.0
+        version: 3.35.0(react@19.2.4)
       '@types/lodash.merge':
         specifier: 4.6.9
         version: 4.6.9
@@ -13658,8 +13661,16 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0
 
+  '@tabler/icons-react@3.35.0':
+    resolution: {integrity: sha512-XG7t2DYf3DyHT5jxFNp5xyLVbL4hMJYJhiSdHADzAjLRYfL7AnjlRfiHDHeXxkb2N103rEIvTsBRazxXtAUz2g==}
+    peerDependencies:
+      react: '>= 16'
+
   '@tabler/icons@2.44.0':
     resolution: {integrity: sha512-WPPtihDcAwEm1QZM9MXQw6+r/R2/qx7KMU1eegsi9DsqBLAb0W2kbt6e/syvd6j9c+6XNpRVBW1ziGqSWQAWOg==}
+
+  '@tabler/icons@3.35.0':
+    resolution: {integrity: sha512-yYXe+gJ56xlZFiXwV9zVoe3FWCGuZ/D7/G4ZIlDtGxSx5CGQK110wrnT29gUj52kEZoxqF7oURTk97GQxELOFQ==}
 
   '@testing-library/angular@13.4.0':
     resolution: {integrity: sha512-CPrTMRoWfwQ1ph4SFZ9AONEBkMFBq2Qf3jzF+pnGQGIDEY6p+k6PUDtyn4XFyHqQAjxczSZRMryW12Hd2EFzxA==}
@@ -38042,7 +38053,14 @@ snapshots:
       prop-types: 15.8.1
       react: 19.2.4
 
+  '@tabler/icons-react@3.35.0(react@19.2.4)':
+    dependencies:
+      '@tabler/icons': 3.35.0
+      react: 19.2.4
+
   '@tabler/icons@2.44.0': {}
+
+  '@tabler/icons@3.35.0': {}
 
   '@testing-library/angular@13.4.0(@angular/common@17.1.3(@angular/core@17.1.3(rxjs@7.8.2)(zone.js@0.14.10))(rxjs@7.8.2))(@angular/core@17.1.3(rxjs@7.8.2)(zone.js@0.14.10))(@angular/platform-browser@17.1.3(@angular/animations@17.1.3(@angular/core@17.1.3(rxjs@7.8.2)(zone.js@0.14.10)))(@angular/common@17.1.3(@angular/core@17.1.3(rxjs@7.8.2)(zone.js@0.14.10))(rxjs@7.8.2))(@angular/core@17.1.3(rxjs@7.8.2)(zone.js@0.14.10)))(@angular/router@17.1.3(@angular/common@17.1.3(@angular/core@17.1.3(rxjs@7.8.2)(zone.js@0.14.10))(rxjs@7.8.2))(@angular/core@17.1.3(rxjs@7.8.2)(zone.js@0.14.10))(@angular/platform-browser@17.1.3(@angular/animations@17.1.3(@angular/core@17.1.3(rxjs@7.8.2)(zone.js@0.14.10)))(@angular/common@17.1.3(@angular/core@17.1.3(rxjs@7.8.2)(zone.js@0.14.10))(rxjs@7.8.2))(@angular/core@17.1.3(rxjs@7.8.2)(zone.js@0.14.10)))(rxjs@7.8.2))':
     dependencies:


### PR DESCRIPTION
- span renders border that looks like a Textbox
- border supports forced colors mode for default, focus an disabled
- the icon slots are clickable without JavaScript
- container is `inline-*` like `<input>`, not `display: block`
- focus-visible state is only displayed when the `<input>` has focus, not when any actions have focus
- there are slots that don't change the accessible name: iconStart, iconEnd, actionsStart, actionsEnd
- there are slots nudge folks to choose if something should change the accessible label or description

TODO, for another time perhaps:
Investigate if there should be a `<FormField>` that renders a fieldset but still looks the same, there is a clear group for screenreader users for when there is a combination of `<input>` + `<button>` action, and for `<input>` + `<select>` action.