### PR TITLE
Feat/grid total columns option

### DIFF
--- a/.changeset/green-dogs-swim.md
+++ b/.changeset/green-dogs-swim.md
@@ -1,0 +1,5 @@
+---
+"@utrecht/grid-react": minor
+---
+
+Add `cols` prop to `Grid` component to set the total number of equal-width columns (1–12).

--- a/.changeset/purple-pumas-chew.md
+++ b/.changeset/purple-pumas-chew.md
@@ -1,0 +1,5 @@
+---
+"@utrecht/grid-css": minor
+---
+
+Add `utrecht-grid--cols-{n}` modifier classes (3–12) to set equal-width column counts via CSS custom properties.

--- a/.changeset/purple-pumas-chew.md
+++ b/.changeset/purple-pumas-chew.md
@@ -2,4 +2,4 @@
 "@utrecht/grid-css": minor
 ---
 
-Add `utrecht-grid--cols-{n}` modifier classes (3–12) to set equal-width column counts via CSS custom properties.
+Add `utrecht-grid--cols-{n}` modifier classes (1–12) to set equal-width column counts via CSS custom properties.

--- a/components/grid/README.md
+++ b/components/grid/README.md
@@ -51,6 +51,7 @@ A flexible, responsive grid layout component for the Utrecht Design System with 
 - `utrecht-grid--justify-content-{flex-start|center|flex-end|space-between}` - Horizontal alignment
 - `utrecht-grid--align-items-{flex-start|center|flex-end}` - Vertical alignment
 - `utrecht-grid--flex-direction-{row|column|row-reverse|column-reverse}` - Flex direction
+- `utrecht-grid--cols-{3|4|5|6|7|8|9|10|11|12}` - Set the total column count (3-12 columns)
 
 ### Cell Classes
 
