### PR TITLE
feat(drawer): add header, body and footer parts

### DIFF
--- a/.changeset/drawer-close-button.md
+++ b/.changeset/drawer-close-button.md
@@ -1,0 +1,5 @@
+---
+"@utrecht/drawer-css": minor
+---
+
+Add a `utrecht-drawer__close` class to align a Drawer close button to the inline-end of the header. The Drawer is closed with the native `<dialog>` behaviour: a button in a `<form method="dialog">`, or `HTMLDialogElement.close()`.

--- a/.changeset/drawer-close-button.md
+++ b/.changeset/drawer-close-button.md
@@ -2,4 +2,4 @@
 "@utrecht/drawer-css": minor
 ---
 
-Add a `utrecht-drawer__close` class to align a Drawer close button to the inline-end of the header. The Drawer is closed with the native `<dialog>` behaviour: a button in a `<form method="dialog">`, or `HTMLDialogElement.close()`.
+Add a `utrecht-drawer__header-actions` class to align a Drawer close button to the inline-end of the header. The Drawer is closed with the native `<dialog>` behaviour: a button in a `<form method="dialog">`, or `HTMLDialogElement.close()`.

--- a/.changeset/drawer-header-body-footer.md
+++ b/.changeset/drawer-header-body-footer.md
@@ -1,0 +1,5 @@
+---
+"@utrecht/drawer-css": minor
+---
+
+Add `utrecht-drawer__header`, `utrecht-drawer__body` and `utrecht-drawer__footer` parts to the Drawer, with design tokens for their padding, the body `row-gap`, and the header/footer separator borders (`border-block-end` / `border-block-start`).

--- a/components/drawer/README.md
+++ b/components/drawer/README.md
@@ -3,3 +3,13 @@
 # Drawer
 
 Een paneel aan de zijkant van een scherm, die geopend kan worden voor gerelateerde informatie, formulieren of acties.
+
+## Onderdelen
+
+Een Drawer kan optioneel uit de volgende onderdelen bestaan:
+
+- `utrecht-drawer__header`: de header van de Drawer, doorgaans op een `<header>`, bijvoorbeeld met een titel en een sluitknop, met een optionele scheidingslijn eronder (`border-block-end`). Het onderdeel verzorgt de eigen padding en de rand; de layout van titel en sluitknop bepaalt de consument zelf.
+- `utrecht-drawer__body`: de inhoud van de Drawer, doorgaans op een `<div>`; stapelt onderdelen met `row-gap`.
+- `utrecht-drawer__footer`: de footer van de Drawer, doorgaans op een `<footer>`, bijvoorbeeld met acties, met een optionele scheidingslijn erboven (`border-block-start`).
+
+Geef je de Drawer een header, body of footer, zet dan de eigen padding van de Drawer (`--utrecht-drawer-padding-*`) op `0`. De onderdelen verzorgen dan zelf de ruimte, zodat de scheidingslijnen de volle breedte kunnen beslaan en padding niet dubbel wordt opgeteld.

--- a/components/drawer/README.md
+++ b/components/drawer/README.md
@@ -16,15 +16,15 @@ Geef je de Drawer een header, body of footer, zet dan de eigen padding van de Dr
 
 ## Sluitknop
 
-De header bevat doorgaans een sluitknop. Geef de knop, of het `<form method="dialog">` eromheen, de class `utrecht-drawer__close` om hem naar de inline-end van de header uit te lijnen.
+De header bevat doorgaans een sluitknop. Geef de knop, of het `<form method="dialog">` eromheen, de class `utrecht-drawer__header-actions` om hem naar de inline-end van de header uit te lijnen.
 
 Sluit de Drawer met de standaard `<dialog>`-mogelijkheden: een knop in een `<form method="dialog">` sluit de dialog zonder JavaScript, of gebruik `HTMLDialogElement.close()`.
 
 ```html
 <header class="utrecht-drawer__header">
   <h2>Titel</h2>
-  <form class="utrecht-drawer__close" method="dialog">
-    <button type="submit" aria-label="Sluiten">…</button>
+  <form class="utrecht-drawer__header-actions" method="dialog">
+    <button type="submit">Sluiten</button>
   </form>
 </header>
 ```

