### PR TITLE
fix(accordion): wire accordion button border-radius token

### DIFF
--- a/.changeset/accordion-button-border-radius.md
+++ b/.changeset/accordion-button-border-radius.md
@@ -1,0 +1,6 @@
+---
+"@utrecht/accordion-css": minor
+"@utrecht/design-tokens": minor
+---
+
+Wire the existing `utrecht.accordion.button.border-radius` token. The token was declared in the Accordion schema (`figma-implementation: true`) but had no value and was never applied, so the accordion button's radius was locked to the global `--utrecht-button-border-radius` with no way to set it separately. In themes with a non-zero button radius, that rounding showed on the subtle button's hover and focus background across the full-width row. The token now controls the button radius and defaults to the button radius, so the default appearance is unchanged while themes can give the accordion button its own radius.

--- a/components/accordion/src/_mixin.scss
+++ b/components/accordion/src/_mixin.scss
@@ -54,6 +54,7 @@
   --utrecht-button-subtle-focus-color: var(--utrecht-accordion-button-focus-color);
   --utrecht-button-subtle-border-color: var(--utrecht-accordion-button-border-color);
   --utrecht-button-subtle-border-width: var(--utrecht-accordion-button-border-width);
+  --utrecht-button-border-radius: var(--utrecht-accordion-button-border-radius);
   --utrecht-button-icon-gap: var(--utrecht-accordion-button-gap, var(--utrecht-space-text-xs));
   --utrecht-button-font-family: var(--utrecht-accordion-button-font-family);
   --utrecht-button-subtle-font-size: var(--utrecht-accordion-button-font-size);

--- a/proprietary/design-tokens/src/component/utrecht/accordion.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/accordion.tokens.json
@@ -19,6 +19,7 @@
         "background-color": {},
         "color": { "$value": "{utrecht.color.blue.40}" },
         "border-color": { "$value": "transparent" },
+        "border-radius": { "$value": "{utrecht.button.border-radius}" },
         "border-width": { "$value": "0" },
         "font-family": { "$value": "{utrecht.button.font-family}" },
         "font-size": { "$value": "{utrecht.button.font-size}" },


### PR DESCRIPTION
The `utrecht.accordion.button.border-radius` token is declared in the Accordion schema (`figma-implementation: true`) but had no value and was never applied, so the accordion button's radius was locked to the global `--utrecht-button-border-radius` with no way to set it separately. In themes with a non-zero button radius, that rounding showed on the subtle button's hover and focus background across the full-width row.

## Changes
- **CSS** (`@utrecht/accordion-css`): map `--utrecht-button-border-radius` to `--utrecht-accordion-button-border-radius` in the `utrecht-accordion__button` mixin, next to the existing `--utrecht-button-subtle-border-*` mappings.
- **Tokens** (`@utrecht/design-tokens`): give `utrecht.accordion.button.border-radius` a default of `{utrecht.button.border-radius}`, so the accordion button follows the theme's button radius by default and can be set independently.

Default appearance is unchanged (the Utrecht button radius is `0`). This is the upstream version of nl-design-system/rijkshuisstijl-community#2703.