### PR TITLE
feat(form-field): add inputId prop to FormFieldTextbox and FormFieldTextarea

### DIFF
--- a/.changeset/form-field-input-id.md
+++ b/.changeset/form-field-input-id.md
@@ -1,0 +1,5 @@
+---
+"@utrecht/component-library-react": minor
+---
+
+Add `inputId` prop to `FormFieldTextbox` and `FormFieldTextarea` to set the `id` of the form control, so other elements can reference the input, for example links in an error summary.

--- a/packages/component-library-react/src/FormFieldTextarea.test.tsx
+++ b/packages/component-library-react/src/FormFieldTextarea.test.tsx
@@ -133,6 +133,24 @@ describe('Form field with a textarea', () => {
     });
   });
 
+  describe('inputId', () => {
+    it('renders the textarea with the specified id', () => {
+      render(<FormFieldTextarea {...defaultProps} inputId="subject" />);
+
+      const textbox = screen.getByRole('textbox');
+
+      expect(textbox).toHaveAttribute('id', 'subject');
+    });
+
+    it('associates the label with the specified id', () => {
+      const { container } = render(<FormFieldTextarea {...defaultProps} inputId="subject" />);
+
+      const label = container.querySelector('label[for]');
+
+      expect(label).toHaveAttribute('for', 'subject');
+    });
+  });
+
   describe('description', () => {
     it('is not rendered by default', () => {
       const { container } = render(<FormFieldTextarea {...defaultProps} />);

--- a/packages/component-library-react/src/FormFieldTextarea.tsx
+++ b/packages/component-library-react/src/FormFieldTextarea.tsx
@@ -33,6 +33,7 @@ export interface FormFieldTextareaProps
   description?: ReactNode;
   errorMessage?: ReactNode;
   inputDir?: TextareaProps['dir'];
+  inputId?: string;
   inputRequired?: TextareaProps['required'];
   label: ReactNode;
   status?: ReactNode;
@@ -50,6 +51,7 @@ export const FormFieldTextarea = forwardRef(
       disabled,
       errorMessage,
       inputDir,
+      inputId: definedInputId,
       inputRequired,
       invalid,
       label,
@@ -71,7 +73,8 @@ export const FormFieldTextarea = forwardRef(
     }: FormFieldTextareaProps,
     ref: ForwardedRef<HTMLDivElement>,
   ) => {
-    const inputId = useId();
+    const generatedInputId = useId();
+    const inputId = definedInputId || generatedInputId;
     const descriptionId = useId();
     const statusId = useId();
     const errorMessageId = useId();

--- a/packages/component-library-react/src/FormFieldTextbox.test.tsx
+++ b/packages/component-library-react/src/FormFieldTextbox.test.tsx
@@ -133,6 +133,24 @@ describe('Form field with a textbox', () => {
     });
   });
 
+  describe('inputId', () => {
+    it('renders the textbox with the specified id', () => {
+      render(<FormFieldTextbox {...defaultProps} inputId="subject" />);
+
+      const textbox = screen.getByRole('textbox');
+
+      expect(textbox).toHaveAttribute('id', 'subject');
+    });
+
+    it('associates the label with the specified id', () => {
+      const { container } = render(<FormFieldTextbox {...defaultProps} inputId="subject" />);
+
+      const label = container.querySelector('label[for]');
+
+      expect(label).toHaveAttribute('for', 'subject');
+    });
+  });
+
   describe('description', () => {
     it('is not rendered by default', () => {
       const { container } = render(<FormFieldTextbox {...defaultProps} />);

--- a/packages/component-library-react/src/FormFieldTextbox.tsx
+++ b/packages/component-library-react/src/FormFieldTextbox.tsx
@@ -35,6 +35,7 @@ export interface FormFieldTextboxProps
   description?: ReactNode;
   errorMessage?: ReactNode;
   inputDir?: TextboxProps['dir'];
+  inputId?: string;
   inputRef?: Ref<HTMLInputElement>;
   label: ReactNode;
   status?: ReactNode;
@@ -63,6 +64,7 @@ export const FormFieldTextbox = forwardRef(
       required,
       inputRequired,
       inputDir,
+      inputId: definedInputId,
       type,
       value,
       onChange,
@@ -77,7 +79,8 @@ export const FormFieldTextbox = forwardRef(
     }: PropsWithChildren<FormFieldTextboxProps>,
     ref: ForwardedRef<HTMLDivElement>,
   ) => {
-    const inputId = useId();
+    const generatedInputId = useId();
+    const inputId = definedInputId || generatedInputId;
     const descriptionId = useId();
     const statusId = useId();
     const errorMessageId = useId();


### PR DESCRIPTION
`FormFieldTextbox` and `FormFieldTextarea` always generate the id of the form control with `useId()`, so consumers cannot reference the input from elsewhere in the document. An `id` passed as prop ends up on the form field root element via the props spread, not on the input. This blocks the error summary pattern, where a list of links at the top of the form points at each invalid input (`href="#subject"`), and other patterns that need a predictable id on the control.

This adds an optional `inputId` prop that overrides the generated id of the control. The `<label for>` and `aria-describedby` wiring keep working, and the default behavior is unchanged when the prop is not set. The prop name follows the existing `inputRef` and `inputDir` props; the `id` prop keeps targeting the form field root element.