### PR TITLE
refactor: generate unordered-list level selectors with a Sass loop

### DIFF
--- a/components/unordered-list/src/_mixin.scss
+++ b/components/unordered-list/src/_mixin.scss
@@ -4,6 +4,9 @@
  * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
+// Marker characters for each nesting level, used with `utrecht-unordered-list--level()`
+$utrecht-unordered-list-level-markers: "●", "○", "◆", "◇", "■", "□", "▲", "△" !default;
+
 @mixin utrecht-unordered-list {
   --_utrecht-unordered-list-list-style-type: var(--utrecht-unordered-list-list-style-type, "●");
   --_utrecht-unordered-list-marker-font-size: var(--utrecht-unordered-list-marker-font-size, "1rem");
@@ -71,35 +74,14 @@
   );
 }
 
-// Individual level mixins
-@mixin utrecht-unordered-list--level-1 {
-  @include utrecht-unordered-list--level(1, "●", 1em);
-}
+// Selector suffix matching a `ul` nested `$level` levels deep, e.g. `> li > ul > li > ul` for level 3
+// A repeated child-combinator chain is the only way to express "N levels deep": `:has()` only describes
+// an element's descendants, not how many ancestors lie above it, and `:where()` only groups selectors at
+// zero specificity, it cannot shorten or replace the chain itself.
+@function utrecht-unordered-list-nesting($level) {
+  @if $level <= 1 {
+    @return "";
+  }
 
-@mixin utrecht-unordered-list--level-2 {
-  @include utrecht-unordered-list--level(2, "○", 1em);
-}
-
-@mixin utrecht-unordered-list--level-3 {
-  @include utrecht-unordered-list--level(3, "◆", 1em);
-}
-
-@mixin utrecht-unordered-list--level-4 {
-  @include utrecht-unordered-list--level(4, "◇", 1em);
-}
-
-@mixin utrecht-unordered-list--level-5 {
-  @include utrecht-unordered-list--level(5, "■", 1em);
-}
-
-@mixin utrecht-unordered-list--level-6 {
-  @include utrecht-unordered-list--level(6, "□", 1em);
-}
-
-@mixin utrecht-unordered-list--level-7 {
-  @include utrecht-unordered-list--level(7, "▲", 1em);
-}
-
-@mixin utrecht-unordered-list--level-8 {
-  @include utrecht-unordered-list--level(8, "△", 1em);
+  @return utrecht-unordered-list-nesting($level - 1) + " > li > ul";
 }

--- a/components/unordered-list/src/html/_mixin.scss
+++ b/components/unordered-list/src/html/_mixin.scss
@@ -4,13 +4,14 @@
  * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
+@use "sass:list";
 @use "../mixin" as *;
 
 @mixin utrecht-html-ul {
   ul {
     @include utrecht-unordered-list;
     @include utrecht-unordered-list--distanced;
-    @include utrecht-unordered-list--level-1;
+    @include utrecht-unordered-list--level(1, list.nth($utrecht-unordered-list-level-markers, 1), 1em);
   }
 
   ul > li {
@@ -22,31 +23,9 @@
     @include utrecht-unordered-list__marker;
   }
 
-  ul > li > ul {
-    @include utrecht-unordered-list--level-2;
-  }
-
-  ul > li > ul > li > ul {
-    @include utrecht-unordered-list--level-3;
-  }
-
-  ul > li > ul > li > ul > li > ul {
-    @include utrecht-unordered-list--level-4;
-  }
-
-  ul > li > ul > li > ul > li > ul > li > ul {
-    @include utrecht-unordered-list--level-5;
-  }
-
-  ul > li > ul > li > ul > li > ul > li > ul > li > ul {
-    @include utrecht-unordered-list--level-6;
-  }
-
-  ul > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul {
-    @include utrecht-unordered-list--level-7;
-  }
-
-  ul > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul {
-    @include utrecht-unordered-list--level-8;
+  @for $level from 2 through 8 {
+    ul#{utrecht-unordered-list-nesting($level)} {
+      @include utrecht-unordered-list--level($level, list.nth($utrecht-unordered-list-level-markers, $level), 1em);
+    }
   }
 }

--- a/components/unordered-list/src/index.scss
+++ b/components/unordered-list/src/index.scss
@@ -4,6 +4,7 @@
  * Copyright (c) 2021-2024 Gemeente Utrecht
  */
 
+@use "sass:list";
 @use "./mixin" as *;
 
 .utrecht-unordered-list,
@@ -37,50 +38,10 @@
   @include utrecht-unordered-list__marker;
 }
 
-.utrecht-unordered-list--html-content,
-.utrecht-unordered-list--html-content ol ul,
-.utrecht-unordered-list--level-1 {
-  @include utrecht-unordered-list--level-1;
-}
-
-.utrecht-unordered-list--html-content > li > ul,
-.utrecht-unordered-list--html-content ol ul > li > ul,
-.utrecht-unordered-list--level-2 {
-  @include utrecht-unordered-list--level-2;
-}
-
-.utrecht-unordered-list--html-content > li > ul > li > ul,
-.utrecht-unordered-list--html-content ol ul > li > ul > li > ul,
-.utrecht-unordered-list--level-3 {
-  @include utrecht-unordered-list--level-3;
-}
-
-.utrecht-unordered-list--html-content > li > ul > li > ul > li > ul,
-.utrecht-unordered-list--html-content ol ul > li > ul > li > ul > li > ul,
-.utrecht-unordered-list--level-4 {
-  @include utrecht-unordered-list--level-4;
-}
-
-.utrecht-unordered-list--html-content > li > ul > li > ul > li > ul > li > ul,
-.utrecht-unordered-list--html-content ol ul > li > ul > li > ul > li > ul > li > ul,
-.utrecht-unordered-list--level-5 {
-  @include utrecht-unordered-list--level-5;
-}
-
-.utrecht-unordered-list--html-content > li > ul > li > ul > li > ul > li > ul > li > ul,
-.utrecht-unordered-list--html-content ol ul > li > ul > li > ul > li > ul > li > ul > li > ul,
-.utrecht-unordered-list--level-6 {
-  @include utrecht-unordered-list--level-6;
-}
-
-.utrecht-unordered-list--html-content > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul,
-.utrecht-unordered-list--html-content ol ul > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul,
-.utrecht-unordered-list--level-7 {
-  @include utrecht-unordered-list--level-7;
-}
-
-.utrecht-unordered-list--html-content > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul,
-.utrecht-unordered-list--html-content ol ul > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul > li > ul,
-.utrecht-unordered-list--level-8 {
-  @include utrecht-unordered-list--level-8;
+@for $level from 1 through 8 {
+  .utrecht-unordered-list--html-content#{utrecht-unordered-list-nesting($level)},
+  .utrecht-unordered-list--html-content ol ul#{utrecht-unordered-list-nesting($level)},
+  .utrecht-unordered-list--level-#{$level} {
+    @include utrecht-unordered-list--level($level, list.nth($utrecht-unordered-list-level-markers, $level), 1em);
+  }
 }


### PR DESCRIPTION
Replace the 8 hand-duplicated `--level-N` mixins and selector chains in `_mixin.scss`, `index.scss`, and `html/_mixin.scss` with a shared `utrecht-unordered-list-nesting()` function and `@for` loops. Compiled CSS output is unchanged.