### PR TITLE
feat(drawer): add close button alignment class

### DIFF
--- a/.changeset/drawer-close-button.md
+++ b/.changeset/drawer-close-button.md
@@ -1,0 +1,5 @@
+---
+"@utrecht/drawer-css": minor
+---
+
+Add a `utrecht-drawer__close` class to align a Drawer close button to the inline-end of the header. The Drawer is closed with the native `<dialog>` behaviour: a button in a `<form method="dialog">`, or `HTMLDialogElement.close()`.

--- a/components/drawer/README.md
+++ b/components/drawer/README.md
@@ -13,3 +13,18 @@ Een Drawer kan optioneel uit de volgende onderdelen bestaan:
 - `utrecht-drawer__footer`: de footer van de Drawer, doorgaans op een `<footer>`, bijvoorbeeld met acties, met een optionele scheidingslijn erboven (`border-block-start`).
 
 Geef je de Drawer een header, body of footer, zet dan de eigen padding van de Drawer (`--utrecht-drawer-padding-*`) op `0`. De onderdelen verzorgen dan zelf de ruimte, zodat de scheidingslijnen de volle breedte kunnen beslaan en padding niet dubbel wordt opgeteld.
+
+## Sluitknop
+
+De header bevat doorgaans een sluitknop. Geef de knop, of het `<form method="dialog">` eromheen, de class `utrecht-drawer__close` om hem naar de inline-end van de header uit te lijnen.
+
+Sluit de Drawer met de standaard `<dialog>`-mogelijkheden: een knop in een `<form method="dialog">` sluit de dialog zonder JavaScript, of gebruik `HTMLDialogElement.close()`.
+
+```html
+<header class="utrecht-drawer__header">
+  <h2>Titel</h2>
+  <form class="utrecht-drawer__close" method="dialog">
+    <button type="submit" aria-label="Sluiten">…</button>
+  </form>
+</header>
+```

--- a/components/drawer/src/_mixin.scss
+++ b/components/drawer/src/_mixin.scss
@@ -127,3 +127,9 @@
   padding-inline-end: var(--utrecht-drawer-footer-padding-inline-end);
   padding-inline-start: var(--utrecht-drawer-footer-padding-inline-start);
 }
+
+@mixin utrecht-drawer__close {
+  /* Align the close button to the inline-end of the header and keep it at its own size. */
+  flex-shrink: 0;
+  margin-inline-start: auto;
+}

--- a/components/drawer/src/index.scss
+++ b/components/drawer/src/index.scss
@@ -41,3 +41,7 @@
 .utrecht-drawer__footer {
   @include utrecht-drawer__footer;
 }
+
+.utrecht-drawer__close {
+  @include utrecht-drawer__close;
+}

--- a/packages/storybook-css/src/Drawer.stories.tsx
+++ b/packages/storybook-css/src/Drawer.stories.tsx
@@ -152,11 +152,13 @@ export const HeaderBodyFooter: Story = {
       '--utrecht-drawer-footer-padding-inline-start': '24px',
     } as React.CSSProperties,
     children: [
-      <header className="utrecht-drawer__header" key="header" style={{ justifyContent: 'space-between' }}>
+      <header className="utrecht-drawer__header" key="header">
         <Heading1>Drawer title</Heading1>
-        <button aria-label="Sluiten" type="button">
-          &times;
-        </button>
+        <form className="utrecht-drawer__close" method="dialog">
+          <button aria-label="Sluiten" type="submit">
+            &times;
+          </button>
+        </form>
       </header>,
       <div className="utrecht-drawer__body" key="body">
         <Paragraph>


### PR DESCRIPTION
Closes #2478

Adds a `utrecht-drawer__close` class to align a Drawer close button to the inline-end of the header (`margin-inline-start: auto` + `flex-shrink: 0`), so the title and close button lay out without the header itself imposing a `justify-content`.

Closing the Drawer uses the native `<dialog>` behaviour: a button in a `<form method="dialog">` closes it without JavaScript, or `HTMLDialogElement.close()`. The README documents the pattern and the CSS Storybook story shows it.

Stacked on #3176 (the header, body and footer parts), since the close button lives in the header.
