### PR TITLE
feat(textarea): add hover state tokens

### DIFF
--- a/.changeset/gentle-panthers-accept.md
+++ b/.changeset/gentle-panthers-accept.md
@@ -1,0 +1,6 @@
+---
+"@utrecht/textarea-react": minor
+"@utrecht/textarea-css": minor
+---
+
+Add `utrecht-textarea--hover` mixin and class name.

--- a/.changeset/textarea-hover-tokens.md
+++ b/.changeset/textarea-hover-tokens.md
@@ -1,0 +1,6 @@
+---
+"@utrecht/textarea-css": minor
+"@utrecht/design-tokens": patch
+---
+
+Add `utrecht.textarea.hover.background-color`, `utrecht.textarea.hover.border-color` and `utrecht.textarea.hover.color` design tokens and apply them on the Textarea `:hover` state, as requested in #2716 for all form controls. The tokens are empty by default and fall back to the existing Textarea and Form Control tokens, so the default appearance is unchanged. Disabled and read-only states keep precedence over hover.

--- a/components/textarea/src/_mixin.scss
+++ b/components/textarea/src/_mixin.scss
@@ -150,6 +150,27 @@ $utrecht-support-prince-xml: false !default;
   @include utrecht-focus-visible;
 }
 
+@mixin utrecht-textarea--hover {
+  background-color: var(
+    --utrecht-textarea-hover-background-color,
+    var(
+      --utrecht-form-control-hover-background-color,
+      var(--utrecht-textarea-background-color, var(--utrecht-form-control-background-color))
+    )
+  );
+  border-color: var(
+    --utrecht-textarea-hover-border-color,
+    var(
+      --utrecht-form-control-hover-border-color,
+      var(--utrecht-textarea-border-color, var(--utrecht-form-control-border-color))
+    )
+  );
+  color: var(
+    --utrecht-textarea-hover-color,
+    var(--utrecht-form-control-hover-color, var(--utrecht-textarea-color, var(--utrecht-form-control-color)))
+  );
+}
+
 @mixin utrecht-textarea--read-only {
   background-color: var(
     --utrecht-textarea-read-only-background-color,
@@ -181,6 +202,12 @@ $utrecht-support-prince-xml: false !default;
 }
 
 @mixin utrecht-textarea--html-textarea {
+  /* `:hover` is declared before the other states, so that with equal specificity
+   * `:focus`, `:invalid`, `:read-only` and `:disabled` take precedence over `:hover`. */
+  &:hover {
+    @include utrecht-textarea--hover;
+  }
+
   &:focus {
     @include utrecht-textarea--focus;
   }

--- a/components/textarea/src/index.scss
+++ b/components/textarea/src/index.scss
@@ -15,6 +15,10 @@
   @include utrecht-textarea--invalid;
 }
 
+.utrecht-textarea--hover {
+  @include utrecht-textarea--hover;
+}
+
 .utrecht-textarea--disabled {
   @include utrecht-textarea--disabled;
 }

--- a/components/textarea/src/tokens.json
+++ b/components/textarea/src/tokens.json
@@ -238,6 +238,44 @@
           "$type": "color"
         }
       },
+      "hover": {
+        "background-color": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<color>",
+            "nl.nldesignsystem.fallback": [
+              "utrecht.form-control.hover.background-color",
+              "utrecht.textarea.background-color",
+              "utrecht.form-control.background-color"
+            ],
+            "nl.nldesignsystem.figma-implementation": true
+          },
+          "$type": "color"
+        },
+        "border-color": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<color>",
+            "nl.nldesignsystem.fallback": [
+              "utrecht.form-control.hover.border-color",
+              "utrecht.textarea.border-color",
+              "utrecht.form-control.border-color"
+            ],
+            "nl.nldesignsystem.figma-implementation": true
+          },
+          "$type": "color"
+        },
+        "color": {
+          "$extensions": {
+            "nl.nldesignsystem.css-property-syntax": "<color>",
+            "nl.nldesignsystem.fallback": [
+              "utrecht.form-control.hover.color",
+              "utrecht.textarea.color",
+              "utrecht.form-control.color"
+            ],
+            "nl.nldesignsystem.figma-implementation": true
+          },
+          "$type": "color"
+        }
+      },
       "invalid": {
         "background-color": {
           "$extensions": {

--- a/proprietary/design-tokens/src/component/utrecht/textarea.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/textarea.tokens.json
@@ -8,6 +8,11 @@
         "border-color": {},
         "color": {}
       },
+      "hover": {
+        "background-color": {},
+        "border-color": {},
+        "color": {}
+      },
       "invalid": {
         "border-color": {},
         "border-width": {}


### PR DESCRIPTION
Adds `utrecht.textarea.hover.{background-color,border-color,color}` and applies them on `:hover`, before the other states in source order so focus, invalid, read-only and disabled keep precedence. Same approach as the Textbox equivalent, including the shared `--utrecht-form-control-hover-*` fallback layer that the Select already uses: `textarea-hover → form-control-hover → textarea → form-control`. The tokens have no default value, so the default appearance is unchanged.

Scope note: #2716 mentions `hover.background-color` and `hover.color`; this also adds `hover.border-color`.

Part of #2716.