### PR TITLE
Add max-inline-size token for Page Header and Page Footer

### DIFF
--- a/components/page-footer/src/tokens.json
+++ b/components/page-footer/src/tokens.json
@@ -65,6 +65,13 @@
           },
           "$type": "color"
         },
+        "max-inline-size": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<length>",
+            "nl.nldesignsystem.figma-implementation": false
+          },
+          "$type": "dimension"
+        },
         "padding-inline": {
           "$extensions": {
             "nl.nldesignsystem.css-property-syntax": "<length>",

--- a/components/page-header/src/tokens.json
+++ b/components/page-header/src/tokens.json
@@ -65,6 +65,13 @@
           },
           "$type": "color"
         },
+        "max-inline-size": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<length>",
+            "nl.nldesignsystem.figma-implementation": false
+          },
+          "$type": "dimension"
+        },
         "padding-block-start": {
           "$extensions": {
             "nl.nldesignsystem.css-property-syntax": "<length>",


### PR DESCRIPTION
Added design tokens `utrecht.page-header.content.max-inline-size` and `utrecht.page-footer.content.max-inline-size` to the corresponding json files.