--- a/components/drawer/README.md
+++ b/components/drawer/README.md
@@ -13,3 +13,18 @@ Een Drawer kan optioneel uit de volgende onderdelen bestaan:
 - `utrecht-drawer__footer`: de footer van de Drawer, doorgaans op een `<footer>`, bijvoorbeeld met acties, met een optionele scheidingslijn erboven (`border-block-start`).
 
 Geef je de Drawer een header, body of footer, zet dan de eigen padding van de Drawer (`--utrecht-drawer-padding-*`) op `0`. De onderdelen verzorgen dan zelf de ruimte, zodat de scheidingslijnen de volle breedte kunnen beslaan en padding niet dubbel wordt opgeteld.
+
+## Sluitknop
+
+De header bevat doorgaans een sluitknop. Geef de knop, of het `<form method="dialog">` eromheen, de class `utrecht-drawer__close` om hem naar de inline-end van de header uit te lijnen.
+
+Sluit de Drawer met de standaard `<dialog>`-mogelijkheden: een knop in een `<form method="dialog">` sluit de dialog zonder JavaScript, of gebruik `HTMLDialogElement.close()`.
+
+```html
+<header class="utrecht-drawer__header">
+  <h2>Titel</h2>
+  <form class="utrecht-drawer__close" method="dialog">
+    <button type="submit" aria-label="Sluiten">…</button>
+  </form>
+</header>
+```

--- a/components/drawer/src/_mixin.scss
+++ b/components/drawer/src/_mixin.scss
@@ -15,6 +15,8 @@
   border-width: var(--utrecht-drawer-border-width, 0);
   box-sizing: border-box;
   color: var(--utrecht-drawer-color, CanvasText);
+  display: flex;
+  flex-direction: column;
   overflow: auto;
   padding-block-end: var(--utrecht-drawer-padding-block-end);
   padding-block-start: var(--utrecht-drawer-padding-block-start);
@@ -110,6 +112,7 @@
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
+  flex-grow: 1;
   padding-block-end: var(--utrecht-drawer-body-padding-block-end);
   padding-block-start: var(--utrecht-drawer-body-padding-block-start);
   padding-inline-end: var(--utrecht-drawer-body-padding-inline-end);
@@ -128,8 +131,8 @@
   padding-inline-start: var(--utrecht-drawer-footer-padding-inline-start);
 }
 
-@mixin utrecht-drawer__close {
-  /* Align the close button to the inline-end of the header and keep it at its own size. */
+@mixin utrecht-drawer__header-actions {
+  /* Align the header actions (for example a close button) to the inline-end of the header and keep them at their own size. */
   flex-shrink: 0;
   margin-inline-start: auto;
 }

--- a/components/drawer/src/_mixin.scss
+++ b/components/drawer/src/_mixin.scss
@@ -15,8 +15,6 @@
   border-width: var(--utrecht-drawer-border-width, 0);
   box-sizing: border-box;
   color: var(--utrecht-drawer-color, CanvasText);
-  display: flex;
-  flex-direction: column;
   overflow: auto;
   padding-block-end: var(--utrecht-drawer-padding-block-end);
   padding-block-start: var(--utrecht-drawer-padding-block-start);
@@ -24,6 +22,17 @@
   padding-inline-start: var(--utrecht-drawer-padding-inline-start);
   position: fixed;
   z-index: var(--utrecht-drawer-z-index, 1);
+}
+
+/*
+An HTML `<dialog>` keeps its User-Agent `display: none` until it is opened, so the flex
+column layout that stacks the header, body and footer must not live in the base
+`utrecht-drawer` mixin. Apply it only when the Drawer is actually shown, otherwise a
+closed `<dialog class="utrecht-drawer">` would stay visible.
+*/
+@mixin utrecht-drawer--open {
+  display: flex;
+  flex-direction: column;
 }
 
 @mixin utrecht-drawer--html-dialog {

--- a/components/drawer/src/_mixin.scss
+++ b/components/drawer/src/_mixin.scss
@@ -93,3 +93,37 @@
   inset-block-end: 0;
   inset-block-start: auto;
 }
