### PR TITLE
fix(accordion): apply accordion button icon size token

### DIFF
--- a/.changeset/accordion-button-icon-size.md
+++ b/.changeset/accordion-button-icon-size.md
@@ -2,4 +2,6 @@
 "@utrecht/accordion-css": minor
 ---
 
-Apply the existing `utrecht.accordion.button.icon.size` token. The accordion button icon now reserves its configured size as an inline column and exposes `--utrecht-icon-size` to icon children, so the icon and the panel text line up predictably. Previously the token was defined (and flagged `figma-implementation: true`) but never applied in the CSS.
+Apply the existing `utrecht.accordion.button.icon.size` token. The accordion button icon now reserves its configured size as an inline column and exposes `--utrecht-icon-size` to icon children. Previously the token was defined (and flagged `figma-implementation: true`) but never applied in the CSS.
+
+The icon column also makes the button label line up with the panel content: `padding-inline-start` plus the icon size equals the panel's `padding-inline-start`. The button gap is set through `--utrecht-button-column-gap` (the property the button actually reads) and defaults to `0`, so the label lands exactly on that line instead of overshooting it. The icon is centered within its column, and the unused `utrecht-accordion__button--rtl` mixin has been removed.

--- a/.changeset/accordion-button-icon-size.md
+++ b/.changeset/accordion-button-icon-size.md
@@ -1,0 +1,5 @@
+---
+"@utrecht/accordion-css": minor
+---
+
+Apply the existing `utrecht.accordion.button.icon.size` token. The accordion button icon now reserves its configured size as an inline column and exposes `--utrecht-icon-size` to icon children, so the icon and the panel text line up predictably. Previously the token was defined (and flagged `figma-implementation: true`) but never applied in the CSS.

--- a/components/accordion/src/_mixin.scss
+++ b/components/accordion/src/_mixin.scss
@@ -54,7 +54,11 @@
   --utrecht-button-subtle-focus-color: var(--utrecht-accordion-button-focus-color);
   --utrecht-button-subtle-border-color: var(--utrecht-accordion-button-border-color);
   --utrecht-button-subtle-border-width: var(--utrecht-accordion-button-border-width);
-  --utrecht-button-icon-gap: var(--utrecht-accordion-button-gap, var(--utrecht-space-text-xs));
+
+  /* The button reads `--utrecht-button-column-gap`, so the icon column defines the label offset:
+     button padding-inline-start + icon size lines the label up with the panel's padding-inline-start.
+     Default to 0 so that alignment holds; a theme can still opt into a gap via `--utrecht-accordion-button-gap`. */
+  --utrecht-button-column-gap: var(--utrecht-accordion-button-gap, 0);
 
   align-items: baseline;
   justify-content: start !important;
@@ -72,12 +76,10 @@
 @mixin utrecht-accordion__button-icon {
   --utrecht-icon-size: var(--utrecht-accordion-button-icon-size);
 
+  align-items: center;
   display: flex;
   inline-size: var(--utrecht-accordion-button-icon-size);
-}
-
-@mixin utrecht-accordion__button--rtl {
-  justify-content: end !important;
+  justify-content: center;
 }
 
 @mixin utrecht-accordion__panel {

--- a/components/accordion/src/_mixin.scss
+++ b/components/accordion/src/_mixin.scss
@@ -70,7 +70,10 @@
 }
 
 @mixin utrecht-accordion__button-icon {
+  --utrecht-icon-size: var(--utrecht-accordion-button-icon-size);
+
   display: flex;
+  inline-size: var(--utrecht-accordion-button-icon-size);
 }
 
 @mixin utrecht-accordion__button--rtl {


### PR DESCRIPTION
The `utrecht.accordion.button.icon.size` token already exists (24px, `figma-implementation: true`) but was never applied, so the icon kept its intrinsic size and the panel text couldn't be lined up with the button label. This applies it on `.utrecht-accordion__button-icon` as the icon column width, and exposes `--utrecht-icon-size` to icon children.

Heads up for review: the default chevron in `Accordion.tsx` is a fixed 14x8 SVG, so it doesn't scale with `--utrecht-icon-size`; this mainly gives the icon a predictable column width. Whether to also center the chevron in that column, or make the default SVG scalable, is worth a quick look. I marked the changeset `minor` since it changes the default rendering.
