### PR TITLE
fix(calendar): use calendar year rather than week-local year

### DIFF
--- a/.changeset/angry-news-breathe.md
+++ b/.changeset/angry-news-breathe.md
@@ -1,0 +1,5 @@
+---
+"@utrecht/calendar-react": patch
+---
+
+Fixed the calendar day accessible label to use the calendar year instead of the local week-numbering year

--- a/packages/components-react/calendar-react/src/index.tsx
+++ b/packages/components-react/calendar-react/src/index.tsx
@@ -191,7 +191,7 @@ export const Calendar = ({
                         setSelectedDate(day.date);
                         onCalendarClick(formatISO(day.date));
                       }}
-                      aria-label={format(day.date, 'eeee dd LLLL Y', { locale })}
+                      aria-label={format(day.date, 'eeee dd LLLL y', { locale })}
                       day={day.date.getDate().toString()}
                       emphasis={day.emphasis}
                       selected={day.selected || (selectedDate && isSameDay(day.date, selectedDate))}


### PR DESCRIPTION
Closes #3107

Similar to the fix applied in b9125019294fa835d51101dc78e88729e0e04df9, apply the same logic to the accessible label of the day buttons, otherwise you get off-by-one errors on the last days of december (sometimes).

At first I thought the warning was emitted by using the single-character 'y' format string and required suppression, however it's an actual valid warning pointing out a real bug.

The added benefit is that the console in the browser and test suites will no longer be spammed by these warnings.