### PR TITLE
feat(checkbox): add checked and indeterminate hover and active state tokens

### DIFF
--- a/.changeset/checkbox-checked-state-tokens.md
+++ b/.changeset/checkbox-checked-state-tokens.md
@@ -1,0 +1,7 @@
+---
+"@utrecht/checkbox-css": minor
+"@utrecht/custom-checkbox-css": minor
+"@utrecht/design-tokens": patch
+---
+
+Add `utrecht.checkbox.checked.hover`, `utrecht.checkbox.checked.active`, `utrecht.checkbox.indeterminate.hover` and `utrecht.checkbox.indeterminate.active` design tokens (each with `background-color`, `border-color`, `border-width` and `color`) and apply them on the custom checkbox, so the checked and indeterminate states can be themed for hover and active interaction, as requested in #2716. The tokens are empty by default and fall back to the existing checked and indeterminate tokens, so the default appearance is unchanged. Disabled checkboxes keep precedence over hover and active.

--- a/.changeset/checkbox-checked-state-tokens.md
+++ b/.changeset/checkbox-checked-state-tokens.md
@@ -5,3 +5,5 @@
 ---
 
 Add `utrecht.checkbox.checked.hover`, `utrecht.checkbox.checked.active`, `utrecht.checkbox.indeterminate.hover` and `utrecht.checkbox.indeterminate.active` design tokens (each with `background-color`, `border-color`, `border-width` and `color`) and apply them on the custom checkbox, so the checked and indeterminate states can be themed for hover and active interaction, as requested in #2716. The tokens are empty by default and fall back to the existing checked and indeterminate tokens, so the default appearance is unchanged. Disabled checkboxes keep precedence over hover and active.
+
+Each new state also gets a matching modifier class (`utrecht-checkbox--checked-hover`, `utrecht-checkbox--checked-active`, `utrecht-checkbox--indeterminate-hover` and `utrecht-checkbox--indeterminate-active`), to be combined with `utrecht-checkbox--checked` or `utrecht-checkbox--indeterminate`, so the checked and indeterminate hover and active states can also be rendered without user interaction.

--- a/components/checkbox/src/tokens.json
+++ b/components/checkbox/src/tokens.json
@@ -218,6 +218,80 @@
             "nl.nldesignsystem.figma-implementation": true
           },
           "$type": "color"
+        },
+        "hover": {
+          "border-color": {
+            "$extensions": {
+              "nl.nldesignsystem.css-property-syntax": "<color>",
+              "nl.nldesignsystem.fallback": ["utrecht.checkbox.checked.border-color", "utrecht.checkbox.border-color"],
+              "nl.nldesignsystem.figma-implementation": true
+            },
+            "$type": "color"
+          },
+          "border-width": {
+            "$extensions": {
+              "nl.nldesignsystem.css-property-syntax": "<length>",
+              "nl.nldesignsystem.fallback": ["utrecht.checkbox.checked.border-width", "utrecht.checkbox.border-width"],
+              "nl.nldesignsystem.figma-implementation": true
+            },
+            "$type": "dimension"
+          },
+          "background-color": {
+            "$extensions": {
+              "nl.nldesignsystem.css-property-syntax": "<color>",
+              "nl.nldesignsystem.fallback": [
+                "utrecht.checkbox.checked.background-color",
+                "utrecht.checkbox.background-color"
+              ],
+              "nl.nldesignsystem.figma-implementation": true
+            },
+            "$type": "color"
+          },
+          "color": {
+            "$extensions": {
+              "nl.nldesignsystem.css-property-syntax": "<color>",
+              "nl.nldesignsystem.fallback": ["utrecht.checkbox.checked.color", "utrecht.checkbox.color"],
+              "nl.nldesignsystem.figma-implementation": true
+            },
+            "$type": "color"
+          }
+        },
+        "active": {
+          "border-color": {
+            "$extensions": {
+              "nl.nldesignsystem.css-property-syntax": "<color>",
+              "nl.nldesignsystem.fallback": ["utrecht.checkbox.checked.border-color", "utrecht.checkbox.border-color"],
+              "nl.nldesignsystem.figma-implementation": true
+            },
+            "$type": "color"
+          },
+          "border-width": {
+            "$extensions": {
+              "nl.nldesignsystem.css-property-syntax": "<length>",
+              "nl.nldesignsystem.fallback": ["utrecht.checkbox.checked.border-width", "utrecht.checkbox.border-width"],
+              "nl.nldesignsystem.figma-implementation": true
+            },
+            "$type": "dimension"
+          },
+          "background-color": {
+            "$extensions": {
+              "nl.nldesignsystem.css-property-syntax": "<color>",
+              "nl.nldesignsystem.fallback": [
+                "utrecht.checkbox.checked.background-color",
+                "utrecht.checkbox.background-color"
+              ],
+              "nl.nldesignsystem.figma-implementation": true
+            },
+            "$type": "color"
+          },
+          "color": {
+            "$extensions": {
+              "nl.nldesignsystem.css-property-syntax": "<color>",
+              "nl.nldesignsystem.fallback": ["utrecht.checkbox.checked.color", "utrecht.checkbox.color"],
+              "nl.nldesignsystem.figma-implementation": true
+            },
+            "$type": "color"
+          }
         }
       },
       "indeterminate": {
@@ -251,6 +325,92 @@
             "nl.nldesignsystem.figma-implementation": true
           },
           "$type": "color"
