### PR TITLE
fix: remove margin-block-end for label + description

### DIFF
--- a/components/form-field/src/_mixin.scss
+++ b/components/form-field/src/_mixin.scss
@@ -74,6 +74,11 @@
   // padding-block-end: var(--utrecht-form-field-label-margin-block-end);
   margin-block-start: 0;
   order: 1;
+
+  /* If a description follows immediately → remove margin */
+  &:has(+ .utrecht-form-field__description) {
+    margin-block-end: 0;
+  }
 }
 
 @mixin utrecht-form-field__description {


### PR DESCRIPTION
This change removes the margin-block-end of the label when a description is present directly after it, preventing double spacing between label and description.

It uses the :has() selector for contextual styling. In browsers without :has() support, the existing spacing remains unchanged as a graceful fallback.