### PR TITLE
feat(accordion): add accordion button typography tokens

### DIFF
--- a/.changeset/accordion-button-typography-tokens.md
+++ b/.changeset/accordion-button-typography-tokens.md
@@ -1,0 +1,6 @@
+---
+"@utrecht/accordion-css": minor
+"@utrecht/design-tokens": minor
+---
+
+Add `utrecht.accordion.button.font-family`, `font-size`, `font-weight` and `line-height` design tokens and apply them on the Accordion button. This lets the button text be themed independently, for example to align it with Heading styling, as requested in #2719. The tokens default to the Button typography, so the default appearance is unchanged.

--- a/components/accordion/src/_mixin.scss
+++ b/components/accordion/src/_mixin.scss
@@ -55,6 +55,10 @@
   --utrecht-button-subtle-border-color: var(--utrecht-accordion-button-border-color);
   --utrecht-button-subtle-border-width: var(--utrecht-accordion-button-border-width);
   --utrecht-button-icon-gap: var(--utrecht-accordion-button-gap, var(--utrecht-space-text-xs));
+  --utrecht-button-font-family: var(--utrecht-accordion-button-font-family);
+  --utrecht-button-subtle-font-size: var(--utrecht-accordion-button-font-size);
+  --utrecht-button-subtle-font-weight: var(--utrecht-accordion-button-font-weight);
+  --utrecht-button-subtle-line-height: var(--utrecht-accordion-button-line-height);
 
   align-items: baseline;
   justify-content: start !important;

--- a/components/accordion/src/tokens.json
+++ b/components/accordion/src/tokens.json
@@ -86,6 +86,34 @@
           },
           "$type": "dimension"
         },
+        "font-family": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "*",
+            "nl.nldesignsystem.figma-implementation": true
+          },
+          "$type": "fontFamily"
+        },
+        "font-size": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<length>",
+            "nl.nldesignsystem.figma-implementation": true
+          },
+          "$type": "dimension"
+        },
+        "font-weight": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<number>",
+            "nl.nldesignsystem.figma-implementation": true
+          },
+          "$type": "fontWeight"
+        },
+        "line-height": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": ["<length>", "<number>"],
+            "nl.nldesignsystem.figma-implementation": true
+          },
+          "$type": "dimension"
+        },
         "gap": {
           "$extensions": {
             "nl.nldesignsystem.css-property-syntax": "<length>",

--- a/proprietary/design-tokens/src/component/utrecht/accordion.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/accordion.tokens.json
@@ -20,6 +20,10 @@
         "color": { "$value": "{utrecht.color.blue.40}" },
         "border-color": { "$value": "transparent" },
         "border-width": { "$value": "0" },
+        "font-family": { "$value": "{utrecht.button.font-family}" },
+        "font-size": { "$value": "{utrecht.button.font-size}" },
+        "font-weight": { "$value": "{utrecht.button.font-weight}" },
+        "line-height": {},
         "gap": {},
         "hover": {
           "background-color": { "$value": "{utrecht.color.grey.95}" },


### PR DESCRIPTION
Adds the four accordion button typography tokens requested in #2719 (`utrecht.accordion.button.font-family`, `font-size`, `font-weight` and `line-height`) and wires them into the button, so the button text can be themed separately from a regular button, for example to line it up with Heading styling.

They default to the Button typography, so nothing changes visually out of the box. `line-height` is left without a default value, like the existing `background-color` and `gap` tokens.

Closes #2719
