### PR TITLE
ci: opt in to pnpm v11 for pnpm audit with an environment variable

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -32,6 +32,13 @@ jobs:
           cache: pnpm
 
       - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
+        run: |
+          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
+          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
+
+      - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,13 @@ jobs:
           cache: pnpm
 
       - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
+        run: |
+          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
+          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
+
+      - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical
@@ -58,6 +65,13 @@ jobs:
           cache: pnpm
 
       - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
+        run: |
+          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
+          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
+
+      - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical
@@ -90,6 +104,13 @@ jobs:
           cache: pnpm
 
       - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
+        run: |
+          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
+          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
+
+      - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical
@@ -165,6 +186,13 @@ jobs:
           cache: pnpm
 
       - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
+        run: |
+          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
+          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
+
+      - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical
@@ -207,6 +235,13 @@ jobs:
           cache: pnpm
 
       - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 == '1'
+        run: |
+          echo "Auditing npm dependencies with pnpm v11 before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
+          pnpm dlx pnpm@11.0.0-rc.2 --config.manage-package-manager-versions=false audit --audit-level critical
+
+      - name: Check for known security issues with npm packages
+        if: vars.ENABLE_PNPM_AUDIT_V11 != '1'
         run: |
           echo "Auditing npm dependencies before installing them. For more information, see: https://nldesignsystem.nl/pnpm-audit"
           pnpm audit --audit-level critical


### PR DESCRIPTION
This PR updates the pnpm audit command to use the v11 version of the command.

It only affects the pnpm audit command, and does not affect the other pnpm commands like pnpm install.
You have to opt in to this by setting the `ENABLE_PNPM_AUDIT_V11` environment variable to `1`.
You can choose to do this on the repository level or on the organization level.

See https://github.com/nl-design-system/beheer/issues/70 for more details.