+
+@mixin utrecht-drawer__header {
+  border-block-end-color: var(--utrecht-drawer-header-border-color, currentColor);
+  border-block-end-style: solid;
+  border-block-end-width: var(--utrecht-drawer-header-border-block-end-width, 0);
+  box-sizing: border-box;
+  display: flex;
+  padding-block-end: var(--utrecht-drawer-header-padding-block-end);
+  padding-block-start: var(--utrecht-drawer-header-padding-block-start);
+  padding-inline-end: var(--utrecht-drawer-header-padding-inline-end);
+  padding-inline-start: var(--utrecht-drawer-header-padding-inline-start);
+}
+
+@mixin utrecht-drawer__body {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  padding-block-end: var(--utrecht-drawer-body-padding-block-end);
+  padding-block-start: var(--utrecht-drawer-body-padding-block-start);
+  padding-inline-end: var(--utrecht-drawer-body-padding-inline-end);
+  padding-inline-start: var(--utrecht-drawer-body-padding-inline-start);
+  row-gap: var(--utrecht-drawer-body-row-gap);
+}
+
+@mixin utrecht-drawer__footer {
+  border-block-start-color: var(--utrecht-drawer-footer-border-color, currentColor);
+  border-block-start-style: solid;
+  border-block-start-width: var(--utrecht-drawer-footer-border-block-start-width, 0);
+  box-sizing: border-box;
+  padding-block-end: var(--utrecht-drawer-footer-padding-block-end);
+  padding-block-start: var(--utrecht-drawer-footer-padding-block-start);
+  padding-inline-end: var(--utrecht-drawer-footer-padding-inline-end);
+  padding-inline-start: var(--utrecht-drawer-footer-padding-inline-start);
+}

--- a/components/drawer/src/_mixin.scss
+++ b/components/drawer/src/_mixin.scss
@@ -127,3 +127,9 @@
   padding-inline-end: var(--utrecht-drawer-footer-padding-inline-end);
   padding-inline-start: var(--utrecht-drawer-footer-padding-inline-start);
 }
+
+@mixin utrecht-drawer__close {
+  /* Align the close button to the inline-end of the header and keep it at its own size. */
+  flex-shrink: 0;
+  margin-inline-start: auto;
+}

--- a/components/drawer/src/index.scss
+++ b/components/drawer/src/index.scss
@@ -42,6 +42,6 @@
   @include utrecht-drawer__footer;
 }
 
-.utrecht-drawer__close {
-  @include utrecht-drawer__close;
+.utrecht-drawer__header-actions {
+  @include utrecht-drawer__header-actions;
 }

--- a/components/drawer/src/index.scss
+++ b/components/drawer/src/index.scss
@@ -41,3 +41,7 @@
 .utrecht-drawer__footer {
   @include utrecht-drawer__footer;
 }
+
+.utrecht-drawer__close {
+  @include utrecht-drawer__close;
+}

--- a/components/drawer/src/index.scss
+++ b/components/drawer/src/index.scss
@@ -29,3 +29,15 @@
 .utrecht-drawer--block-end {
   @include utrecht-drawer--block-end;
 }
+
+.utrecht-drawer__header {
+  @include utrecht-drawer__header;
+}
+
+.utrecht-drawer__body {
+  @include utrecht-drawer__body;
+}
+
+.utrecht-drawer__footer {
+  @include utrecht-drawer__footer;
+}

--- a/components/drawer/src/index.scss
+++ b/components/drawer/src/index.scss
@@ -45,3 +45,13 @@
 .utrecht-drawer__header-actions {
   @include utrecht-drawer__header-actions;
 }
+
+/*
+Only lay out the Drawer as a flex column when it is shown, so a closed `<dialog>` keeps its
+User-Agent `display: none`. This matches any element with the class, except an HTML
+`<dialog>` without the `open` attribute, and except an element that is `[hidden]`.
+*/
+.utrecht-drawer--open,
+.utrecht-drawer:not(dialog:not([open]), [hidden]) {
+  @include utrecht-drawer--open;
+}

--- a/components/drawer/src/tokens.json
+++ b/components/drawer/src/tokens.json
@@ -99,6 +99,131 @@
         },
         "$type": "other"
       },