@@ -176,3 +177,25 @@ Integrate with Style Dictionary:
   <div class="utrecht-grid__cell utrecht-grid--xs-4 utrecht-grid--order-2">Second</div>
 </div>
 ```
+
+### Total Column Count
+
+```html
+<div class="utrecht-grid utrecht-grid--cols-5">
+  <div class="utrecht-grid__cell">Column 1 (20%)</div>
+  <div class="utrecht-grid__cell">Column 2 (20%)</div>
+  <div class="utrecht-grid__cell">Column 3 (20%)</div>
+  <div class="utrecht-grid__cell">Column 4 (20%)</div>
+  <div class="utrecht-grid__cell">Column 5 (20%)</div>
+</div>
+```
+
+The total column count feature allows you to create grids with any column count between 3 and 12. Each column will have equal width (100% / column count).
+
+**Available column counts:** 3, 4, 5, 6, 7, 8, 9, 10, 11, 12
+
+**Use cases:**
+
+- Dashboard layouts with equal-width items
+- Data visualization grids
+- Simple content sections with consistent column widths

--- a/components/grid/README.md
+++ b/components/grid/README.md
@@ -51,7 +51,7 @@ A flexible, responsive grid layout component for the Utrecht Design System with 
 - `utrecht-grid--justify-content-{flex-start|center|flex-end|space-between}` - Horizontal alignment
 - `utrecht-grid--align-items-{flex-start|center|flex-end}` - Vertical alignment
 - `utrecht-grid--flex-direction-{row|column|row-reverse|column-reverse}` - Flex direction
-- `utrecht-grid--cols-{3|4|5|6|7|8|9|10|11|12}` - Set the total column count (3-12 columns)
+- `utrecht-grid--cols-{1-12}` - Set the total column count (1-12 columns)
 
 ### Cell Classes
 
@@ -192,7 +192,7 @@ Integrate with Style Dictionary:
 
 The total column count feature allows you to create grids with any column count between 3 and 12. Each column will have equal width (100% / column count).
 
-**Available column counts:** 3, 4, 5, 6, 7, 8, 9, 10, 11, 12
+**Available column counts:** 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12
 
 **Use cases:**
 

--- a/components/grid/src/_mixin.scss
+++ b/components/grid/src/_mixin.scss
@@ -21,9 +21,9 @@
   flex-wrap: var(--_utrecht-grid-flex-wrap, wrap);
   justify-content: var(--_utrecht-grid-justify-content, initial);
 
-  // Generate CSS modifiers for column counts (3-12)
+  // Generate CSS modifiers for column counts (1-12)
   // Each modifier sets the total columns and default column width
-  @for $i from 3 through 12 {
+  @for $i from 1 through 12 {
     &--cols-#{$i} {
       --_utrecht-grid-columns-total: #{$i};
       --_utrecht-grid-columns-default: 1;

--- a/components/grid/src/_mixin.scss
+++ b/components/grid/src/_mixin.scss
@@ -20,6 +20,15 @@
   flex-direction: var(--_utrecht-grid-flex-direction, row);
   flex-wrap: var(--_utrecht-grid-flex-wrap, wrap);
   justify-content: var(--_utrecht-grid-justify-content, initial);
+
+  // Generate CSS modifiers for column counts (3-12)
+  // Each modifier sets the total columns and default column width
+  @for $i from 3 through 12 {
+    &--cols-#{$i} {
+      --_utrecht-grid-columns-total: #{$i};
+      --_utrecht-grid-columns-default: 1;
+    }
+  }
 }
 
 // Cell styles mixin

--- a/packages/components-react/grid-react/src/index.tsx
+++ b/packages/components-react/grid-react/src/index.tsx
@@ -27,7 +27,7 @@ export interface GridProps extends HTMLAttributes<HTMLDivElement> {
   alignItemsMd?: AlignItems;
   alignItemsLg?: AlignItems;
   flexDirection?: FlexDirection;
-  cols?: 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+  cols?: Cols;
 }
 
 export interface GridCellProps extends HTMLAttributes<HTMLDivElement> {
@@ -83,16 +83,7 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
         [`utrecht-grid--align-items-md-${alignItemsMd}`]: alignItemsMd,
         [`utrecht-grid--align-items-lg-${alignItemsLg}`]: alignItemsLg,
         [`utrecht-grid--flex-direction-${flexDirection}`]: flexDirection,
-        'utrecht-grid--cols-3': cols === 3,
-        'utrecht-grid--cols-4': cols === 4,
-        'utrecht-grid--cols-5': cols === 5,
-        'utrecht-grid--cols-6': cols === 6,
-        'utrecht-grid--cols-7': cols === 7,
-        'utrecht-grid--cols-8': cols === 8,
-        'utrecht-grid--cols-9': cols === 9,
-        'utrecht-grid--cols-10': cols === 10,
-        'utrecht-grid--cols-11': cols === 11,
-        'utrecht-grid--cols-12': cols === 12,
+        [`utrecht-grid--cols-${cols}`]: cols,
       })}
       {...props}
     >

--- a/packages/components-react/grid-react/src/index.tsx
+++ b/packages/components-react/grid-react/src/index.tsx
@@ -27,6 +27,7 @@ export interface GridProps extends HTMLAttributes<HTMLDivElement> {
   alignItemsMd?: AlignItems;
   alignItemsLg?: AlignItems;
   flexDirection?: FlexDirection;
+  cols?: 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 }
 
 export interface GridCellProps extends HTMLAttributes<HTMLDivElement> {
@@ -63,6 +64,7 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
       alignItemsMd,
       alignItemsLg,
       flexDirection,
+      cols,
       className,
       ...props
     },
@@ -81,6 +83,16 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
         [`utrecht-grid--align-items-md-${alignItemsMd}`]: alignItemsMd,
         [`utrecht-grid--align-items-lg-${alignItemsLg}`]: alignItemsLg,
         [`utrecht-grid--flex-direction-${flexDirection}`]: flexDirection,
+        'utrecht-grid--cols-3': cols === 3,
+        'utrecht-grid--cols-4': cols === 4,
+        'utrecht-grid--cols-5': cols === 5,
+        'utrecht-grid--cols-6': cols === 6,
+        'utrecht-grid--cols-7': cols === 7,
+        'utrecht-grid--cols-8': cols === 8,
+        'utrecht-grid--cols-9': cols === 9,
+        'utrecht-grid--cols-10': cols === 10,
+        'utrecht-grid--cols-11': cols === 11,
+        'utrecht-grid--cols-12': cols === 12,
       })}
       {...props}
     >

--- a/packages/storybook-css/src/Grid.stories.tsx
+++ b/packages/storybook-css/src/Grid.stories.tsx
@@ -58,17 +58,15 @@ const meta = {
       description: 'Vertical alignment of grid cells',
     },
     cols: {
-      control: {
-        type: 'select',
-        options: [3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
-      },
+      control: 'select',
+      options: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12'],
       description:
-        'Sets the total number of columns in the grid (3-12). Each column will have equal width (100% / cols). Creates a flexible grid where all columns have the same width.',
+        'Sets the total number of columns in the grid (1-12). Each column will have equal width (100% / cols). Creates a flexible grid where all columns have the same width.',
     },
   },
   args: {
     spacing: 'md',
-    cols: 5,
+    cols: 12,
   },
   tags: ['autodocs'],
   parameters: {

--- a/packages/storybook-css/src/Grid.stories.tsx
+++ b/packages/storybook-css/src/Grid.stories.tsx
@@ -57,9 +57,18 @@ const meta = {
       options: ['flex-start', 'center', 'flex-end'],
       description: 'Vertical alignment of grid cells',
     },
+    cols: {
+      control: {
+        type: 'select',
+        options: [3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+      },
+      description:
+        'Sets the total number of columns in the grid (3-12). Each column will have equal width (100% / cols). Creates a flexible grid where all columns have the same width.',
+    },
   },
   args: {
     spacing: 'md',
+    cols: 5,
   },
   tags: ['autodocs'],
   parameters: {
@@ -361,6 +370,56 @@ export const CustomBreakpoints: Story = {
       description: {
         story:
           'This story uses custom breakpoints: sm=400px, md=1024px, lg=1440px (vs defaults: sm=600px, md=960px, lg=1280px). Resize browser to see the difference.',
+      },
+    },
+  },
+};
+
+export const FiveColumns: Story = {
+  name: '5-Column Layout',
+  args: {
+    spacing: 'md',
+    cols: 5,
+    children: (
+      <>
+        <GridColumn color="#ffcccb">Column 1 (20%)</GridColumn>
+        <GridColumn color="#add8e6">Column 2 (20%)</GridColumn>
+        <GridColumn color="#90ee90">Column 3 (20%)</GridColumn>
+        <GridColumn color="#ffd700">Column 4 (20%)</GridColumn>
+        <GridColumn color="#d8bfd8">Column 5 (20%)</GridColumn>
+      </>
+    ),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'This story demonstrates a 5-column layout using the simple cols prop. Each column takes up exactly 20% of the width (100% / 5).',
+      },
+    },
+  },
+};
+
+export const SevenColumns: Story = {
+  name: '7-Column Layout',
+  args: {
+    spacing: 'md',
+    cols: 7,
+    children: (
+      <>
+        {Array.from({ length: 7 }, (_, i) => (
+          <GridColumn key={i} color={['#ffcccb', '#add8e6', '#90ee90', '#ffd700', '#d8bfd8', '#e8f4fd', '#ffe8e8'][i]}>
+            Column {i + 1}
+          </GridColumn>
+        ))}
+      </>
+    ),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'This example shows a 7-column layout. Each column takes up approximately 14.29% of the width (100% / 7).',
       },
     },
   },


### PR DESCRIPTION
Adding CSS modifiers to add the option of setting the total columns of a grid.

## Important Limitations:
- Cannot be set for specific breakpoints

## Use Cases:
- Dashboard layouts with 5 equal items
- Toptasks like https://www.utrecht.nl/zorg-en-onderwijs