### PR TITLE
fix(contact-card): add leading space before subtitle text in heading

### DIFF
--- a/components/contact-card/src/_mixin.scss
+++ b/components/contact-card/src/_mixin.scss
@@ -61,7 +61,7 @@
   font-weight: var(--utrecht-contact-card-subtitle-font-weight);
 
   &::before {
-    content: " " var(--utrecht-contact-card-subtitle-separator) " ";
+    content: " " var(--utrecht-contact-card-subtitle-separator);
   }
 }
 

--- a/packages/components-react/contact-card-react/src/index.tsx
+++ b/packages/components-react/contact-card-react/src/index.tsx
@@ -72,7 +72,7 @@ export const ContactCard = forwardRef(
           <div className="utrecht-contact-card__title">
             <Heading level={2}>
               {heading}
-              {subtitle && <span className="utrecht-contact-card__subtitle">{subtitle}</span>}
+              {subtitle && <span className="utrecht-contact-card__subtitle">&nbsp;{subtitle}</span>}
             </Heading>
           </div>
         )}

--- a/packages/web-component-library-stencil/src/components/contact-card.tsx
+++ b/packages/web-component-library-stencil/src/components/contact-card.tsx
@@ -54,7 +54,7 @@ export class ContactCard {
             <div class="utrecht-contact-card__title">
               <h2 class="utrecht-heading-2">
                 {this.heading}
-                {this.subtitle && <span class="utrecht-contact-card__subtitle">{this.subtitle}</span>}
+                {this.subtitle && <span class="utrecht-contact-card__subtitle"> {this.subtitle}</span>}
               </h2>
             </div>
           )}

--- a/packages/web-component-library-stencil/src/components/contact-card.tsx
+++ b/packages/web-component-library-stencil/src/components/contact-card.tsx
@@ -54,7 +54,7 @@ export class ContactCard {
             <div class="utrecht-contact-card__title">
               <h2 class="utrecht-heading-2">
                 {this.heading}
-                {this.subtitle && <span class="utrecht-contact-card__subtitle"> {this.subtitle}</span>}
+                {this.subtitle && <span class="utrecht-contact-card__subtitle">&nbsp;{this.subtitle}</span>}
               </h2>
             </div>
           )}


### PR DESCRIPTION
SiteImprove geeft aan dat de gecombineerde kop van het contactblok 'spelfouten' oplevert wegens het ontbreken van deze spatie.