+      "header": {
+        "border-color": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<color>",
+            "nl.nldesignsystem.figma-implementation": false
+          },
+          "$type": "color"
+        },
+        "border-block-end-width": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<length>",
+            "nl.nldesignsystem.figma-implementation": false
+          },
+          "$type": "dimension"
+        },
+        "padding-block-start": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<length>",
+            "nl.nldesignsystem.figma-implementation": false
+          },
+          "$type": "dimension"
+        },
+        "padding-block-end": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<length>",
+            "nl.nldesignsystem.figma-implementation": false
+          },
+          "$type": "dimension"
+        },
+        "padding-inline-start": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<length>",
+            "nl.nldesignsystem.figma-implementation": false
+          },
+          "$type": "dimension"
+        },
+        "padding-inline-end": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<length>",
+            "nl.nldesignsystem.figma-implementation": false
+          },
+          "$type": "dimension"
+        }
+      },
+      "body": {
+        "row-gap": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<length>",
+            "nl.nldesignsystem.figma-implementation": false
+          },
+          "$type": "dimension"
+        },
+        "padding-block-start": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<length>",
+            "nl.nldesignsystem.figma-implementation": false
+          },
+          "$type": "dimension"
+        },
+        "padding-block-end": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<length>",
+            "nl.nldesignsystem.figma-implementation": false
+          },
+          "$type": "dimension"
+        },
+        "padding-inline-start": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<length>",
+            "nl.nldesignsystem.figma-implementation": false
+          },
+          "$type": "dimension"
+        },
+        "padding-inline-end": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<length>",
+            "nl.nldesignsystem.figma-implementation": false
+          },
+          "$type": "dimension"
+        }
+      },
+      "footer": {
+        "border-color": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<color>",
+            "nl.nldesignsystem.figma-implementation": false
+          },
+          "$type": "color"
+        },
+        "border-block-start-width": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<length>",
+            "nl.nldesignsystem.figma-implementation": false
+          },
+          "$type": "dimension"
+        },
+        "padding-block-start": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<length>",
+            "nl.nldesignsystem.figma-implementation": false
+          },
+          "$type": "dimension"
+        },
+        "padding-block-end": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<length>",
+            "nl.nldesignsystem.figma-implementation": false
+          },
+          "$type": "dimension"
+        },
+        "padding-inline-start": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<length>",
+            "nl.nldesignsystem.figma-implementation": false
+          },
+          "$type": "dimension"
+        },
+        "padding-inline-end": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<length>",
+            "nl.nldesignsystem.figma-implementation": false
+          },
+          "$type": "dimension"
+        }
+      },
       "backdrop": {
         "min-size": {
           "$extensions": {

--- a/packages/storybook-css/src/Drawer.stories.tsx
+++ b/packages/storybook-css/src/Drawer.stories.tsx
@@ -152,11 +152,13 @@ export const HeaderBodyFooter: Story = {
       '--utrecht-drawer-footer-padding-inline-start': '24px',
     } as React.CSSProperties,
     children: [
-      <header className="utrecht-drawer__header" key="header" style={{ justifyContent: 'space-between' }}>
+      <header className="utrecht-drawer__header" key="header">
         <Heading1>Drawer title</Heading1>
-        <button aria-label="Sluiten" type="button">
-          &times;
-        </button>
+        <form className="utrecht-drawer__close" method="dialog">
+          <button aria-label="Sluiten" type="submit">
+            &times;
+          </button>
+        </form>
       </header>,
       <div className="utrecht-drawer__body" key="body">
         <Paragraph>

--- a/packages/storybook-css/src/Drawer.stories.tsx
+++ b/packages/storybook-css/src/Drawer.stories.tsx
@@ -123,4 +123,54 @@ export const OverflowY: Story = {
   name: 'Overflow Y',
 };
 
+export const HeaderBodyFooter: Story = {
+  args: {
+    align: 'inline-start',
+    open: true,
+    // The Utrecht theme has no values for the new slot tokens yet, so the demo sets them inline.
+    style: {
+      '--utrecht-drawer-padding-block-end': '0',
+      '--utrecht-drawer-padding-block-start': '0',
+      '--utrecht-drawer-padding-inline-end': '0',
+      '--utrecht-drawer-padding-inline-start': '0',
+      '--utrecht-drawer-header-border-block-end-width': '1px',
+      '--utrecht-drawer-header-border-color': '#bcbcbc',
+      '--utrecht-drawer-header-padding-block-end': '0',
+      '--utrecht-drawer-header-padding-block-start': '24px',
+      '--utrecht-drawer-header-padding-inline-end': '24px',
+      '--utrecht-drawer-header-padding-inline-start': '24px',
+      '--utrecht-drawer-body-padding-block-end': '24px',
+      '--utrecht-drawer-body-padding-block-start': '16px',
+      '--utrecht-drawer-body-padding-inline-end': '24px',
+      '--utrecht-drawer-body-padding-inline-start': '24px',
+      '--utrecht-drawer-body-row-gap': '16px',
+      '--utrecht-drawer-footer-border-block-start-width': '1px',
+      '--utrecht-drawer-footer-border-color': '#bcbcbc',
+      '--utrecht-drawer-footer-padding-block-end': '24px',
+      '--utrecht-drawer-footer-padding-block-start': '0',
+      '--utrecht-drawer-footer-padding-inline-end': '24px',
+      '--utrecht-drawer-footer-padding-inline-start': '24px',
+    } as React.CSSProperties,
+    children: [
+      <header className="utrecht-drawer__header" key="header" style={{ justifyContent: 'space-between' }}>
+        <Heading1>Drawer title</Heading1>
+        <button aria-label="Sluiten" type="button">
+          &times;
+        </button>
+      </header>,
+      <div className="utrecht-drawer__body" key="body">
+        <Paragraph>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua.
+        </Paragraph>
+        <Paragraph>Een tweede alinea om de row-gap tussen de onderdelen van de body te tonen.</Paragraph>
+      </div>,
+      <footer className="utrecht-drawer__footer" key="footer">
+        <button type="button">Actie</button>
+      </footer>,
+    ],
+  },
+  name: 'Header, body and footer',
+};
+
 export const DesignTokens = designTokenStory(meta);

--- a/packages/storybook-css/src/Drawer.stories.tsx
+++ b/packages/storybook-css/src/Drawer.stories.tsx
@@ -154,10 +154,8 @@ export const HeaderBodyFooter: Story = {
     children: [
       <header className="utrecht-drawer__header" key="header">
         <Heading1>Drawer title</Heading1>
-        <form className="utrecht-drawer__close" method="dialog">
-          <button aria-label="Sluiten" type="submit">
-            &times;
-          </button>
+        <form className="utrecht-drawer__header-actions" method="dialog">
+          <button type="submit">Sluiten</button>
         </form>
       </header>,
       <div className="utrecht-drawer__body" key="body">


### PR DESCRIPTION
Closes #2478

Adds optional `utrecht-drawer__header`, `utrecht-drawer__body` and `utrecht-drawer__footer` parts to the Drawer, plus a `utrecht-drawer__close` class for the close button. A drawer can have a header (for example a title and a close button) and a footer (for example actions) with separator lines, and a body that stacks its content.

## Changes

- **CSS**: new `.utrecht-drawer__header`, `.utrecht-drawer__body`, `.utrecht-drawer__footer` and `.utrecht-drawer__close` classes (mixins in `_mixin.scss`). The header and footer carry an optional separator border (`border-block-end` / `border-block-start`); the body stacks its children with `row-gap`; `__close` aligns a close button to the inline-end of the header (`margin-inline-start: auto`).
- **Design tokens**: `utrecht.drawer.header/body/footer.*` (4-sided padding per part, the body `row-gap`, and the header/footer separator border color + width).
- **README**: documents the parts, the recommended semantic elements (`<header>` / `<footer>`), that the drawer's own padding should be set to `0` when using the parts (so the parts own the spacing and the separators can span the full width), and the close button (native `<dialog>` close via a button in a `<form method="dialog">`, or `HTMLDialogElement.close()`).
- **Story**: a `Header, body and footer` story in the CSS Storybook, including the close button.

Additive and non-breaking: the existing `.utrecht-drawer` is unchanged and the parts are optional. The web component picks up the parts automatically (it consumes `@utrecht/drawer-css`). The design tokens are metadata-only (`figma-implementation: false`); their values come from the consuming theme.
