### PR TITLE
feat(link-button): support --utrecht-button-column-gap token

### DIFF
--- a/.changeset/silly-rules-cover.md
+++ b/.changeset/silly-rules-cover.md
@@ -1,0 +1,5 @@
+---
+"@utrecht/link-button-css": minor
+---
+
+Prefer the button-column-gap token over the button-icon-gap one

--- a/components/link-button/src/_mixin.scss
+++ b/components/link-button/src/_mixin.scss
@@ -15,12 +15,15 @@
 
   align-items: center;
   border-radius: var(--utrecht-button-border-radius, 0);
+
+  // @deprecated the `--utrecht-button-icon-gap` token is deprecated, remove in next
+  // major release
+  column-gap: var(--utrecht-button-column-gap, var(--utrecht-button-icon-gap));
   cursor: pointer;
   display: inline-flex;
   font-family: var(--utrecht-button-font-family, var(--utrecht-document-font-family));
   font-size: var(--utrecht-button-font-size, var(--utrecht-document-font-family));
   font-weight: var(--utrecht-button-font-weight);
-  gap: var(--utrecht-button-icon-gap);
   inline-size: var(--utrecht-button-inline-size, auto);
   justify-content: center;
   line-height: inherit;


### PR DESCRIPTION
The button-css component/package was updated to use the --utrecht-button-column-gap token in favour of --utrecht-button-icon-gap but the link-button component is missing this update.

The intent is clearly that the link-button component reuses the button component tokens. For backwards compatibility, it still falls back to the old token so that a major release is not yet necessary.

Closes #3188.