### PR TITLE
fix: apply nesting-level modifier classes to React UnorderedList

### DIFF
--- a/.changeset/silly-otters-march.md
+++ b/.changeset/silly-otters-march.md
@@ -1,0 +1,5 @@
+---
+"@utrecht/component-library-react": patch
+---
+
+Fix `UnorderedList` to apply `utrecht-unordered-list--level-{n}` modifier classes based on nesting depth, so that level-specific design tokens (such as marker style and font size) are applied correctly for nested lists (levels 1–8).

--- a/packages/component-library-react/src/UnorderedList.test.tsx
+++ b/packages/component-library-react/src/UnorderedList.test.tsx
@@ -29,6 +29,14 @@ describe('Unordered list', () => {
     expect(list).toHaveClass('utrecht-unordered-list');
   });
 
+  it('renders a level-1 class name', () => {
+    const { container } = render(<UnorderedList />);
+
+    const list = container.querySelector(':only-child');
+
+    expect(list).toHaveClass('utrecht-unordered-list--level-1');
+  });
+
   it('can contain a list item', () => {
     const { container } = render(
       <UnorderedList>
@@ -113,5 +121,50 @@ describe('Unordered list', () => {
     // Check that nested list has the correct class
     const nestedList = nestedLists[1];
     expect(nestedList).toHaveClass('utrecht-unordered-list');
+  });
+
+  it('assigns increasing level classes to nested unordered lists', () => {
+    const { container } = render(
+      <UnorderedList>
+        <UnorderedListItem>
+          Level 1
+          <UnorderedList>
+            <UnorderedListItem>
+              Level 2
+              <UnorderedList>
+                <UnorderedListItem>Level 3</UnorderedListItem>
+              </UnorderedList>
+            </UnorderedListItem>
+          </UnorderedList>
+        </UnorderedListItem>
+      </UnorderedList>,
+    );
+
+    const lists = container.querySelectorAll('ul');
+
+    expect(lists[0]).toHaveClass('utrecht-unordered-list--level-1');
+    expect(lists[1]).toHaveClass('utrecht-unordered-list--level-2');
+    expect(lists[2]).toHaveClass('utrecht-unordered-list--level-3');
+  });
+
+  it('clamps the level class at 8 for deeply nested unordered lists', () => {
+    let tree = <UnorderedListItem>Deepest level</UnorderedListItem>;
+
+    for (let level = 9; level >= 1; level--) {
+      tree = (
+        <UnorderedListItem>
+          <UnorderedList>{tree}</UnorderedList>
+        </UnorderedListItem>
+      );
+    }
+
+    const { container } = render(<UnorderedList>{tree}</UnorderedList>);
+
+    const lists = container.querySelectorAll('ul');
+
+    expect(lists).toHaveLength(10);
+    expect(lists[7]).toHaveClass('utrecht-unordered-list--level-8');
+    expect(lists[8]).toHaveClass('utrecht-unordered-list--level-8');
+    expect(lists[9]).toHaveClass('utrecht-unordered-list--level-8');
   });
 });

--- a/packages/component-library-react/src/UnorderedList.test.tsx
+++ b/packages/component-library-react/src/UnorderedList.test.tsx
@@ -147,6 +147,57 @@ describe('Unordered list', () => {
     expect(lists[2]).toHaveClass('utrecht-unordered-list--level-3');
   });
 
+  it('accepts a level prop that overrides the automatically detected level', () => {
+    const { container } = render(<UnorderedList level={4} />);
+
+    const list = container.querySelector(':only-child');
+
+    expect(list).toHaveClass('utrecht-unordered-list--level-4');
+  });
+
+  it('propagates an overridden level to nested unordered lists', () => {
+    const { container } = render(
+      <UnorderedList level={4}>
+        <UnorderedListItem>
+          Level 4
+          <UnorderedList>
+            <UnorderedListItem>Level 5</UnorderedListItem>
+          </UnorderedList>
+        </UnorderedListItem>
+      </UnorderedList>,
+    );
+
+    const lists = container.querySelectorAll('ul');
+
+    expect(lists[0]).toHaveClass('utrecht-unordered-list--level-4');
+    expect(lists[1]).toHaveClass('utrecht-unordered-list--level-5');
+  });
+
+  it('lets a level prop correct the depth after a non-React list breaks the nesting chain', () => {
+    // Simulates a raw HTML <ul> (not rendered by this component) sitting between two
+    // React-managed lists, which would otherwise leave the inner list's context-derived
+    // level stuck at 2 instead of the visually correct 3.
+    const { container } = render(
+      <UnorderedList>
+        <UnorderedListItem>
+          <ul className="utrecht-unordered-list utrecht-unordered-list--level-2">
+            <li className="utrecht-unordered-list__item">
+              <UnorderedList level={3}>
+                <UnorderedListItem>Deepest item</UnorderedListItem>
+              </UnorderedList>
+            </li>
+          </ul>
+        </UnorderedListItem>
+      </UnorderedList>,
+    );
+
+    const lists = container.querySelectorAll('ul');
+
+    expect(lists[0]).toHaveClass('utrecht-unordered-list--level-1');
+    expect(lists[1]).toHaveClass('utrecht-unordered-list--level-2');
+    expect(lists[2]).toHaveClass('utrecht-unordered-list--level-3');
+  });
+
   it('clamps the level class at 8 for deeply nested unordered lists', () => {
     let tree = <UnorderedListItem>Deepest level</UnorderedListItem>;
 

--- a/packages/component-library-react/src/UnorderedList.tsx
+++ b/packages/component-library-react/src/UnorderedList.tsx
@@ -7,7 +7,14 @@
 import clsx from 'clsx';
 import { createContext, ForwardedRef, forwardRef, HTMLAttributes, PropsWithChildren, useContext } from 'react';
 
-export type UnorderedListProps = HTMLAttributes<HTMLUListElement>;
+export interface UnorderedListProps extends HTMLAttributes<HTMLUListElement> {
+  /**
+   * Overrides the automatically detected nesting level. Use this when a list is nested inside
+   * markup that isn't rendered by this component (e.g. raw HTML or another framework), since the
+   * automatic detection can only count `UnorderedList` ancestors in the React tree.
+   */
+  level?: number;
+}
 
 /** The deepest nesting level for which the design system defines `--level-*` styles */
 const maxUnorderedListLevel = 8;
@@ -16,10 +23,11 @@ export const UnorderedListLevelContext = createContext(1);
 
 export const UnorderedList = forwardRef(
   (
-    { children, className, ...restProps }: PropsWithChildren<UnorderedListProps>,
+    { children, className, level: levelProp, ...restProps }: PropsWithChildren<UnorderedListProps>,
     ref: ForwardedRef<HTMLUListElement>,
   ) => {
-    const level = useContext(UnorderedListLevelContext);
+    const contextLevel = useContext(UnorderedListLevelContext);
+    const level = levelProp ?? contextLevel;
 
     return (
       <ul

--- a/packages/component-library-react/src/UnorderedList.tsx
+++ b/packages/component-library-react/src/UnorderedList.tsx
@@ -5,19 +5,37 @@
  */
 
 import clsx from 'clsx';
-import { ForwardedRef, forwardRef, HTMLAttributes, PropsWithChildren } from 'react';
+import { createContext, ForwardedRef, forwardRef, HTMLAttributes, PropsWithChildren, useContext } from 'react';
 
 export type UnorderedListProps = HTMLAttributes<HTMLUListElement>;
+
+/** The deepest nesting level for which the design system defines `--level-*` styles */
+const maxUnorderedListLevel = 8;
+
+export const UnorderedListLevelContext = createContext(1);
 
 export const UnorderedList = forwardRef(
   (
     { children, className, ...restProps }: PropsWithChildren<UnorderedListProps>,
     ref: ForwardedRef<HTMLUListElement>,
-  ) => (
-    <ul role="list" {...restProps} ref={ref} className={clsx('utrecht-unordered-list', className)}>
-      {children}
-    </ul>
-  ),
+  ) => {
+    const level = useContext(UnorderedListLevelContext);
+
+    return (
+      <ul
+        role="list"
+        {...restProps}
+        ref={ref}
+        className={clsx(
+          'utrecht-unordered-list',
+          `utrecht-unordered-list--level-${Math.min(level, maxUnorderedListLevel)}`,
+          className,
+        )}
+      >
+        <UnorderedListLevelContext.Provider value={level + 1}>{children}</UnorderedListLevelContext.Provider>
+      </ul>
+    );
+  },
 );
 
 UnorderedList.displayName = 'UnorderedList';

--- a/packages/component-library-react/src/index.ts
+++ b/packages/component-library-react/src/index.ts
@@ -224,6 +224,6 @@ export { Textbox } from './Textbox';
 export type { URLDataProps } from './URLData';
 export { URLData } from './URLData';
 export type { UnorderedListProps } from './UnorderedList';
-export { UnorderedList } from './UnorderedList';
+export { UnorderedList, UnorderedListLevelContext } from './UnorderedList';
 export type { UnorderedListItemProps } from './UnorderedListItem';
 export { UnorderedListItem } from './UnorderedListItem';

--- a/packages/storybook-react/src/stories/UnorderedList.stories.tsx
+++ b/packages/storybook-react/src/stories/UnorderedList.stories.tsx
@@ -374,4 +374,30 @@ export const CustomMarkers: Story = {
   },
 };
 
+export const LevelOverride: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Use the `level` prop to correct the nesting level when a list is nested inside markup that this component did not render (e.g. raw HTML or another framework), since the automatic detection can only count `UnorderedList` ancestors in the React tree. Without the override, the inner `UnorderedList` below would incorrectly render as level 2 instead of level 3, colliding with the raw HTML list in between.',
+      },
+    },
+  },
+  render: () => (
+    <UnorderedList>
+      <UnorderedListItem>
+        Level 1 (React)
+        <ul className="utrecht-unordered-list utrecht-unordered-list--level-2">
+          <li className="utrecht-unordered-list__item">
+            Level 2 (raw HTML, not rendered by this component)
+            <UnorderedList level={3}>
+              <UnorderedListItem>Level 3 (React, with an explicit level override)</UnorderedListItem>
+            </UnorderedList>
+          </li>
+        </ul>
+      </UnorderedListItem>
+    </UnorderedList>
+  ),
+};
+
 export const DesignTokens = designTokenStory(meta);