+        },
+        "hover": {
+          "border-color": {
+            "$extensions": {
+              "nl.nldesignsystem.css-property-syntax": "<color>",
+              "nl.nldesignsystem.fallback": [
+                "utrecht.checkbox.indeterminate.border-color",
+                "utrecht.checkbox.border-color"
+              ],
+              "nl.nldesignsystem.figma-implementation": true
+            },
+            "$type": "color"
+          },
+          "border-width": {
+            "$extensions": {
+              "nl.nldesignsystem.css-property-syntax": "<length>",
+              "nl.nldesignsystem.fallback": [
+                "utrecht.checkbox.indeterminate.border-width",
+                "utrecht.checkbox.border-width"
+              ],
+              "nl.nldesignsystem.figma-implementation": true
+            },
+            "$type": "dimension"
+          },
+          "background-color": {
+            "$extensions": {
+              "nl.nldesignsystem.css-property-syntax": "<color>",
+              "nl.nldesignsystem.fallback": [
+                "utrecht.checkbox.indeterminate.background-color",
+                "utrecht.checkbox.background-color"
+              ],
+              "nl.nldesignsystem.figma-implementation": true
+            },
+            "$type": "color"
+          },
+          "color": {
+            "$extensions": {
+              "nl.nldesignsystem.css-property-syntax": "<color>",
+              "nl.nldesignsystem.fallback": ["utrecht.checkbox.indeterminate.color", "utrecht.checkbox.color"],
+              "nl.nldesignsystem.figma-implementation": true
+            },
+            "$type": "color"
+          }
+        },
+        "active": {
+          "border-color": {
+            "$extensions": {
+              "nl.nldesignsystem.css-property-syntax": "<color>",
+              "nl.nldesignsystem.fallback": [
+                "utrecht.checkbox.indeterminate.border-color",
+                "utrecht.checkbox.border-color"
+              ],
+              "nl.nldesignsystem.figma-implementation": true
+            },
+            "$type": "color"
+          },
+          "border-width": {
+            "$extensions": {
+              "nl.nldesignsystem.css-property-syntax": "<length>",
+              "nl.nldesignsystem.fallback": [
+                "utrecht.checkbox.indeterminate.border-width",
+                "utrecht.checkbox.border-width"
+              ],
+              "nl.nldesignsystem.figma-implementation": true
+            },
+            "$type": "dimension"
+          },
+          "background-color": {
+            "$extensions": {
+              "nl.nldesignsystem.css-property-syntax": "<color>",
+              "nl.nldesignsystem.fallback": [
+                "utrecht.checkbox.indeterminate.background-color",
+                "utrecht.checkbox.background-color"
+              ],
+              "nl.nldesignsystem.figma-implementation": true
+            },
+            "$type": "color"
+          },
+          "color": {
+            "$extensions": {
+              "nl.nldesignsystem.css-property-syntax": "<color>",
+              "nl.nldesignsystem.fallback": ["utrecht.checkbox.indeterminate.color", "utrecht.checkbox.color"],
+              "nl.nldesignsystem.figma-implementation": true
+            },
+            "$type": "color"
+          }
         }
       },
       "invalid": {

--- a/components/custom-checkbox/src/_mixin.scss
+++ b/components/custom-checkbox/src/_mixin.scss
@@ -37,6 +37,7 @@
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3e%3cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='m6 10 3 3 6-6'/%3e%3c/svg%3e");
   border-color: var(--utrecht-checkbox-checked-border-color, var(--utrecht-checkbox-border-color));
   border-width: var(--utrecht-checkbox-checked-border-width, var(--utrecht-checkbox-border-width));
+  color: var(--utrecht-checkbox-checked-color, var(--utrecht-checkbox-color));
 }
 
 @mixin utrecht-custom-checkbox--disabled {
@@ -77,6 +78,82 @@
   background-color: var(--utrecht-checkbox-hover-background-color, var(--utrecht-checkbox-background-color));
   border-color: var(--utrecht-checkbox-hover-border-color, var(--utrecht-checkbox-border-color));
   border-width: var(--utrecht-checkbox-hover-border-width, var(--utrecht-checkbox-border-width));
+}
+
+@mixin utrecht-custom-checkbox--checked-hover {
+  background-color: var(
+    --utrecht-checkbox-checked-hover-background-color,
+    var(--utrecht-checkbox-checked-background-color, var(--utrecht-checkbox-background-color))
+  );
+  border-color: var(
+    --utrecht-checkbox-checked-hover-border-color,
+    var(--utrecht-checkbox-checked-border-color, var(--utrecht-checkbox-border-color))
+  );
+  border-width: var(
+    --utrecht-checkbox-checked-hover-border-width,
+    var(--utrecht-checkbox-checked-border-width, var(--utrecht-checkbox-border-width))
+  );
+  color: var(
+    --utrecht-checkbox-checked-hover-color,
+    var(--utrecht-checkbox-checked-color, var(--utrecht-checkbox-color))
+  );
+}
+
+@mixin utrecht-custom-checkbox--checked-active {
+  background-color: var(
+    --utrecht-checkbox-checked-active-background-color,
+    var(--utrecht-checkbox-checked-background-color, var(--utrecht-checkbox-background-color))
+  );
+  border-color: var(
+    --utrecht-checkbox-checked-active-border-color,
+    var(--utrecht-checkbox-checked-border-color, var(--utrecht-checkbox-border-color))
+  );
+  border-width: var(
+    --utrecht-checkbox-checked-active-border-width,
+    var(--utrecht-checkbox-checked-border-width, var(--utrecht-checkbox-border-width))
+  );
+  color: var(
+    --utrecht-checkbox-checked-active-color,
+    var(--utrecht-checkbox-checked-color, var(--utrecht-checkbox-color))
+  );
+}
+
+@mixin utrecht-custom-checkbox--indeterminate-hover {
+  background-color: var(
+    --utrecht-checkbox-indeterminate-hover-background-color,
+    var(--utrecht-checkbox-indeterminate-background-color, var(--utrecht-checkbox-background-color))
+  );
+  border-color: var(
+    --utrecht-checkbox-indeterminate-hover-border-color,
+    var(--utrecht-checkbox-indeterminate-border-color, var(--utrecht-checkbox-border-color))
+  );
+  border-width: var(
+    --utrecht-checkbox-indeterminate-hover-border-width,
+    var(--utrecht-checkbox-indeterminate-border-width, var(--utrecht-checkbox-border-width))
+  );
+  color: var(
+    --utrecht-checkbox-indeterminate-hover-color,
+    var(--utrecht-checkbox-indeterminate-color, var(--utrecht-checkbox-color))
+  );
+}
+
+@mixin utrecht-custom-checkbox--indeterminate-active {
+  background-color: var(
+    --utrecht-checkbox-indeterminate-active-background-color,
+    var(--utrecht-checkbox-indeterminate-background-color, var(--utrecht-checkbox-background-color))
+  );
+  border-color: var(
+    --utrecht-checkbox-indeterminate-active-border-color,
+    var(--utrecht-checkbox-indeterminate-border-color, var(--utrecht-checkbox-border-color))
+  );
+  border-width: var(
+    --utrecht-checkbox-indeterminate-active-border-width,
+    var(--utrecht-checkbox-indeterminate-border-width, var(--utrecht-checkbox-border-width))
+  );
+  color: var(
+    --utrecht-checkbox-indeterminate-active-color,
+    var(--utrecht-checkbox-indeterminate-color, var(--utrecht-checkbox-color))
+  );
 }
 
 @mixin utrecht-custom-checkbox--focus {
@@ -124,5 +201,23 @@
   &:indeterminate,
   &:checked:indeterminate {
     @include utrecht-custom-checkbox--indeterminate;
+  }
+
+  /* The guards keep disabled checkboxes out of hover and active styling; without them these
+   * higher-specificity selectors would override the earlier disabled rules. */
+  &:checked:hover:not([aria-disabled="true"], :disabled) {
+    @include utrecht-custom-checkbox--checked-hover;
+  }
+
+  &:checked:active:not([aria-disabled="true"], :disabled) {
+    @include utrecht-custom-checkbox--checked-active;
+  }
+
+  &:indeterminate:hover:not([aria-disabled="true"], :disabled) {
+    @include utrecht-custom-checkbox--indeterminate-hover;
+  }
+
+  &:indeterminate:active:not([aria-disabled="true"], :disabled) {
+    @include utrecht-custom-checkbox--indeterminate-active;
   }
 }

