### PR TITLE
fix: customizable-text-input hover specificity fix

### DIFF
--- a/.changeset/big-bikes-whisper.md
+++ b/.changeset/big-bikes-whisper.md
@@ -1,0 +1,5 @@
+---
+"@utrecht/customizable-text-input-css": patch
+---
+
+Fixed a specificity problem with the customizable-text-input hover state

--- a/components/customizable-text-input/src/_mixin.scss
+++ b/components/customizable-text-input/src/_mixin.scss
@@ -89,11 +89,14 @@
   ); /* [1] */
 
   &,
-  &:focus,
-  &:focus-visible,
-  &.utrecht-textbox--focus-visible,
-  &.utrecht-textbox--invalid,
-  &.utrecht-textbox--disabled {
+  &:is(
+      :hover,
+      :focus,
+      :focus-visible,
+      .utrecht-textbox--focus-visible,
+      .utrecht-textbox--invalid,
+      .utrecht-textbox--disabled
+    ) {
     background-color: transparent;
     border-width: 0;
     box-shadow: none;


### PR DESCRIPTION
The hover state of the TextBox component was creating a white background color over the borders of the CustomizableTextInput component. This PR fixes that. 

## Screenshots
From:
<img width="462" height="55" alt="Screenshot 2026-08-18 at 10 53 25" src="https://github.com/user-attachments/assets/784fdc30-bfb0-4fa9-98df-87d7b01abb05" />

To:
<img width="461" height="61" alt="Screenshot 2026-08-18 at 10 53 31" src="https://github.com/user-attachments/assets/2c58bf91-f689-4ecf-a8a7-4a1b47e3a6d6" />

