### PR TITLE
feat(textbox): add hover state tokens

### DIFF
--- a/.changeset/stupid-eyes-drive.md
+++ b/.changeset/stupid-eyes-drive.md
@@ -1,0 +1,6 @@
+---
+"@utrecht/textbox-react": minor
+"@utrecht/textbox-css": minor
+---
+
+Add `utrecht-textbox--hover` class name and mixin.

--- a/.changeset/textbox-hover-tokens.md
+++ b/.changeset/textbox-hover-tokens.md
@@ -1,0 +1,6 @@
+---
+"@utrecht/textbox-css": minor
+"@utrecht/design-tokens": patch
+---
+
+Add `utrecht.textbox.hover.background-color`, `utrecht.textbox.hover.border-color` and `utrecht.textbox.hover.color` design tokens and apply them on the Textbox `:hover` state, as requested in #2716 for all form controls. The tokens are empty by default and fall back to the existing Textbox and Form Control tokens, so the default appearance is unchanged. Disabled and read-only states keep precedence over hover.

--- a/components/textbox/src/_mixin.scss
+++ b/components/textbox/src/_mixin.scss
@@ -202,6 +202,27 @@ $utrecht-support-prince-xml: false !default;
   @include utrecht-focus-visible;
 }
 
+@mixin utrecht-textbox--hover {
+  background-color: var(
+    --utrecht-textbox-hover-background-color,
+    var(
+      --utrecht-form-control-hover-background-color,
+      var(--utrecht-textbox-background-color, var(--utrecht-form-control-background-color))
+    )
+  );
+  border-color: var(
+    --utrecht-textbox-hover-border-color,
+    var(
+      --utrecht-form-control-hover-border-color,
+      var(--utrecht-textbox-border-color, var(--utrecht-form-control-border-color))
+    )
+  );
+  color: var(
+    --utrecht-textbox-hover-color,
+    var(--utrecht-form-control-hover-color, var(--utrecht-textbox-color, var(--utrecht-form-control-color)))
+  );
+}
+
 @mixin utrecht-textbox--read-only {
   background-color: var(
     --utrecht-textbox-read-only-background-color,
@@ -265,6 +286,12 @@ $utrecht-support-prince-xml: false !default;
 }
 
 @mixin utrecht-textbox--html-input {
+  /* `:hover` is declared before the other states, so that with equal specificity
+   * `:focus`, `:user-invalid`, `:read-only` and `:disabled` take precedence over `:hover`. */
+  &:hover {
+    @include utrecht-textbox--hover;
+  }
+
   &:focus {
     @include utrecht-textbox--focus;
   }

--- a/components/textbox/src/index.scss
+++ b/components/textbox/src/index.scss
@@ -19,6 +19,10 @@
   @include utrecht-textbox--disabled;
 }
 
+.utrecht-textbox--hover {
+  @include utrecht-textbox--hover;
+}
+
 .utrecht-textbox--focus {
   @include utrecht-focus;
   @include utrecht-textbox--focus;

--- a/components/textbox/src/tokens.json
+++ b/components/textbox/src/tokens.json
@@ -193,6 +193,44 @@
           "$type": "color"
         }
       },
+      "hover": {
+        "background-color": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<color>",
+            "nl.nldesignsystem.fallback": [
+              "utrecht.form-control.hover.background-color",
+              "utrecht.textbox.background-color",
+              "utrecht.form-control.background-color"
+            ],
+            "nl.nldesignsystem.figma-implementation": true
+          },
+          "$type": "color"
+        },
+        "border-color": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<color>",
+            "nl.nldesignsystem.fallback": [
+              "utrecht.form-control.hover.border-color",
+              "utrecht.textbox.border-color",
+              "utrecht.form-control.border-color"
+            ],
+            "nl.nldesignsystem.figma-implementation": true
+          },
+          "$type": "color"
+        },
+        "color": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<color>",
+            "nl.nldesignsystem.fallback": [
+              "utrecht.form-control.hover.color",
+              "utrecht.textbox.color",
+              "utrecht.form-control.color"
+            ],
+            "nl.nldesignsystem.figma-implementation": true
+          },
+          "$type": "color"
+        }
+      },
       "invalid": {
         "background-color": {
           "$extensions": {

--- a/proprietary/design-tokens/src/component/utrecht/textbox.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/textbox.tokens.json
@@ -1,7 +1,12 @@
 {
   "utrecht": {
     "textbox": {
-      "border-bottom-width": { "$value": "3px" }
+      "border-bottom-width": { "$value": "3px" },
+      "hover": {
+        "background-color": {},
+        "border-color": {},
+        "color": {}
+      }
     }
   }
 }


### PR DESCRIPTION
Adds `utrecht.textbox.hover.{background-color,border-color,color}` and applies them on `:hover`, placed before the other states in source order so focus, invalid, read-only and disabled keep precedence. The fallback chain includes the shared `--utrecht-form-control-hover-*` layer that the Select already uses, so a theme can style hover for all form controls in one place: `textbox-hover → form-control-hover → textbox → form-control`. The tokens have no default value, so the default appearance is unchanged.

Scope note: #2716 mentions `hover.background-color` and `hover.color`; this also adds `hover.border-color`, since a border color change is the most common hover treatment for form controls.

Part of #2716.