--- a/components/custom-checkbox/src/_mixin.scss
+++ b/components/custom-checkbox/src/_mixin.scss
@@ -6,6 +6,11 @@
 
 @use "~@utrecht/focus-ring-css/src/mixin" as *;
 
+/* States that already show a fill; plain hover and active styling skips these so it never
+ * paints over the check or dash mark. Includes the modifier classes because :indeterminate
+ * cannot be set declaratively in HTML, only through JavaScript. */
+$utrecht-custom-checkbox-filled-states: ":checked, :indeterminate, .utrecht-checkbox--checked, .utrecht-checkbox--indeterminate, .utrecht-custom-checkbox--checked, .utrecht-custom-checkbox--indeterminate" !default;
+
 @mixin utrecht-custom-checkbox {
   /*
    * Use 24x24px as hardcoded minimum target size, to meet WCAG 2.5.8 standards.
@@ -173,7 +178,7 @@
     @include utrecht-custom-checkbox--disabled;
   }
 
-  &:hover {
+  &:hover:not(:where(#{$utrecht-custom-checkbox-filled-states}, [aria-disabled="true"], :disabled)) {
     @include utrecht-custom-checkbox--hover;
   }
 
@@ -190,7 +195,7 @@
     @include utrecht-custom-checkbox--invalid;
   }
 
-  &:active {
+  &:active:not(:where(#{$utrecht-custom-checkbox-filled-states}, [aria-disabled="true"], :disabled)) {
     @include utrecht-custom-checkbox--active;
   }
 

--- a/components/custom-checkbox/src/index.scss
+++ b/components/custom-checkbox/src/index.scss
@@ -51,6 +51,26 @@
   @include utrecht-custom-checkbox--focus-visible;
 }
 
+.utrecht-checkbox--custom.utrecht-checkbox--checked-hover,
+.utrecht-custom-checkbox--checked-hover {
+  @include utrecht-custom-checkbox--checked-hover;
+}
+
+.utrecht-checkbox--custom.utrecht-checkbox--checked-active,
+.utrecht-custom-checkbox--checked-active {
+  @include utrecht-custom-checkbox--checked-active;
+}
+
+.utrecht-checkbox--custom.utrecht-checkbox--indeterminate-hover,
+.utrecht-custom-checkbox--indeterminate-hover {
+  @include utrecht-custom-checkbox--indeterminate-hover;
+}
+
+.utrecht-checkbox--custom.utrecht-checkbox--indeterminate-active,
+.utrecht-custom-checkbox--indeterminate-active {
+  @include utrecht-custom-checkbox--indeterminate-active;
+}
+
 .utrecht-checkbox--custom.utrecht-checkbox--html-input,
 .utrecht-custom-checkbox--html-input {
   @include utrecht-custom-checkbox--html-input;

--- a/packages/storybook-css/src/Checkbox.stories.tsx
+++ b/packages/storybook-css/src/Checkbox.stories.tsx
@@ -24,15 +24,38 @@ interface CheckboxStoryProps extends CheckboxProps {
   focusVisible?: boolean;
   hover?: boolean;
   active?: boolean;
+  checkedHover?: boolean;
+  checkedActive?: boolean;
+  indeterminateHover?: boolean;
+  indeterminateActive?: boolean;
 }
 
-const CheckboxStory = ({ active, focus, focusVisible, hover, name, checked, value, ...args }: CheckboxStoryProps) => (
+const CheckboxStory = ({
+  active,
+  focus,
+  focusVisible,
+  hover,
+  checkedHover,
+  checkedActive,
+  indeterminateHover,
+  indeterminateActive,
+  name,
+  checked,
+  value,
+  ...args
+}: CheckboxStoryProps) => (
   <Checkbox
     className={clsx({
       'utrecht-checkbox--active': active,
       'utrecht-checkbox--focus': focus,
       'utrecht-checkbox--focus-visible': focusVisible,
       'utrecht-checkbox--hover': hover,
+      'utrecht-checkbox--checked': checkedHover || checkedActive,
+      'utrecht-checkbox--checked-hover': checkedHover,
+      'utrecht-checkbox--checked-active': checkedActive,
+      'utrecht-checkbox--indeterminate': indeterminateHover || indeterminateActive,
+      'utrecht-checkbox--indeterminate-hover': indeterminateHover,
+      'utrecht-checkbox--indeterminate-active': indeterminateActive,
     })}
     defaultChecked={checked}
     defaultValue={value}
@@ -52,6 +75,10 @@ const meta = {
     hover: false,
     focus: false,
     focusVisible: false,
+    checkedHover: false,
+    checkedActive: false,
+    indeterminateHover: false,
+    indeterminateActive: false,
     invalid: false,
     name: '',
   },
@@ -146,6 +173,38 @@ const meta = {
     },
     focusVisible: {
       description: 'Focus-visible',
+      control: 'boolean',
+      table: {
+        category: 'Simulate state',
+        defaultValue: { summary: '' },
+      },
+    },
+    checkedHover: {
+      description: 'Checked and hover',
+      control: 'boolean',
+      table: {
+        category: 'Simulate state',
+        defaultValue: { summary: '' },
+      },
+    },
+    checkedActive: {
+      description: 'Checked and active',
+      control: 'boolean',
+      table: {
+        category: 'Simulate state',
+        defaultValue: { summary: '' },
+      },
+    },
+    indeterminateHover: {
+      description: 'Indeterminate and hover',
+      control: 'boolean',
+      table: {
+        category: 'Simulate state',
+        defaultValue: { summary: '' },
+      },
+    },
+    indeterminateActive: {
+      description: 'Indeterminate and active',
       control: 'boolean',
       table: {
         category: 'Simulate state',
@@ -294,16 +353,30 @@ export const CheckedAndFocusVisible: Story = {
 export const CheckedAndHover: Story = {
   name: 'Checked and Hover',
   args: {
-    checked: true,
-    hover: true,
+    checkedHover: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Rendered through the `utrecht-checkbox--checked-hover` modifier class so the checked hover state is visible without pointer interaction.',
+      },
+    },
   },
 };
 
 export const CheckedAndActive: Story = {
   name: 'Checked and Active',
   args: {
-    checked: true,
-    active: true,
+    checkedActive: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Rendered through the `utrecht-checkbox--checked-active` modifier class so the checked active state is visible without pointer interaction.',
+      },
+    },
   },
 };
 
@@ -402,6 +475,36 @@ export const CheckedAndIndeterminateAndDisabled: Story = {
     checked: true,
     disabled: true,
     indeterminate: true,
+  },
+};
+
+export const IndeterminateAndHover: Story = {
+  name: 'Indeterminate and Hover',
+  args: {
+    indeterminateHover: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Rendered through the `utrecht-checkbox--indeterminate-hover` modifier class so the indeterminate hover state is visible without pointer interaction.',
+      },
+    },
+  },
+};
+
+export const IndeterminateAndActive: Story = {
+  name: 'Indeterminate and Active',
+  args: {
+    indeterminateActive: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Rendered through the `utrecht-checkbox--indeterminate-active` modifier class so the indeterminate active state is visible without pointer interaction.',
+      },
+    },
   },
 };
 

--- a/proprietary/design-tokens/src/component/utrecht/checkbox.tokens.json
+++ b/proprietary/design-tokens/src/component/utrecht/checkbox.tokens.json
@@ -27,10 +27,34 @@
       "checked": {
         "border-color": { "$value": "{utrecht.color.blue.40}" },
         "border-width": {},
-        "background-color": { "$value": "{utrecht.color.blue.40}" }
+        "background-color": { "$value": "{utrecht.color.blue.40}" },
+        "hover": {
+          "border-color": {},
+          "border-width": {},
+          "background-color": {},
+          "color": {}
+        },
+        "active": {
+          "border-color": {},
+          "border-width": {},
+          "background-color": {},
+          "color": {}
+        }
       },
       "indeterminate": {
-        "background-color": { "$value": "{utrecht.color.blue.40}" }
+        "background-color": { "$value": "{utrecht.color.blue.40}" },
+        "hover": {
+          "border-color": {},
+          "border-width": {},
+          "background-color": {},
+          "color": {}
+        },
+        "active": {
+          "border-color": {},
+          "border-width": {},
+          "background-color": {},
+          "color": {}
+        }
       },
       "invalid": {
         "border-color": { "$value": "{utrecht.form-control.invalid.border-color}" },


### PR DESCRIPTION
The custom checkbox has hover/active tokens and checked/indeterminate tokens, but no combination states: hovering a checked checkbox falls back to the plain checked colors. This adds `utrecht.checkbox.{checked,indeterminate}.{hover,active}.{background-color,border-color,border-width,color}` (16 tokens) and applies them via `:checked:hover:not([aria-disabled="true"], :disabled)` etc., so disabled keeps precedence (same guard as the Radio Button). The base `--checked` styling now also applies `utrecht.checkbox.checked.color`, which existed in the schema but was never consumed. All defaults fall back to the existing checked/indeterminate values, so the default appearance is unchanged.

Two deliberate implementation notes:
- The fallback order is `checked-hover → checked → base`: a hovered checked checkbox without a hover token keeps its checked look. The Radio Button schema currently falls back from `checked.hover` straight to base; aligning that could be a follow-up.
- This uses combination selectors rather than the Radio Button's private state-variable remapping, to keep the change small; the checkbox mixins don't have that indirection layer yet. Happy to refactor towards the radio approach if preferred.

Part of #2716.