### PR TITLE
style: add design token for Toptask Link

### DIFF
--- a/.changeset/top-task-tokens.md
+++ b/.changeset/top-task-tokens.md
@@ -1,0 +1,5 @@
+---
+"@utrecht/top-task-link-css": minor
+---
+
+Add design tokens for `border-radius`, `font-family` and `font-weight`.

--- a/components/toptask-link/src/index.scss
+++ b/components/toptask-link/src/index.scss
@@ -15,6 +15,7 @@
   display: flex;
   flex-direction: column;
   font-size: var(--utrecht-toptask-link-font-size);
+  font-weight: var(--utrecht-toptask-link-font-weight);
   line-height: var(--utrecht-toptask-link-line-height);
   max-inline-size: var(--utrecht-toptask-link-max-inline-size);
   min-block-size: var(--utrecht-toptask-link-min-block-size);

--- a/components/toptask-link/src/index.scss
+++ b/components/toptask-link/src/index.scss
@@ -11,9 +11,11 @@
   --utrecht-icon-size: var(--utrecht-toptask-link-icon-size);
 
   background-color: var(--utrecht-toptask-link-background-color);
+  border-radius: var(--utrecht-toptask-link-border-radius);
   color: var(--utrecht-toptask-link-color);
   display: flex;
   flex-direction: column;
+  font-family: var(--utrecht-toptask-link-font-family);
   font-size: var(--utrecht-toptask-link-font-size);
   font-weight: var(--utrecht-toptask-link-font-weight);
   line-height: var(--utrecht-toptask-link-line-height);

--- a/components/toptask-link/src/tokens.json
+++ b/components/toptask-link/src/tokens.json
@@ -8,12 +8,27 @@
         },
         "$type": "color"
       },
+      "border-radius": {
+        "$extensions": {
+          "nl.nldesignsystem.css-property-syntax": "<length-percentage>",
+          "nl.nldesignsystem.figma-implementation": true
+        },
+        "$type": "dimension"
+      },
       "color": {
         "$extensions": {
           "nl.nldesignsystem.css-property-syntax": "<color>",
           "nl.nldesignsystem.figma-implementation": false
         },
         "$type": "color"
+      },
+      "font-family": {
+        "$extensions": {
+          "nl.nldesignsystem.css-property-syntax": "*",
+          "nl.nldesignsystem.fallback": ["utrecht.document.font-family"],
+          "nl.nldesignsystem.figma-implementation": true
+        },
+        "$type": "fontFamily"
       },
       "font-size": {
         "$extensions": {

--- a/components/toptask-link/src/tokens.json
+++ b/components/toptask-link/src/tokens.json
@@ -22,6 +22,13 @@
         },
         "$type": "dimension"
       },
+      "font-weight": {
+        "$extensions": {
+          "nl.nldesignsystem.css-property-syntax": "<number>",
+          "nl.nldesignsystem.figma-implementation": true
+        },
+        "$type": "fontWeight"
+      },
       "line-height": {
         "$extensions": {
           "nl.nldesignsystem.css-property-syntax": ["<length>", "<number>"],

--- a/components/toptask-link/src/tokens.json
+++ b/components/toptask-link/src/tokens.json
@@ -11,7 +11,7 @@
       "border-radius": {
         "$extensions": {
           "nl.nldesignsystem.css-property-syntax": "<length-percentage>",
-          "nl.nldesignsystem.figma-implementation": true
+          "nl.nldesignsystem.figma-implementation": false
         },
         "$type": "dimension"
       },
@@ -26,7 +26,7 @@
         "$extensions": {
           "nl.nldesignsystem.css-property-syntax": "*",
           "nl.nldesignsystem.fallback": ["utrecht.document.font-family"],
-          "nl.nldesignsystem.figma-implementation": true
+          "nl.nldesignsystem.figma-implementation": false
         },
         "$type": "fontFamily"
       },
@@ -40,7 +40,7 @@
       "font-weight": {
         "$extensions": {
           "nl.nldesignsystem.css-property-syntax": "<number>",
-          "nl.nldesignsystem.figma-implementation": true
+          "nl.nldesignsystem.figma-implementation": false
         },
         "$type": "fontWeight"
       },


### PR DESCRIPTION
Als designer wil ik graag de optie hebben om de font-weight van de Toptask Link te kunnen bepalen, zodat ik de tekst bold kan maken, waardoor deze call-to-actions steviger aanvoelen.

UPDATE: Ik kwam [dit issue tegen](https://github.com/nl-design-system/utrecht/issues/3048) waarbij ook om font-weight werd gevraagd + border-radius + font-family. Dus ik ben zo vrij geweest deze ook direct mee te nemen.