--- a/packages/storybook-react/src/stories/UnorderedList.stories.tsx
+++ b/packages/storybook-react/src/stories/UnorderedList.stories.tsx
@@ -1,12 +1,17 @@
 // performance optimizations are not relevant for story rendering, ignore ESLint
 
-import { Meta, StoryObj } from '@storybook/react-vite';
+import { Decorator, Meta, StoryObj } from '@storybook/react-vite';
 import tokens from '@utrecht/design-tokens/dist/list.mjs';
 import readme from '@utrecht/unordered-list-css/README.md?raw';
 import tokensDefinition from '@utrecht/unordered-list-css/dist/tokens.mjs';
 import React from 'react';
 import { designTokenStory } from './util.js';
-import { UnorderedList, UnorderedListItem } from '../../../component-library-react/src/index.js';
+import {
+  OrderedList,
+  OrderedListItem,
+  UnorderedList,
+  UnorderedListItem,
+} from '../../../component-library-react/src/index.js';
 
 const meta = {
   title: 'React Component/Unordered List',
@@ -44,5 +49,329 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+const createNestedListItem = (depth: number, maxDepth: number): React.ReactNode => (
+  <UnorderedListItem>
+    Dit is diepteniveau {depth} van de list.{' '}
+    {depth < maxDepth && <UnorderedList>{createNestedListItem(depth + 1, maxDepth)}</UnorderedList>}
+  </UnorderedListItem>
+);
+
+export const Nested: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Een genestelde lijst met maximaal 8 niveaus. In de praktijk zullen er waarschijnlijk niet zoveel niveaus zijn, maar het is goed om te weten dat het component hierop voorbereid is.',
+      },
+    },
+  },
+  args: {
+    children: createNestedListItem(1, 8),
+  },
+};
+
+const multilineText = (depth: number) =>
+  `Dit is diepteniveau ${depth} van de list. Deze tekst is langer gemaakt om te testen hoe de component omgaat met meerdere regels tekst op elk niveau. Op deze manier kunnen we zien of de spacing en marker nog steeds correct worden weergegeven, zelfs als de tekst meerdere regels beslaat.`;
+
+const createMultilineNestedListItem = (depth: number, maxDepth: number): React.ReactNode => (
+  <UnorderedListItem>
+    {multilineText(depth)}{' '}
+    {depth < maxDepth && <UnorderedList>{createMultilineNestedListItem(depth + 1, maxDepth)}</UnorderedList>}
+  </UnorderedListItem>
+);
+
+export const NestedMultiline: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Een genestelde lijst met langere tekst (multiline) om te testen hoe de component omgaat met meerdere regels tekst op elk niveau.',
+      },
+    },
+  },
+  args: {
+    children: createMultilineNestedListItem(1, 4),
+  },
+};
+
+export const NestingOrderedAndUnorderedLists: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Geneste lijsten kunnen ook van verschillende types zijn, zoals een ongeordende lijst binnen een geordende lijst binnen een ongeordende lijst. Zolang de juiste HTML-structuur wordt gevolgd, zal het component de juiste styling toepassen op elk niveau.',
+      },
+    },
+  },
+  render: () => (
+    <UnorderedList>
+      <UnorderedListItem>Dit is een ongeordend lijstitem op het hoofdniveau.</UnorderedListItem>
+      <UnorderedListItem>
+        Dit ongeordende lijstitem bevat een geordende lijst:
+        <OrderedList>
+          <OrderedListItem>Dit is een geordend lijstitem.</OrderedListItem>
+          <OrderedListItem>
+            Dit geordende lijstitem bevat weer een ongeordende lijst:
+            <UnorderedList>
+              <UnorderedListItem>
+                Dit is weer een ongeordend lijstitem binnen het geordende lijstitem.
+              </UnorderedListItem>
+            </UnorderedList>
+          </OrderedListItem>
+        </OrderedList>
+      </UnorderedListItem>
+    </UnorderedList>
+  ),
+};
+
+const createNestedHtmlListItem = (depth: number, maxDepth: number): React.ReactNode => (
+  <li>
+    Dit is diepteniveau {depth} van de list.
+    {depth < maxDepth && <ul>{createNestedHtmlListItem(depth + 1, maxDepth)}</ul>}
+  </li>
+);
+
+export const NestingOrderedAndUnorderedListsWithHtmlContent: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Geneste lijsten met verschillende types kunnen ook worden weergegeven met de htmlContent modifier. Dit is handig wanneer u alleen controle heeft over de buitenste `<ul>` template en geen BEM class names kunt toevoegen aan de geneste elementen.',
+      },
+    },
+  },
+  args: {
+    className: 'utrecht-unordered-list--html-content',
+    children: (
+      <li>
+        Dit ongeordende lijstitem bevat een geordende lijst:
+        <ol>
+          <li>
+            Dit is een geordend lijstitem.
+            <ul>
+              <li>Dit is weer een ongeordend lijstitem binnen het geordende lijstitem.</li>
+            </ul>
+          </li>
+          <li>
+            Dit geordende lijstitem bevat weer een ongeordende lijst:
+            <ul>{createNestedHtmlListItem(1, 4)}</ul>
+          </li>
+        </ol>
+      </li>
+    ),
+  },
+};
+
+export const HTMLContent: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Use the `utrecht-unordered-list--html-content` modifier when you only have control over the template for the outer `<ul>` and cannot add BEM class names to the `<li>` elements.',
+      },
+    },
+  },
+  args: {
+    className: 'utrecht-unordered-list--html-content',
+    children: [
+      <li>Alle reisdocumenten (paspoort en ID-kaart) die u nu hebt, ook als ze zijn verlopen.</li>,
+      <li>
+        Een kleurenpasfoto die voldoet aan de eisen voor pasfoto’s. De goedgelijkende pasfoto mag maximaal 6 maanden oud
+        zijn op het moment van de aanvraag.
+      </li>,
+      <li>Een bankpas of contant geld. U betaalt direct bij de aanvraag aan de balie.</li>,
+      <li>
+        Dit is diepteniveau 1 van de list.
+        <ul>{createNestedHtmlListItem(2, 8)}</ul>
+      </li>,
+    ],
+  },
+};
+
+const ContainerWithCenteredText: Decorator = (Story) => <div style={{ textAlign: 'center' }}>{Story()}</div>;
+
+export const Center: Story = {
+  args: {
+    className: 'utrecht-unordered-list--center',
+    children: [
+      <UnorderedListItem>The Quick Brown Fox</UnorderedListItem>,
+      <UnorderedListItem>Jumps</UnorderedListItem>,
+      <UnorderedListItem>Over The Lazy Dog</UnorderedListItem>,
+    ],
+  },
+  decorators: [ContainerWithCenteredText],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '_Unordered list_ moet niet als gecentreerde tekst gebruikt worden worden. Wanneer het niet te vermijden is, dan moeten marker dicht naast de tekst staan, niet in de marge.',
+      },
+    },
+    status: {
+      type: 'WORK IN PROGRESS',
+    },
+  },
+};
+
+export const CenterMultiline: Story = {
+  args: {
+    className: 'utrecht-unordered-list--center',
+    children: [
+      <UnorderedListItem>
+        Centered unordered list with multiline text to test how markers are displayed when text wraps to multiple lines.
+        This is needed to ensure that the spacing and marker alignment remains correct even when the text spans multiple
+        lines.
+      </UnorderedListItem>,
+      <UnorderedListItem>
+        Centered unordered list with multiline text to test how markers are displayed when text wraps to multiple lines.
+        This is needed to ensure that the spacing and marker alignment remains correct even when the text spans multiple
+        lines.
+      </UnorderedListItem>,
+      <UnorderedListItem>
+        Centered unordered list with multiline text to test how markers are displayed when text wraps to multiple lines.
+        This is needed to ensure that the spacing and marker alignment remains correct even when the text spans multiple
+        lines.
+      </UnorderedListItem>,
+    ],
+  },
+  decorators: [ContainerWithCenteredText],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Centered unordered list with multiline text to test how markers are displayed when text wraps to multiple lines.',
+      },
+    },
+    status: {
+      type: 'WORK IN PROGRESS',
+    },
+  },
+};
+
+export const CenterMultilineNested: Story = {
+  args: {
+    className: 'utrecht-unordered-list--center',
+    children: createMultilineNestedListItem(1, 4),
+  },
+  decorators: [ContainerWithCenteredText],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Centered unordered list with multiline text and nested items (4 levels deep) to test how markers and spacing are displayed when text wraps to multiple lines in a nested structure.',
+      },
+    },
+    status: {
+      type: 'WORK IN PROGRESS',
+    },
+  },
+};
+
+const NarrowContainerWithCenteredText: Decorator = (Story) => (
+  <div
+    style={
+      {
+        textAlign: 'center',
+        inlineSize: '50%',
+        borderInlineStart: '1px solid currentColor',
+        borderInlineEnd: '1px solid currentColor',
+        paddingInline: '1em',
+      } as React.CSSProperties
+    }
+  >
+    {Story()}
+  </div>
+);
+
+export const NarrowContainerCenter: Story = {
+  args: {
+    className: 'utrecht-unordered-list--center',
+    children: [
+      <UnorderedListItem>The Quick Brown Fox</UnorderedListItem>,
+      <UnorderedListItem>Jumps</UnorderedListItem>,
+      <UnorderedListItem>Over The Lazy Dog</UnorderedListItem>,
+    ],
+  },
+  decorators: [NarrowContainerWithCenteredText],
+  parameters: {
+    docs: {
+      description: {
+        story: 'De _list item marker_ moet niet te ver van de tekst staan.',
+      },
+    },
+    status: {
+      type: 'WORK IN PROGRESS',
+    },
+  },
+};
+
+export const NarrowContainerCenterLongText: Story = {
+  args: {
+    className: 'utrecht-unordered-list--center',
+    children: [
+      <UnorderedListItem>
+        Alle reisdocumenten (paspoort en ID-kaart) die u nu hebt, ook als ze zijn verlopen. Alle reisdocumenten
+        (paspoort en ID-kaart) die u nu hebt, ook als ze zijn verlopen. Alle reisdocumenten (paspoort en ID-kaart) die u
+        nu hebt, ook als ze zijn verlopen.
+      </UnorderedListItem>,
+      <UnorderedListItem>
+        Een kleurenpasfoto die voldoet aan de eisen voor pasfoto’s. De goedgelijkende pasfoto mag maximaal 6 maanden oud
+        zijn op het moment van de aanvraag. Een kleurenpasfoto die voldoet aan de eisen voor pasfoto’s. De
+        goedgelijkende pasfoto mag maximaal 6 maanden oud zijn op het moment van de aanvraag. Een kleurenpasfoto die
+        voldoet aan de eisen voor pasfoto’s.
+      </UnorderedListItem>,
+      <UnorderedListItem>
+        Een bankpas of contant geld. U betaalt direct bij de aanvraag aan de balie. Een bankpas of contant geld. U
+        betaalt direct bij de aanvraag aan de balie. Een bankpas of contant geld. U betaalt direct bij de aanvraag aan
+        de balie.
+      </UnorderedListItem>,
+      <UnorderedListItem>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+        magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+        pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
+        laborum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+        dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+      </UnorderedListItem>,
+    ],
+  },
+  decorators: [NarrowContainerWithCenteredText],
+  parameters: {
+    docs: {
+      description: {
+        story: 'Lange tekst moet binnen de container passen.',
+      },
+    },
+    status: {
+      type: 'WORK IN PROGRESS',
+    },
+  },
+};
+
+export const CustomMarkers: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Het marker-teken van elk niveau kan worden aangepast met de design tokens `--utrecht-unordered-list-level-{n}-list-style-type`. In dit voorbeeld is de standaardreeks (●○◆◇■□▲△) vervangen door een eigen reeks van gevulde en open symbolen.',
+      },
+    },
+  },
+  args: {
+    children: createNestedListItem(1, 8),
+    style: {
+      '--utrecht-unordered-list-level-1-list-style-type': '"★"',
+      '--utrecht-unordered-list-level-2-list-style-type': '"☆"',
+      '--utrecht-unordered-list-level-3-list-style-type': '"♥"',
+      '--utrecht-unordered-list-level-4-list-style-type': '"♡"',
+      '--utrecht-unordered-list-level-5-list-style-type': '"▼"',
+      '--utrecht-unordered-list-level-6-list-style-type': '"▽"',
+      '--utrecht-unordered-list-level-7-list-style-type': '"✦"',
+      '--utrecht-unordered-list-level-8-list-style-type': '"✧"',
+    } as React.CSSProperties,
+  },
+};
 
 export const DesignTokens = designTokenStory(meta);


### PR DESCRIPTION
The React `UnorderedList` component never applied `utrecht-unordered-list--level-{n}` classes, so level-specific design tokens (marker style, marker font size) had no effect on the outer list or any nested lists.

Track nesting depth via a React context that increments for each nested `UnorderedList`, and apply the corresponding level class (clamped to level 8, the deepest level defined by the CSS). Add Storybook stories covering nested lists, mixed ordered/unordered nesting, and custom per-level markers.

Closes #3168